### PR TITLE
Evergaols/Legacy Dungeons ids + Varré 1st step

### DIFF
--- a/data/checklists/quests.yaml
+++ b/data/checklists/quests.yaml
@@ -859,13 +859,7 @@ sections:
     link: "https://eldenring.wiki.fextralife.com/White+Mask+Varre"
     items:
       - id: "8_1"
-        data: ["Found at the First Step Site of Grace. Exhaust his dialogue."]
-      - id: "8_1_2"
-        data: ["Return to talk after unlocking Roundtable Hold."]
-      - id: "8_1_3"
-        data: ["Return again after killing Godrick."]
-      - id: "8_1_4"
-        data: ["Return once more after meeting the Fingers for dialogues and an emote."]
+        data: ["Found just outside the starting area, talk to him then return to talk after unlocking Roundtable Hold. Return again after killing Godrick and once more after meeting the Fingers for dialogues and an emote."]
       - id: "8_2"
         data: ["Go to the Rose Church located on an island in the South-West area of Liurnia Lake. Talk to him for Festering Bloody Fingers then perform 3 Invasions, outcome don't matter and you can even leave immediately after arriving, then talk to him again for a Lord of Blood's Favor."]
       - id: "8_3"

--- a/data/pages.yaml
+++ b/data/pages.yaml
@@ -147,8 +147,8 @@ item_links:
   - link_all: [bosses_1_7, crystal_tears_0_3, crystal_tears_0_2] #ERDTREE AVATAR/OPALINE BUBBLETEAR
   - link_all: [bosses_1_8, caves_0_3, weapons_19_6] #SCALY MISBEGOTTEN/MORNE TUNNEL/RUSTED ANCHOR GREATAXE
   - link_all: [bosses_1_9, caves_0_5, talismans_1_3] #MIRANDA/TOMBSWARD CAVE/VIRIDIAN AMBER MEDALLION
-  - link_all: [bosses_1_10, evergaols_0_1, talismans_1_6] #ANCIENT HERO ZAMOR/WEEPING EVERGAOL/RADAGON'S SCARSEAL
-  - link_all: [bosses_1_11, legacy_1_1, weapons_5_10, legendaries_1_2] #LEONINE MISBEGOTTEN/CASTLE MORNE/GRAFTED BLADE GREATSWORD (+LEGENDARY)
+  - link_all: [bosses_1_10, caves_e3, talismans_1_6] #ANCIENT HERO ZAMOR/WEEPING EVERGAOL/RADAGON'S SCARSEAL
+  - link_all: [bosses_1_11, caves_ld2, weapons_5_10, legendaries_1_2] #LEONINE MISBEGOTTEN/CASTLE MORNE/GRAFTED BLADE GREATSWORD (+LEGENDARY)
   - link_all: [bosses_2_1, caves_1_1] #TUT GODRICK/STRANDED GRAVEYARD
   - link_all: [bosses_2_2, caves_1_3,playthrough_29] #DEMI-HUMAN CHIEF/COASTAL CAVE/Walkthrough 29
   - link_all: [bosses_2_3, caves_1_10, spirit_ashes_2_5] #ERDTREE BURIAL WATCHDOG/STORMFOOT CATACOMBS/NOBLE SORCERER ASHES
@@ -165,8 +165,8 @@ item_links:
   - link_all: [bosses_2_15, dragon_hearts_death_roots_0_1, playthrough_36] #FLYING DRAGON AGHEEL/DRAGON HEART/Walkthrough 16
   - link_all: [bosses_2_16, spirit_ashes_2_6, dragon_hearts_death_roots_1_1, playthrough_13] #TIBIA MARINER/SKELETAL MILITIAMAN ASHES/DEATHROOT/Walkthrough 13
   - link_all: [bosses_2_17, talismans_2_19] #ANASTASIA/SACRED SCORPION CHARM
-  - link_all: [bosses_2_18, evergaols_1_1, weapons_8_3, playthrough_67] #BLOODHOUND KNIGHT DARRIWILL/FORLORN HOUND EVERGAOL/BLOODHOUND'S FANG/WALKTHROUGH 67
-  - link_all: [bosses_2_19, evergaols_1_2, incantations_5_3] #CRUCIBLE KNIGHT/STORMHILL EVERGAOL/AOTC TAIL
+  - link_all: [bosses_2_18, caves_e1, weapons_8_3, playthrough_67] #BLOODHOUND KNIGHT DARRIWILL/FORLORN HOUND EVERGAOL/BLOODHOUND'S FANG/WALKTHROUGH 67
+  - link_all: [bosses_2_19, caves_e2, incantations_5_3] #CRUCIBLE KNIGHT/STORMHILL EVERGAOL/AOTC TAIL
   - link_all: [bosses_2_20, bell_bearings_5_1] #BELL BEARING HUNTER/BONE PEDDLER'S BELL BEARING
   - link_all: [bosses_2_21, talismans_2_17] #DEATHBIRD/BLUE-FEATHERED BRANCHSWORD
   - link_all: [bosses_2_22, armor_518, armor_519, armor_521, armor_522] #OLD KNIGHT ISTVAN/SCALED SET (HELM, ARMOR, GAUNTLETS, GREAVES)
@@ -176,12 +176,12 @@ item_links:
   - link_all: [bosses_2_24, flasks_1_8, talismans_2_6] #ULCERATED TREE SPIRIT/GOLDEN SEED/PRINCE OF DEATH'S PUSTULE TALISMAN
   - link_all: [bosses_2_25, incantations_5_2] #CRUCIBLE KNIGHT/AOTC HORNS
   - link_all: [bosses_2_28, memory_stones_talisman_pouches_1_2] #MARGIT THE FELL OMEN/TALISMAN POUCH
-  - link_all: [bosses_2_29, legacy_1_2, great_runes_1_1, remembrances_mausoleums_1_1] #GODRICK THE GRAFTED/STORMVEIL CASTLE/GODRICK'S GREAT RUNE/REMEMBRANCE OF THE GRAFTED
+  - link_all: [bosses_2_29, caves_ld1, great_runes_1_1, remembrances_mausoleums_1_1] #GODRICK THE GRAFTED/STORMVEIL CASTLE/GODRICK'S GREAT RUNE/REMEMBRANCE OF THE GRAFTED
   - link_all: [bosses_2_31, weapons_30_9] #ELITE PHANTOM/DRAGON COMMUNION SEAL
   - link_all: [bosses_3_2, weapons_28_6, armor_482] #ENSHA/CLINGING BONE FIST/ROYAL REMAINS SET
   - link_all: [bosses_4_1, caves_2_8, talismans_4_10] #CLEANROT KNIGHT/STILLWATER CAVE/WINGED SWORD INSIGNIA TALISMAN
   - link_all: [bosses_4_37, caves_2_4, talismans_4_6] #BLOODHOUND KNIGHT/LAKESIDE CRYSTAL CAVE/CERULEAN AMBER MEDALLION
-  - link_all: [bosses_4_2, evergaols_2_2, incantations_6_2, legendaries_5_1] #ADAN/MALEFACTOR'S EVERGAOL/FLAME OF THE FELL GOD INCANTATION (+LEGENDARY)
+  - link_all: [bosses_4_2, caves_e4, incantations_6_2, legendaries_5_1] #ADAN/MALEFACTOR'S EVERGAOL/FLAME OF THE FELL GOD INCANTATION (+LEGENDARY)
   - link_all: [bosses_4_3, caves_2_3, spirit_ashes_3_1] #ERDTREE BURIAL WATCHDOG/CLIFFBOTTOM CATACOMBS/KAIDEN SELLSWORD ASHES
   - link_all: [bosses_4_4, dragon_hearts_death_roots_1_4, spirit_ashes_3_17] #TIBIA MARINER/DEATHROOT/SKELETAL BANDIT ASHES
   - link_all: [bosses_4_5, ashesofwar_2_3] #NIGHT'S CAVALRY/AOW: ICE SPEAR
@@ -207,21 +207,20 @@ item_links:
   - link_all: [bosses_4_19, ashesofwar_11_3, weapons_25_10] #NIGHT'S CAVALRY/AOW: GIANT HUNT/NIGHTRIDER GLAIVE
   #- link_all: [bosses_4_20, caves_#_#] #ROYAL REVENANT/KINGSREALM RUINS UNDERGROUND #TODO: ASK IF THIS LOCATION SHOULD BE ADDED
   - link_all: [bosses_4_21, weapons_13_14, weapons_34_7] #GRAFTED SCION/ORNAMENTAL STRAIGHT SWORD/GOLDEN BEAST CREST SHIELD
-  - link_all: [bosses_4_22, evergaols_2_1, sorceries_4_6] #BOLS/CUCKOO'S EVERGAOL/GREATBLADE PHALANX SORCERY
+  - link_all: [bosses_4_22, caves_e5, sorceries_4_6] #BOLS/CUCKOO'S EVERGAOL/GREATBLADE PHALANX SORCERY
   - link_all: [bosses_4_23, weapons_25_2] #EDGAR/BANISHED KNIGHT'S HALBERD (+8)
   - link_all: [bosses_4_24, crystal_tears_2_2, crystal_tears_2_3] #ERDTREE AVATAR (WEST)/RUPTURED CRYSTAL TEAR [1]/CERULEAN CRYSTAL TEAR [1]
   - link_all: [bosses_4_25, caves_2_6, spirit_ashes_3_8] #SPIRIT-CALLER SNAIL/ROAD'S END CATACOMBS/GLINTSTONE SORCERER ASHES
   - link_all: [bosses_4_26, talismans_4_17] #OMENKILLER/CRUCIBLE KNOT TALISMAN
-  - link_all: [bosses_4_27, legacy_1_5, sorceries_4_12, ashesofwar_8_7] #ROYAL KNIGHT LORETTA/CARIA MANOR/LORETTA'S GREATBOW SORCERY/AOW: LORETTA'S SLASH
-  - link_all: [bosses_4_29, evergaols_2_3, sorceries_4_8] #ALABASTER LORD (ONYX)/ROYAL GRAVE EVERGAOL/METEORITE SORCERY
+  - link_all: [bosses_4_27, caves_ld4, sorceries_4_12, ashesofwar_8_7] #ROYAL KNIGHT LORETTA/CARIA MANOR/LORETTA'S GREATBOW SORCERY/AOW: LORETTA'S SLASH
+  - link_all: [bosses_4_29, caves_e6, sorceries_4_8] #ALABASTER LORD (ONYX)/ROYAL GRAVE EVERGAOL/METEORITE SORCERY
   - link_all: [bosses_4_40, sorceries_5_1, dragon_hearts_death_roots_0_2] #GLINTSTONE DRAGON ADULA/ADULA'S MOONBLADE SORCERY/DRAGON HEART (X3)
-  - link_all: [bosses_4_32, evergaols_2_4, spirit_ashes_3_3, legendaries_3_4] #ALECTO/RINGLEADER'S EVERGAOL/BLACK KNIFE TICHE ASHES (+LEGENDARY)
-  - link_all: [bosses_4_27, legacy_1_6] #MAGMA WYRM MAKAR/RUIN-STREWN PRECIPICE
+  - link_all: [bosses_4_32, caves_e7, spirit_ashes_3_3, legendaries_3_4] #ALECTO/RINGLEADER'S EVERGAOL/BLACK KNIFE TICHE ASHES (+LEGENDARY)
   - link_all: [bosses_4_33, caves_2_7, weapons_8_4, dragon_hearts_death_roots_0_4] #MAGMA WYRM MAKAR/RUIN-STREWN PRECIPICE/MAGMA WYRM'S SCALESWORD/DRAGON HEART
   - link_all: [bosses_4_34, ashesofwar_6_7] #RAVENMOUNT ASSASSIN/AOW: RAPTOR OF THE MISTS
   - link_all: [bosses_4_35, memory_stones_talisman_pouches_0_4] #RED WOLF OF RADAGON/MEMORY STONE
   - link_all: [bosses_4_38, weapons_33_15] #MOONGRUM/CARIAN KNIGHT'S SHIELD
-  - link_all: [bosses_4_36, legacy_1_4, great_runes_1_2] #RENNALA/RAYA LUCARIA ACADEMY/GREAT RUNE OF THE UNBORN, remembrances_mausoleums_1_2/REMEMBRANCE OF THE FULL MOON QUEEN
+  - link_all: [bosses_4_36, caves_ld3, great_runes_1_2, remembrances_mausoleums_1_2] #RENNALA/RAYA LUCARIA ACADEMY/GREAT RUNE OF THE UNBORN/REMEMBRANCE OF THE FULL MOON QUEEN
   - link_all: [bosses_5_1, caves_3_3, weapons_17_5, dragon_hearts_death_roots_0_9] #MAGMA WYRM/GAEL TUNNEL/MOONVEIL/DRAGON HEART
   - link_all: [bosses_5_2, crystal_tears_3_1, crystal_tears_3_2] #ERDTREE AVATAR (WEST)FLAME-SHROUDING CRACKED TEAR/GREENBURST CRYSTAL TEAR/
   - link_all: [bosses_5_3, caves_3_5, spirit_ashes_4_4] #ERDTREE BURIAL WATCHDOG (SWORD & STAFF)/MINOR ERDTREE CATACOMBS/MAD PUMPKIN HEAD ASHES
@@ -237,7 +236,7 @@ item_links:
   - link_all: [bosses_5_12, weapons_9_15] #NOX (PRIEST & SWORDSTRESS)/NOX FLOWING SWORD
   - link_all: [bosses_5_13, caves_3_6, bell_bearings_2_1] #FALLINGSTAR BEAST/SELLIA CRYSTAL TUNNEL/SOMBERSTONE MINER'S BELL BEARING [1]
   - link_all: [bosses_5_14, caves_3_1, talismans_5_2] #CLEANROT KNIGHT (SICKLE & SPEAR)/ABANDONED CAVE/GOLD SCARAB TALISMAN
-  - link_all: [bosses_5_15, evergaols_3_1, spirit_ashes_4_1] #BATTLEMAGE HUGUES/SELLIA EVERGAOL/BATTLEMAGE HUGUES ASHES
+  - link_all: [bosses_5_15, caves_e8, spirit_ashes_4_1] #BATTLEMAGE HUGUES/SELLIA EVERGAOL/BATTLEMAGE HUGUES ASHES
   - link_all: [bosses_5_16, dragon_hearts_death_roots_0_8] #ELDER DRAGON GREYOLL/DRAGON HEART
   - link_all: [bosses_5_17, sorceries_8_4] #PUTRID CRYSTALIAN (SPEAR & RINGBLADE & STAFF)/CRYSTAL TORRENT SORCERY
   - link_all: [bosses_5_18, armor_168, armor_169, armor_170, armor_171] #GODSKIN APOSTLE/GODSKIN APOSTLE SET (HOOD, ROBE, BRACERS, TROUSERS)
@@ -247,10 +246,10 @@ item_links:
   - link_all: [bosses_5_22, ashesofwar_6_2] #NIGHT'S CAVALRY (LENNE'S RISE BRIDGE)/AOW: BLOODHOUND'S STEP
   - link_all: [bosses_5_23, dragon_hearts_death_roots_0_7] #FLYING DRAGON GREYLL/DRAGON HEART
   - link_all: [bosses_5_24, weapons_25_9] #BLACK BLADE KINDRED/GARGOYLE'S BLACKBLADE/GARGOYLE'S BLACK HALBERD
-  - link_all: [bosses_5_26, legacy_1_7, weapons_5_9, legendaries_1_4] #MISBEGOTTEN WARRIOR & CRUCIBLE KNIGHT/REDMAN CASTLE/RUINS GREATSWORD (+LEGENDARY)
+  - link_all: [bosses_5_26, caves_ld5, weapons_5_9, legendaries_1_4] #MISBEGOTTEN WARRIOR & CRUCIBLE KNIGHT/REDMANE CASTLE/RUINS GREATSWORD (+LEGENDARY)
   - link_all: [bosses_5_27, great_runes_1_3, remembrances_mausoleums_1_3] #RADAHN/RADAHN'S GREAT RUNE/REMEMBRANCE OF THE STARSCOURGE
   - link_all: [bosses_5_29, caves_3_8, flasks_1_17, spirit_ashes_4_8, legendaries_3_2] #PUTRID TREE SPIRIT/WAR-DEAD CATACOMBS/GOLDEN SEED/REDMANE KNIGHT OGHA SPIRIT ASHES (+LEGENDARY)
-  - link_all: [bosses_6_1, evergaols_4_1, talismans_6_5, legendaries_2_4] #GODEFEROY/GOLDEN LINEAGE EVERGAOL/GODFREY ICON TALISMAN (+LEGENDARY)
+  - link_all: [bosses_6_1, caves_e9, talismans_6_5, legendaries_2_4] #GODEFEROY/GOLDEN LINEAGE EVERGAOL/GODFREY ICON TALISMAN (+LEGENDARY)
   - source: caves_5_2
     target: [bosses_7_4] #SAGE'S CAVE/NECROMANCER GARRIS
   - source_and: [bosses_7_4, bosses_6_17]
@@ -279,7 +278,7 @@ item_links:
   - link_all: [bosses_7_3, dragon_hearts_death_roots_1_5, sorceries_9_2] #TIBIA MARINER/DEATHROOT/TIBIA'S SUMMONS SORCERY
   - link_all: [bosses_7_5, caves_5_6, bell_bearings_3_1] #ERDTREE BURIAL WATCHDOG/WYNDHAM CATACOMBS/GLOVEWORT PICKER'S BELL BEARING [1]
   - link_all: [bosses_7_7, weapons_15_6, armor_160, armor_161] #MALEIGH MARAIS/ANTSPUR RAPIER/MARAIS MASK/MARAIS ROBE
-  - link_all: [bosses_7_8, legacy_1_8, weapons_14_13, legendaries_1_6, weapons_34_5] #ELEMER OF THE BRIAR/THE SHADED CASTLE/MARAIS EXECUTIONER'S SWORD (+LEGENDARY)/BRIAR GREATSHIELD
+  - link_all: [bosses_7_8, caves_ld6, weapons_14_13, legendaries_1_6, weapons_34_5] #ELEMER OF THE BRIAR/THE SHADED CASTLE/MARAIS EXECUTIONER'S SWORD (+LEGENDARY)/BRIAR GREATSHIELD
   - link_all: [bosses_7_11, caves_5_5, weapons_2_2] #DEMI-HUMAN QUEEN MARGOT/VOLCANO CAVE/JAR CANNON BALISTA
   - link_all: [bosses_7_12, crystal_tears_5_1, crystal_tears_5_2] #ULCERATED TREE SPIRIT/LEADEN HARDTEAR/CERULEAN HIDDEN TEAR
   - link_all: [bosses_7_13, caves_5_3, talismans_7_5] #KINDRED OF ROT (X2)/SEETHEWATER CAVE/KINDRED OF ROT'S EXULTATION TALISMAN
@@ -294,7 +293,7 @@ item_links:
   - link_all: [bosses_7_21, weapons_6_10] #INQUISITOR GHIZA/GHIZA'S WHEEL COLOSSAL WEAPON
   - link_all: [bosses_7_22, dragon_hearts_death_roots_0_10] #MAGMA WYRM (VOLCANO MANOR)/DRAGON HEART
   - link_all: [bosses_7_23, weapons_16_2] #GODSKIN NOBLE/GODSKIN STITCHER HEAVY THRUSTING SWORD
-  - link_all: [bosses_7_26, legacy_1_9, great_runes_1_5, remembrances_mausoleums_1_8] #RYKARD/VOLCANO MANOR/RYKARD'S GREAT RUNE/REMEMBRANCE OF THE BLASPHEMOUS
+  - link_all: [bosses_7_26, caves_ld7, great_runes_1_5, remembrances_mausoleums_1_8] #RYKARD/VOLCANO MANOR/RYKARD'S GREAT RUNE/REMEMBRANCE OF THE BLASPHEMOUS
   - link_all: [bosses_8_1, flasks_1_28] #ULCERATED TREE SPIRIT (CAPITAL OUTSKIRTS)/GOLDEN SEED
   - link_all: [bosses_8_4, weapons_33_10] #DEATHBIRD/TWINBIRD KITE SHIELD
   - link_all: [bosses_8_5, caves_6_1, weapons_8_1] #ONYX LORD/SEALED TUNNEL/ONYX LORD'S GREATSWORD
@@ -307,9 +306,9 @@ item_links:
   #- link_all: [bosses_8_14, _] #BLACK KNIFE ASSASSIN/ #TODO ADD DROPS
   - link_all: [bosses_8_15, spirit_ashes_7_3] #FELL TWINS (X2)/OMENKILLER ROLLO ASHES
   - link_all: [bosses_8_19, caves_6_3, talismans_9_2] #ESGAR/LEYNDELL CATACOMBS/LORD OF BLOOD'S EXULTATION TALISMAN
-  - link_all: [bosses_8_16, legacy_1_11, incantations_2_3] #MOHG THE OMEN/SUB SHUNNING GROUNDS/BLOODFLAME TALONS INCANTATION
+  - link_all: [bosses_8_16, caves_ld9, incantations_2_3] #MOHG THE OMEN/SUB SHUNNING GROUNDS/BLOODFLAME TALONS INCANTATION
   - link_all: [bosses_8_17, memory_stones_talisman_pouches_1_4] #GODFREY FIRST ELDEN LORD (GOLDEN SHADE)/TALISMAN POUCH
-  - link_all: [bosses_8_18, legacy_1_10, great_runes_1_4, remembrances_mausoleums_1_10] #MORGOTT THE OMEN KING/LEYNDELL ROYAL CAPITAL/MORGOTT'S GREAT RUNE, REMEMBRANCE OF THE OMEN KING
+  - link_all: [bosses_8_18, caves_ld8, great_runes_1_4, remembrances_mausoleums_1_10] #MORGOTT THE OMEN KING/LEYNDELL ROYAL CAPITAL/MORGOTT'S GREAT RUNE, REMEMBRANCE OF THE OMEN KING
   - link_all: [bosses_9_1, ashesofwar_11_4] #NIGHT'S CAVLARY/AOW PHANTOM SLASH
   - link_all: [bosses_9_2, weapons_19_9, weapons_18_5] #BLACK BLADE KINDRED/GARGOYLE'S BLACK AXE/GARGOYLE'S BLACK BLADES
   - link_all: [bosses_9_3, caves_7_1, weapons_8_5, armor_367, armor_368, armor_369, armor_370] #ANCIENT HERO OF ZAMOR/GIANT-CONQUERING HERO'S GRAVE/ZAMOR CURVED SWORD/ZAMOR SET (MASK, ARMOR, BRACELETS, LEGWRAPS)
@@ -318,8 +317,8 @@ item_links:
   - link_all: [bosses_9_6, weapons_27_4, armor_450, armor_452, armor_454, armor_455] #JUNO HOSLOW/HOSLOW'S PETAL WHIP, HOSLOW'S SET (HELM, ARMOR, GAUNTLETS, GREAVES)
   - link_all: [bosses_9_7, weapons_23_15] #DEATH RITE BIRD/DEATH RITUAL SPEAR
   - link_all: [bosses_9_8, weapons_14_17, dragon_hearts_death_roots_1_8] #TIBIA MARINER/HELPHEN'S STEEPLE GREATSWORD/DEATHROOT
-  - link_all: [bosses_9_9, legacy_1_13, weapons_28_7] #COMMANDER NIALL/CASTLE SOL/VETERAN'S PROSTHESIS FIST
-  - link_all: [bosses_9_10, evergaols_5_1, armor_477, armor_478, armor_480, armor_481, incantations_4_11] #VIKE/LORD CONTENDER'S EVERGAOL/FINGERPRINT SET (HELM, ARMOR, GAUNTLET, GREAVES)/VYKE'S DRAGONBOLT INCANTATION
+  - link_all: [bosses_9_9, caves_ld10, weapons_28_7] #COMMANDER NIALL/CASTLE SOL/VETERAN'S PROSTHESIS FIST
+  - link_all: [bosses_9_10, caves_e10, armor_477, armor_478, armor_480, armor_481, incantations_4_11] #VIKE/LORD CONTENDER'S EVERGAOL/FINGERPRINT SET (HELM, ARMOR, GAUNTLET, GREAVES)/VYKE'S DRAGONBOLT INCANTATION
   - link_all: [bosses_9_11, dragon_hearts_death_roots_0_12] #BOREALIS/DRAGON HEART
   - link_all: [bosses_9_12, weapons_17_6, armor_337] #BLOODY FINGER OKINA/RIVERS OF BLOOD KATANA, OKINA MASK
   - link_all: [bosses_9_13, caves_7_3, talismans_9_5, incantations_9_3] #GODSKIN APOSTLE & NOBLE (SPECTRAL DUO)/SPIRITCALLER'S CAVE/GODSKIN SWADDLING CLOTH TALISMAN/BLACK FLAME RITUAL INCANTATION
@@ -334,16 +333,16 @@ item_links:
   - link_all: [bosses_10_8, sorceries_12_4] #DEATH RITE BIRD/EXPLOSIVE GHOSTFLAME SORCERY
   #- link_all: [bosses_10_9, _] #BLACK KNIFE ASSASSIN/ #TODO: ADD INFO ONCE DROPS ARE LISTED ON 'BOSSES' PAGE
   - link_all: [bosses_10_12, ancient_dragon_smithing_stones_15] #ANASTASIA/SOMBER ANCIENT DRAGON SMITHING STONE
-  - link_all: [bosses_10_10, legacy_1_14, sorceries_13_1, weapons_25_15] #LORETTA/MIQUELLA'S HALIGTREE/LORETTA'S MASTERY SORCERY/LORETTA'S WAR SICKLE
-  - link_all: [bosses_10_11, legacy_1_15, great_runes_1_6, remembrances_mausoleums_1_14] #MALENIA/ELPHAEL BRACE OF THE HALIGTREE/MALENIA'S GREAT RUNE/REMEMBRANCE OF THE ROT GODDESS
+  - link_all: [bosses_10_10, caves_ld11, sorceries_13_1, weapons_25_15] #LORETTA/MIQUELLA'S HALIGTREE/LORETTA'S MASTERY SORCERY/LORETTA'S WAR SICKLE
+  - link_all: [bosses_10_11, caves_ld12, great_runes_1_6, remembrances_mausoleums_1_14] #MALENIA/ELPHAEL BRACE OF THE HALIGTREE/MALENIA'S GREAT RUNE/REMEMBRANCE OF THE ROT GODDESS
   - link_all: [bosses_11_2, ashesofwar_4_1, bell_bearings_1_4] #GODSKIN DUO/AOW BLACK FLAME TORNADO/SMITHING-STONE MINER'S BELL BEARING [4]
   - link_all: [bosses_11_3, weapons_22_15, legendaries_1_1, armor_523, armor_525, armor_526, armor_527] #RECUSANT BERNAHL/BLASPHEMOUS CLAW (TOOL)/DEVOURER'S SCEPTER GREAT HAMMER (+LEGENDARY)/BEAST CHAMPION SET #TODO: LINK BLASPHEMOUS CLAW (TOOL) AFTER TOOLS PAGE IS CREATED
   - link_all: [bosses_11_4, armor_533, armor_534, armor_535, armor_536] #DRACONIC TREE SENTINEL/MALFORMED DRAGON SET
   - link_all: [bosses_11_5, remembrances_mausoleums_1_11] #DRAGONLORD PLACIDUSAX/REMEMBRANCE OF THE DRAGONLORD
-  - link_all: [bosses_11_6, legacy_1_12, remembrances_mausoleums_1_7] #MALIKETH/CRUMBLING FARUM AZULA/REMEMBRANCE OF THE BLACK BLADE
+  - link_all: [bosses_11_6, caves_ld13, remembrances_mausoleums_1_7] #MALIKETH/CRUMBLING FARUM AZULA/REMEMBRANCE OF THE BLACK BLADE
   - link_all: [bosses_12_1, weapons_20_14, armor_486, armor_487, armor_489, armor_490] #SIR GIDEON OFNIR/SCEPTER OF THE ALL-KNOWING/ALL-KNOWING SET
   - link_all: [bosses_12_2, remembrances_mausoleums_1_6] #GODFREY (HOARAH LOUX)/REMEMBRANCE OF HOARAH LOUX
-  - link_all: [bosses_12_4, legacy_1_16, remembrances_mausoleums_1_13] #ELDEN BEAST/LEYNDELL ASHEN CAPITAL/ELDEN REMEMBRANCE
+  - link_all: [bosses_12_4, caves_ld14, remembrances_mausoleums_1_13] #ELDEN BEAST/LEYNDELL ASHEN CAPITAL/ELDEN REMEMBRANCE
   - link_all: [bosses_13_1, weapons_25_14] #DRAGONKIN SOLDIER/DRAGON HALBERD
   - link_all: [bosses_13_2, spirit_ashes_11_1] #ANCESTER SPIRIT/ANCESTRAL FOLLOWER ASHES
   - link_all: [bosses_14_1, armor_195] #MIMIC TEAR/SILVER TEAR MASK/LARVAL TEAR (X2) #TODO: LINK IF LARVAL TEAR PAGE IS CREATED (OTHERWISE OK TO DELETE)
@@ -380,7 +379,7 @@ item_links:
 
   # Walkthrough Linking - Limgrave
   - link_all: [playthrough_0, graces_0] # Walkthrough 0/The First Step
-  - link_all: [playthrough_1, quest_order_tldr_1, npc_quests_8_1] # Walkthrough 1/TLDR 1/Varré 1
+  - link_all: [playthrough_1, quest_order_tldr_1] # Walkthrough 1/TLDR 1
   - link_all: [playthrough_2, tools_4_4] # Walkthrough 2/Small Golden Effigy
   - link_all: [playthrough_3, graces_1] # Walkthrough 3/Church of Elleh
   - link_all: [playthrough_4, quest_order_tldr_2] # Walkthrough 4/TLDR 2
@@ -403,8 +402,8 @@ item_links:
   - link_all: [playthrough_21, flasks_1_5] # Walkthrough 21/Golden Seed 5
   - link_all: [playthrough_22, npc_quests_30_2, ashesofwar_1_3] # Walkthrough 22/Kenneth 2/Bloody Slash
   - source_and: [playthrough_22, playthrough_23]
-    target: [quest_order_tldr_12, legacy_1_3] 
-  - source_or: [quest_order_tldr_12, legacy_1_3]
+    target: [quest_order_tldr_12, caves_l16] 
+  - source_or: [quest_order_tldr_12, caves_l16]
     target: [playthrough_22, playthrough_23] # Walkthrough 22-23/TLDR 12/Fort Haight
   - link_all: [playthrough_24, quest_order_tldr_14, npc_quests_37_1, spirit_ashes_2_4] # Walkthrough 24/TLDR 14/Ranni 1/Lone Wolf Ashes
   - link_all: [playthrough_25, quest_order_tldr_13, gestures_1_7] # Walkthrough 25/TLDR 13/Finger Snap

--- a/docs/checklists/npc_questlines.html
+++ b/docs/checklists/npc_questlines.html
@@ -3075,25 +3075,7 @@
                 <li class="list-group-item searchable ps-0" data-id="npc_quests_8_1" id="item_8_1">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" id="npc_quests_8_1" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="npc_quests_8_1">Found at the First Step Site of Grace. Exhaust his dialogue.</label>
-                  </div>
-                </li>
-                <li class="list-group-item searchable ps-0" data-id="npc_quests_8_1_2" id="item_8_1_2">
-                  <div class="form-check checkbox d-flex align-items-center">
-                    <input class="form-check-input" id="npc_quests_8_1_2" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="npc_quests_8_1_2">Return to talk after unlocking Roundtable Hold.</label>
-                  </div>
-                </li>
-                <li class="list-group-item searchable ps-0" data-id="npc_quests_8_1_3" id="item_8_1_3">
-                  <div class="form-check checkbox d-flex align-items-center">
-                    <input class="form-check-input" id="npc_quests_8_1_3" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="npc_quests_8_1_3">Return again after killing Godrick.</label>
-                  </div>
-                </li>
-                <li class="list-group-item searchable ps-0" data-id="npc_quests_8_1_4" id="item_8_1_4">
-                  <div class="form-check checkbox d-flex align-items-center">
-                    <input class="form-check-input" id="npc_quests_8_1_4" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="npc_quests_8_1_4">Return once more after meeting the Fingers for dialogues and an emote.</label>
+                    <label class="form-check-label item_content" for="npc_quests_8_1">Found just outside the starting area, talk to him then return to talk after unlocking Roundtable Hold. Return again after killing Godrick and once more after meeting the Fingers for dialogues and an emote.</label>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="npc_quests_8_2" id="item_8_2">

--- a/docs/js/index.js
+++ b/docs/js/index.js
@@ -2202,9 +2202,6 @@
 "npc_quests_7_8",
 "npc_quests_7_9",
 "npc_quests_8_1",
-"npc_quests_8_1_2",
-"npc_quests_8_1_3",
-"npc_quests_8_1_4",
 "npc_quests_8_2",
 "npc_quests_8_3",
 "npc_quests_8_4",
@@ -3647,7 +3644,7 @@ const playthrough_total = 334;
 var playthrough_checked = 0;
 const quest_order_tldr_total = 272;
 var quest_order_tldr_checked = 0;
-const npc_quests_total = 347;
+const npc_quests_total = 344;
 var npc_quests_checked = 0;
 const achievements_total = 42;
 var achievements_checked = 0;

--- a/docs/js/item_links.js
+++ b/docs/js/item_links.js
@@ -502,7 +502,7 @@ const item_links = {
       "armor_480",
       "armor_481",
       "bosses_9_10",
-      "evergaols_5_1",
+      "caves_e10",
       "incantations_4_11"
     ]
   },
@@ -512,7 +512,7 @@ const item_links = {
       "armor_480",
       "armor_481",
       "bosses_9_10",
-      "evergaols_5_1",
+      "caves_e10",
       "incantations_4_11"
     ]
   },
@@ -522,7 +522,7 @@ const item_links = {
       "armor_478",
       "armor_481",
       "bosses_9_10",
-      "evergaols_5_1",
+      "caves_e10",
       "incantations_4_11"
     ]
   },
@@ -532,7 +532,7 @@ const item_links = {
       "armor_478",
       "armor_480",
       "bosses_9_10",
-      "evergaols_5_1",
+      "caves_e10",
       "incantations_4_11"
     ]
   },
@@ -958,7 +958,7 @@ const item_links = {
   "ashesofwar_8_7": {
     "targets": [
       "bosses_4_27",
-      "legacy_1_5",
+      "caves_ld4",
       "sorceries_4_12"
     ]
   },
@@ -1030,7 +1030,7 @@ const item_links = {
   "bosses_10_10": {
     "targets": [
       "achievements_2_19",
-      "legacy_1_14",
+      "caves_ld11",
       "sorceries_13_1",
       "weapons_25_15"
     ]
@@ -1038,8 +1038,8 @@ const item_links = {
   "bosses_10_11": {
     "targets": [
       "achievements_1_6",
+      "caves_ld12",
       "great_runes_1_6",
-      "legacy_1_15",
       "remembrances_mausoleums_1_14"
     ]
   },
@@ -1124,7 +1124,7 @@ const item_links = {
   "bosses_11_6": {
     "targets": [
       "achievements_2_20",
-      "legacy_1_12",
+      "caves_ld13",
       "remembrances_mausoleums_1_7"
     ]
   },
@@ -1145,7 +1145,7 @@ const item_links = {
   },
   "bosses_12_4": {
     "targets": [
-      "legacy_1_16",
+      "caves_ld14",
       "remembrances_mausoleums_1_13"
     ]
   },
@@ -1245,14 +1245,14 @@ const item_links = {
   },
   "bosses_1_10": {
     "targets": [
-      "evergaols_0_1",
+      "caves_e3",
       "talismans_1_6"
     ]
   },
   "bosses_1_11": {
     "targets": [
       "achievements_2_2",
-      "legacy_1_1",
+      "caves_ld2",
       "legendaries_1_2",
       "weapons_5_10"
     ]
@@ -1361,14 +1361,14 @@ const item_links = {
   },
   "bosses_2_18": {
     "targets": [
-      "evergaols_1_1",
+      "caves_e1",
       "playthrough_67",
       "weapons_8_3"
     ]
   },
   "bosses_2_19": {
     "targets": [
-      "evergaols_1_2",
+      "caves_e2",
       "incantations_5_3"
     ]
   },
@@ -1423,8 +1423,8 @@ const item_links = {
   "bosses_2_29": {
     "targets": [
       "achievements_1_1",
+      "caves_ld1",
       "great_runes_1_1",
-      "legacy_1_2",
       "remembrances_mausoleums_1_1"
     ]
   },
@@ -1563,7 +1563,7 @@ const item_links = {
   },
   "bosses_4_2": {
     "targets": [
-      "evergaols_2_2",
+      "caves_e4",
       "incantations_6_2",
       "legendaries_5_1"
     ]
@@ -1576,7 +1576,7 @@ const item_links = {
   },
   "bosses_4_22": {
     "targets": [
-      "evergaols_2_1",
+      "caves_e5",
       "sorceries_4_6"
     ]
   },
@@ -1606,14 +1606,13 @@ const item_links = {
     "targets": [
       "achievements_2_5",
       "ashesofwar_8_7",
-      "legacy_1_5",
-      "legacy_1_6",
+      "caves_ld4",
       "sorceries_4_12"
     ]
   },
   "bosses_4_29": {
     "targets": [
-      "evergaols_2_3",
+      "caves_e6",
       "sorceries_4_8"
     ]
   },
@@ -1625,7 +1624,7 @@ const item_links = {
   },
   "bosses_4_32": {
     "targets": [
-      "evergaols_2_4",
+      "caves_e7",
       "legendaries_3_4",
       "spirit_ashes_3_3"
     ]
@@ -1652,8 +1651,9 @@ const item_links = {
   "bosses_4_36": {
     "targets": [
       "achievements_2_4",
+      "caves_ld3",
       "great_runes_1_2",
-      "legacy_1_4"
+      "remembrances_mausoleums_1_2"
     ]
   },
   "bosses_4_37": {
@@ -1738,7 +1738,7 @@ const item_links = {
   },
   "bosses_5_15": {
     "targets": [
-      "evergaols_3_1",
+      "caves_e8",
       "spirit_ashes_4_1"
     ]
   },
@@ -1800,7 +1800,7 @@ const item_links = {
   },
   "bosses_5_26": {
     "targets": [
-      "legacy_1_7",
+      "caves_ld5",
       "legendaries_1_4",
       "weapons_5_9"
     ]
@@ -1871,7 +1871,7 @@ const item_links = {
   },
   "bosses_6_1": {
     "targets": [
-      "evergaols_4_1",
+      "caves_e9",
       "legendaries_2_4",
       "talismans_6_5"
     ]
@@ -2044,8 +2044,8 @@ const item_links = {
   "bosses_7_26": {
     "targets": [
       "achievements_1_4",
+      "caves_ld7",
       "great_runes_1_5",
-      "legacy_1_9",
       "remembrances_mausoleums_1_8"
     ]
   },
@@ -2098,7 +2098,7 @@ const item_links = {
   "bosses_7_8": {
     "targets": [
       "achievements_2_14",
-      "legacy_1_8",
+      "caves_ld6",
       "legendaries_1_6",
       "weapons_14_13",
       "weapons_34_5"
@@ -2131,8 +2131,8 @@ const item_links = {
   "bosses_8_16": {
     "targets": [
       "achievements_2_22",
-      "incantations_2_3",
-      "legacy_1_11"
+      "caves_ld9",
+      "incantations_2_3"
     ]
   },
   "bosses_8_17": {
@@ -2144,8 +2144,8 @@ const item_links = {
   "bosses_8_18": {
     "targets": [
       "achievements_1_3",
+      "caves_ld8",
       "great_runes_1_4",
-      "legacy_1_10",
       "remembrances_mausoleums_1_10"
     ]
   },
@@ -2203,7 +2203,7 @@ const item_links = {
       "armor_478",
       "armor_480",
       "armor_481",
-      "evergaols_5_1",
+      "caves_e10",
       "incantations_4_11"
     ]
   },
@@ -2284,7 +2284,7 @@ const item_links = {
   "bosses_9_9": {
     "targets": [
       "achievements_2_16",
-      "legacy_1_13",
+      "caves_ld10",
       "weapons_28_7"
     ]
   },
@@ -2602,6 +2602,178 @@ const item_links = {
       "sorceries_12_5"
     ]
   },
+  "caves_e1": {
+    "targets": [
+      "bosses_2_18",
+      "playthrough_67",
+      "weapons_8_3"
+    ]
+  },
+  "caves_e10": {
+    "targets": [
+      "armor_477",
+      "armor_478",
+      "armor_480",
+      "armor_481",
+      "bosses_9_10",
+      "incantations_4_11"
+    ]
+  },
+  "caves_e2": {
+    "targets": [
+      "bosses_2_19",
+      "incantations_5_3"
+    ]
+  },
+  "caves_e3": {
+    "targets": [
+      "bosses_1_10",
+      "talismans_1_6"
+    ]
+  },
+  "caves_e4": {
+    "targets": [
+      "bosses_4_2",
+      "incantations_6_2",
+      "legendaries_5_1"
+    ]
+  },
+  "caves_e5": {
+    "targets": [
+      "bosses_4_22",
+      "sorceries_4_6"
+    ]
+  },
+  "caves_e6": {
+    "targets": [
+      "bosses_4_29",
+      "sorceries_4_8"
+    ]
+  },
+  "caves_e7": {
+    "targets": [
+      "bosses_4_32",
+      "legendaries_3_4",
+      "spirit_ashes_3_3"
+    ]
+  },
+  "caves_e8": {
+    "targets": [
+      "bosses_5_15",
+      "spirit_ashes_4_1"
+    ]
+  },
+  "caves_e9": {
+    "targets": [
+      "bosses_6_1",
+      "legendaries_2_4",
+      "talismans_6_5"
+    ]
+  },
+  "caves_l16": {
+    "orsources": [
+      "quest_order_tldr_12"
+    ],
+    "ortargets": [
+      "playthrough_22",
+      "playthrough_23"
+    ]
+  },
+  "caves_ld1": {
+    "targets": [
+      "bosses_2_29",
+      "great_runes_1_1",
+      "remembrances_mausoleums_1_1"
+    ]
+  },
+  "caves_ld10": {
+    "targets": [
+      "bosses_9_9",
+      "weapons_28_7"
+    ]
+  },
+  "caves_ld11": {
+    "targets": [
+      "bosses_10_10",
+      "sorceries_13_1",
+      "weapons_25_15"
+    ]
+  },
+  "caves_ld12": {
+    "targets": [
+      "bosses_10_11",
+      "great_runes_1_6",
+      "remembrances_mausoleums_1_14"
+    ]
+  },
+  "caves_ld13": {
+    "targets": [
+      "bosses_11_6",
+      "remembrances_mausoleums_1_7"
+    ]
+  },
+  "caves_ld14": {
+    "targets": [
+      "bosses_12_4",
+      "remembrances_mausoleums_1_13"
+    ]
+  },
+  "caves_ld2": {
+    "targets": [
+      "bosses_1_11",
+      "legendaries_1_2",
+      "weapons_5_10"
+    ]
+  },
+  "caves_ld3": {
+    "targets": [
+      "bosses_4_36",
+      "great_runes_1_2",
+      "remembrances_mausoleums_1_2"
+    ]
+  },
+  "caves_ld4": {
+    "targets": [
+      "ashesofwar_8_7",
+      "bosses_4_27",
+      "sorceries_4_12"
+    ]
+  },
+  "caves_ld5": {
+    "targets": [
+      "bosses_5_26",
+      "legendaries_1_4",
+      "weapons_5_9"
+    ]
+  },
+  "caves_ld6": {
+    "targets": [
+      "bosses_7_8",
+      "legendaries_1_6",
+      "weapons_14_13",
+      "weapons_34_5"
+    ]
+  },
+  "caves_ld7": {
+    "targets": [
+      "bosses_7_26",
+      "great_runes_1_5",
+      "remembrances_mausoleums_1_8"
+    ]
+  },
+  "caves_ld8": {
+    "targets": [
+      "bosses_8_18",
+      "great_runes_1_4",
+      "remembrances_mausoleums_1_10"
+    ]
+  },
+  "caves_ld9": {
+    "targets": [
+      "bosses_8_16",
+      "incantations_2_3"
+    ]
+  },
   "cookbooks_2_2": {
     "targets": [
       "playthrough_48",
@@ -2850,74 +3022,6 @@ const item_links = {
     "targets": [
       "bosses_9_8",
       "weapons_14_17"
-    ]
-  },
-  "evergaols_0_1": {
-    "targets": [
-      "bosses_1_10",
-      "talismans_1_6"
-    ]
-  },
-  "evergaols_1_1": {
-    "targets": [
-      "bosses_2_18",
-      "playthrough_67",
-      "weapons_8_3"
-    ]
-  },
-  "evergaols_1_2": {
-    "targets": [
-      "bosses_2_19",
-      "incantations_5_3"
-    ]
-  },
-  "evergaols_2_1": {
-    "targets": [
-      "bosses_4_22",
-      "sorceries_4_6"
-    ]
-  },
-  "evergaols_2_2": {
-    "targets": [
-      "bosses_4_2",
-      "incantations_6_2",
-      "legendaries_5_1"
-    ]
-  },
-  "evergaols_2_3": {
-    "targets": [
-      "bosses_4_29",
-      "sorceries_4_8"
-    ]
-  },
-  "evergaols_2_4": {
-    "targets": [
-      "bosses_4_32",
-      "legendaries_3_4",
-      "spirit_ashes_3_3"
-    ]
-  },
-  "evergaols_3_1": {
-    "targets": [
-      "bosses_5_15",
-      "spirit_ashes_4_1"
-    ]
-  },
-  "evergaols_4_1": {
-    "targets": [
-      "bosses_6_1",
-      "legendaries_2_4",
-      "talismans_6_5"
-    ]
-  },
-  "evergaols_5_1": {
-    "targets": [
-      "armor_477",
-      "armor_478",
-      "armor_480",
-      "armor_481",
-      "bosses_9_10",
-      "incantations_4_11"
     ]
   },
   "flasks_1_17": {
@@ -3269,14 +3373,15 @@ const item_links = {
   "great_runes_1_1": {
     "targets": [
       "bosses_2_29",
-      "legacy_1_2",
+      "caves_ld1",
       "remembrances_mausoleums_1_1"
     ]
   },
   "great_runes_1_2": {
     "targets": [
       "bosses_4_36",
-      "legacy_1_4"
+      "caves_ld3",
+      "remembrances_mausoleums_1_2"
     ]
   },
   "great_runes_1_3": {
@@ -3288,21 +3393,21 @@ const item_links = {
   "great_runes_1_4": {
     "targets": [
       "bosses_8_18",
-      "legacy_1_10",
+      "caves_ld8",
       "remembrances_mausoleums_1_10"
     ]
   },
   "great_runes_1_5": {
     "targets": [
       "bosses_7_26",
-      "legacy_1_9",
+      "caves_ld7",
       "remembrances_mausoleums_1_8"
     ]
   },
   "great_runes_1_6": {
     "targets": [
       "bosses_10_11",
-      "legacy_1_15",
+      "caves_ld12",
       "remembrances_mausoleums_1_14"
     ]
   },
@@ -3325,7 +3430,7 @@ const item_links = {
   "incantations_2_3": {
     "targets": [
       "bosses_8_16",
-      "legacy_1_11"
+      "caves_ld9"
     ]
   },
   "incantations_3_11": {
@@ -3340,7 +3445,7 @@ const item_links = {
       "armor_480",
       "armor_481",
       "bosses_9_10",
-      "evergaols_5_1"
+      "caves_e10"
     ]
   },
   "incantations_4_12": {
@@ -3371,7 +3476,7 @@ const item_links = {
   "incantations_5_3": {
     "targets": [
       "bosses_2_19",
-      "evergaols_1_2"
+      "caves_e2"
     ]
   },
   "incantations_5_5": {
@@ -3387,7 +3492,7 @@ const item_links = {
   "incantations_6_2": {
     "targets": [
       "bosses_4_2",
-      "evergaols_2_2",
+      "caves_e4",
       "legendaries_5_1"
     ]
   },
@@ -3404,114 +3509,6 @@ const item_links = {
       "weapons_18_3"
     ]
   },
-  "legacy_1_1": {
-    "targets": [
-      "bosses_1_11",
-      "legendaries_1_2",
-      "weapons_5_10"
-    ]
-  },
-  "legacy_1_10": {
-    "targets": [
-      "bosses_8_18",
-      "great_runes_1_4",
-      "remembrances_mausoleums_1_10"
-    ]
-  },
-  "legacy_1_11": {
-    "targets": [
-      "bosses_8_16",
-      "incantations_2_3"
-    ]
-  },
-  "legacy_1_12": {
-    "targets": [
-      "bosses_11_6",
-      "remembrances_mausoleums_1_7"
-    ]
-  },
-  "legacy_1_13": {
-    "targets": [
-      "bosses_9_9",
-      "weapons_28_7"
-    ]
-  },
-  "legacy_1_14": {
-    "targets": [
-      "bosses_10_10",
-      "sorceries_13_1",
-      "weapons_25_15"
-    ]
-  },
-  "legacy_1_15": {
-    "targets": [
-      "bosses_10_11",
-      "great_runes_1_6",
-      "remembrances_mausoleums_1_14"
-    ]
-  },
-  "legacy_1_16": {
-    "targets": [
-      "bosses_12_4",
-      "remembrances_mausoleums_1_13"
-    ]
-  },
-  "legacy_1_2": {
-    "targets": [
-      "bosses_2_29",
-      "great_runes_1_1",
-      "remembrances_mausoleums_1_1"
-    ]
-  },
-  "legacy_1_3": {
-    "orsources": [
-      "quest_order_tldr_12"
-    ],
-    "ortargets": [
-      "playthrough_22",
-      "playthrough_23"
-    ]
-  },
-  "legacy_1_4": {
-    "targets": [
-      "bosses_4_36",
-      "great_runes_1_2"
-    ]
-  },
-  "legacy_1_5": {
-    "targets": [
-      "ashesofwar_8_7",
-      "bosses_4_27",
-      "sorceries_4_12"
-    ]
-  },
-  "legacy_1_6": {
-    "targets": [
-      "bosses_4_27"
-    ]
-  },
-  "legacy_1_7": {
-    "targets": [
-      "bosses_5_26",
-      "legendaries_1_4",
-      "weapons_5_9"
-    ]
-  },
-  "legacy_1_8": {
-    "targets": [
-      "bosses_7_8",
-      "legendaries_1_6",
-      "weapons_14_13",
-      "weapons_34_5"
-    ]
-  },
-  "legacy_1_9": {
-    "targets": [
-      "bosses_7_26",
-      "great_runes_1_5",
-      "remembrances_mausoleums_1_8"
-    ]
-  },
   "legendaries_1_1": {
     "targets": [
       "armor_523",
@@ -3525,21 +3522,21 @@ const item_links = {
   "legendaries_1_2": {
     "targets": [
       "bosses_1_11",
-      "legacy_1_1",
+      "caves_ld2",
       "weapons_5_10"
     ]
   },
   "legendaries_1_4": {
     "targets": [
       "bosses_5_26",
-      "legacy_1_7",
+      "caves_ld5",
       "weapons_5_9"
     ]
   },
   "legendaries_1_6": {
     "targets": [
       "bosses_7_8",
-      "legacy_1_8",
+      "caves_ld6",
       "weapons_14_13",
       "weapons_34_5"
     ]
@@ -3553,7 +3550,7 @@ const item_links = {
   "legendaries_2_4": {
     "targets": [
       "bosses_6_1",
-      "evergaols_4_1",
+      "caves_e9",
       "talismans_6_5"
     ]
   },
@@ -3575,7 +3572,7 @@ const item_links = {
   "legendaries_3_4": {
     "targets": [
       "bosses_4_32",
-      "evergaols_2_4",
+      "caves_e7",
       "spirit_ashes_3_3"
     ]
   },
@@ -3588,7 +3585,7 @@ const item_links = {
   "legendaries_5_1": {
     "targets": [
       "bosses_4_2",
-      "evergaols_2_2",
+      "caves_e4",
       "incantations_6_2"
     ]
   },
@@ -3751,12 +3748,6 @@ const item_links = {
       "quest_order_tldr_9"
     ]
   },
-  "npc_quests_8_1": {
-    "targets": [
-      "playthrough_1",
-      "quest_order_tldr_1"
-    ]
-  },
   "npc_quests_9_1": {
     "targets": [
       "quest_order_tldr_18",
@@ -3784,7 +3775,6 @@ const item_links = {
   },
   "playthrough_1": {
     "targets": [
-      "npc_quests_8_1",
       "quest_order_tldr_1"
     ]
   },
@@ -3878,7 +3868,7 @@ const item_links = {
       "playthrough_23"
     ],
     "andtargets": [
-      "legacy_1_3",
+      "caves_l16",
       "quest_order_tldr_12"
     ],
     "targets": [
@@ -3891,7 +3881,7 @@ const item_links = {
       "playthrough_22"
     ],
     "andtargets": [
-      "legacy_1_3",
+      "caves_l16",
       "quest_order_tldr_12"
     ]
   },
@@ -4241,7 +4231,7 @@ const item_links = {
     ],
     "targets": [
       "bosses_2_18",
-      "evergaols_1_1",
+      "caves_e1",
       "weapons_8_3"
     ]
   },
@@ -4280,7 +4270,6 @@ const item_links = {
   },
   "quest_order_tldr_1": {
     "targets": [
-      "npc_quests_8_1",
       "playthrough_1"
     ]
   },
@@ -4291,7 +4280,7 @@ const item_links = {
   },
   "quest_order_tldr_12": {
     "orsources": [
-      "legacy_1_3"
+      "caves_l16"
     ],
     "ortargets": [
       "playthrough_22",
@@ -4541,15 +4530,15 @@ const item_links = {
   "remembrances_mausoleums_1_1": {
     "targets": [
       "bosses_2_29",
-      "great_runes_1_1",
-      "legacy_1_2"
+      "caves_ld1",
+      "great_runes_1_1"
     ]
   },
   "remembrances_mausoleums_1_10": {
     "targets": [
       "bosses_8_18",
-      "great_runes_1_4",
-      "legacy_1_10"
+      "caves_ld8",
+      "great_runes_1_4"
     ]
   },
   "remembrances_mausoleums_1_10_1": {
@@ -4590,7 +4579,7 @@ const item_links = {
   "remembrances_mausoleums_1_13": {
     "targets": [
       "bosses_12_4",
-      "legacy_1_16"
+      "caves_ld14"
     ]
   },
   "remembrances_mausoleums_1_13_1": {
@@ -4606,8 +4595,8 @@ const item_links = {
   "remembrances_mausoleums_1_14": {
     "targets": [
       "bosses_10_11",
-      "great_runes_1_6",
-      "legacy_1_15"
+      "caves_ld12",
+      "great_runes_1_6"
     ]
   },
   "remembrances_mausoleums_1_14_1": {
@@ -4644,6 +4633,13 @@ const item_links = {
   "remembrances_mausoleums_1_1_2": {
     "targets": [
       "weapons_28_9"
+    ]
+  },
+  "remembrances_mausoleums_1_2": {
+    "targets": [
+      "bosses_4_36",
+      "caves_ld3",
+      "great_runes_1_2"
     ]
   },
   "remembrances_mausoleums_1_2_1": {
@@ -4720,7 +4716,7 @@ const item_links = {
   "remembrances_mausoleums_1_7": {
     "targets": [
       "bosses_11_6",
-      "legacy_1_12"
+      "caves_ld13"
     ]
   },
   "remembrances_mausoleums_1_7_1": {
@@ -4736,8 +4732,8 @@ const item_links = {
   "remembrances_mausoleums_1_8": {
     "targets": [
       "bosses_7_26",
-      "great_runes_1_5",
-      "legacy_1_9"
+      "caves_ld7",
+      "great_runes_1_5"
     ]
   },
   "remembrances_mausoleums_1_8_1": {
@@ -4784,7 +4780,7 @@ const item_links = {
   "sorceries_13_1": {
     "targets": [
       "bosses_10_10",
-      "legacy_1_14",
+      "caves_ld11",
       "weapons_25_15"
     ]
   },
@@ -4798,7 +4794,7 @@ const item_links = {
     "targets": [
       "ashesofwar_8_7",
       "bosses_4_27",
-      "legacy_1_5"
+      "caves_ld4"
     ]
   },
   "sorceries_4_22": {
@@ -4823,7 +4819,7 @@ const item_links = {
   "sorceries_4_6": {
     "targets": [
       "bosses_4_22",
-      "evergaols_2_1"
+      "caves_e5"
     ]
   },
   "sorceries_4_7": {
@@ -4834,7 +4830,7 @@ const item_links = {
   "sorceries_4_8": {
     "targets": [
       "bosses_4_29",
-      "evergaols_2_3"
+      "caves_e6"
     ]
   },
   "sorceries_5_1": {
@@ -4948,7 +4944,7 @@ const item_links = {
   "spirit_ashes_3_3": {
     "targets": [
       "bosses_4_32",
-      "evergaols_2_4",
+      "caves_e7",
       "legendaries_3_4"
     ]
   },
@@ -4961,7 +4957,7 @@ const item_links = {
   "spirit_ashes_4_1": {
     "targets": [
       "bosses_5_15",
-      "evergaols_3_1"
+      "caves_e8"
     ]
   },
   "spirit_ashes_4_3": {
@@ -5040,7 +5036,7 @@ const item_links = {
   "talismans_1_6": {
     "targets": [
       "bosses_1_10",
-      "evergaols_0_1"
+      "caves_e3"
     ]
   },
   "talismans_2_11": {
@@ -5160,7 +5156,7 @@ const item_links = {
   "talismans_6_5": {
     "targets": [
       "bosses_6_1",
-      "evergaols_4_1",
+      "caves_e9",
       "legendaries_2_4"
     ]
   },
@@ -5225,7 +5221,7 @@ const item_links = {
   "weapons_14_13": {
     "targets": [
       "bosses_7_8",
-      "legacy_1_8",
+      "caves_ld6",
       "legendaries_1_6",
       "weapons_34_5"
     ]
@@ -5472,7 +5468,7 @@ const item_links = {
   "weapons_25_15": {
     "targets": [
       "bosses_10_10",
-      "legacy_1_14",
+      "caves_ld11",
       "sorceries_13_1"
     ]
   },
@@ -5520,7 +5516,7 @@ const item_links = {
   "weapons_28_7": {
     "targets": [
       "bosses_9_9",
-      "legacy_1_13"
+      "caves_ld10"
     ]
   },
   "weapons_28_9": {
@@ -5574,7 +5570,7 @@ const item_links = {
   "weapons_34_5": {
     "targets": [
       "bosses_7_8",
-      "legacy_1_8",
+      "caves_ld6",
       "legendaries_1_6",
       "weapons_14_13"
     ]
@@ -5612,7 +5608,7 @@ const item_links = {
   "weapons_5_10": {
     "targets": [
       "bosses_1_11",
-      "legacy_1_1",
+      "caves_ld2",
       "legendaries_1_2"
     ]
   },
@@ -5629,7 +5625,7 @@ const item_links = {
   "weapons_5_9": {
     "targets": [
       "bosses_5_26",
-      "legacy_1_7",
+      "caves_ld5",
       "legendaries_1_4"
     ]
   },
@@ -5674,7 +5670,7 @@ const item_links = {
   "weapons_8_3": {
     "targets": [
       "bosses_2_18",
-      "evergaols_1_1",
+      "caves_e1",
       "playthrough_67"
     ]
   },

--- a/docs/search.html
+++ b/docs/search.html
@@ -3039,16 +3039,7 @@
               <div class="d-flex align-items-center">Lore: Is a Bluntstone, meaning a magic scholar who can't use magic. However he invented a spell worthy of being an entirely new school of magic.</div>
             </a>
             <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/npc_questlines.html#item_8_1" id="/checklists/npc_questlines.html#item_8_1">
-              <div class="d-flex align-items-center">Found at the First Step Site of Grace. Exhaust his dialogue.</div>
-            </a>
-            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/npc_questlines.html#item_8_1_2" id="/checklists/npc_questlines.html#item_8_1_2">
-              <div class="d-flex align-items-center">Return to talk after unlocking Roundtable Hold.</div>
-            </a>
-            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/npc_questlines.html#item_8_1_3" id="/checklists/npc_questlines.html#item_8_1_3">
-              <div class="d-flex align-items-center">Return again after killing Godrick.</div>
-            </a>
-            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/npc_questlines.html#item_8_1_4" id="/checklists/npc_questlines.html#item_8_1_4">
-              <div class="d-flex align-items-center">Return once more after meeting the Fingers for dialogues and an emote.</div>
+              <div class="d-flex align-items-center">Found just outside the starting area, talk to him then return to talk after unlocking Roundtable Hold. Return again after killing Godrick and once more after meeting the Fingers for dialogues and an emote.</div>
             </a>
             <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/npc_questlines.html#item_8_2" id="/checklists/npc_questlines.html#item_8_2">
               <div class="d-flex align-items-center">Go to the Rose Church located on an island in the South-West area of Liurnia Lake. Talk to him for Festering Bloody Fingers then perform 3 Invasions, outcome don't matter and you can even leave immediately after arriving, then talk to him again for a Lord of Blood's Favor.</div>

--- a/docs/search_index.json
+++ b/docs/search_index.json
@@ -3781,19 +3781,7 @@
   },
   {
     "id": "/checklists/npc_questlines.html#item_8_1",
-    "text": "Found at the First Step Site of Grace. Exhaust his dialogue."
-  },
-  {
-    "id": "/checklists/npc_questlines.html#item_8_1_2",
-    "text": "Return to talk after unlocking Roundtable Hold."
-  },
-  {
-    "id": "/checklists/npc_questlines.html#item_8_1_3",
-    "text": "Return again after killing Godrick."
-  },
-  {
-    "id": "/checklists/npc_questlines.html#item_8_1_4",
-    "text": "Return once more after meeting the Fingers for dialogues and an emote."
+    "text": "Found just outside the starting area, talk to him then return to talk after unlocking Roundtable Hold. Return again after killing Godrick and once more after meeting the Fingers for dialogues and an emote."
   },
   {
     "id": "/checklists/npc_questlines.html#item_8_2",


### PR DESCRIPTION
Fixed all the Evergaols and Legacy Dungeons linking with the new ids from the Landmarks page.
Also reverted first step of Varré to the way it was written before since it's more in line with the way the rest of the steps are written.