### PR TITLE
Stonesword Keys page + minor fixes

### DIFF
--- a/data/checklists/bell_bearings.yaml
+++ b/data/checklists/bell_bearings.yaml
@@ -1,7 +1,7 @@
 title: Bell Bearings
 id: bell_bearings
 map_icon: "/map/icons/MENU_MAP_80.png"
-description: "Bell bearings should be given to the Twin Maiden Husks at the Roundtable Hold. Each one found unlocks a unique selection of items for the shop, either adding it to the base stock or creating a new special sub-inventory within \"Bell bearing shops.\" Some are found in the world or as boss drops; additionally, every NPC who sells items will drop a bell bearing if they die so that you can still access what they sell. Some bell bearings, including all from the unnamed Merchants of the world, can only be collected by murder, the only benefit to which is the convenience of their inventory being available in the Roundtable Hold instead of going and finding them if you want to buy from them again. All bell bearings reset upon NG+."
+description: "Bell bearings should be given to the Twin Maiden Husks at the Roundtable Hold. Each one found unlocks a unique selection of items for the shop, either adding it to the base stock or creating a new special sub-inventory within \"Bell bearing shops.\" Some are found in the world or as boss drops; additionally, every NPC who sells items will drop a bell bearing if they die so that you can still access what they sell. Some bell bearings, including all from the unnamed Merchants of the world, can only be collected by murder, the only benefit to which is the convenience of their inventory being available in the Roundtable Hold. Bell bearings from merchants and NPCs reset upon NG+, but the others don't."
 sections:
   -
     title: "Smithing-Stone Miner's Bell Bearings"

--- a/data/checklists/bosses.yaml
+++ b/data/checklists/bosses.yaml
@@ -573,7 +573,7 @@ sections:
       - id: "7_15"
         data: ["Full-Grown Fallingstar Beast", "Ninth Mt. Gelmir Campsite", "21,000 runes, Fallingstar Beast Jaw Colossal Weapon, Somber Smithing Stone, Smithing Stone [6] (x5)", "Field boss."]
       - id: "7_17"
-        data: ["Fire Prelate", "Fort Laiedd", "1309 runes, Prelate's Inferno Crozier Colossal Weapon, Thorned Whip", "Field boss. Chance to drop Fire Prelate Set."]
+        data: ["Fire Prelate", "Fort Laiedd", "1309 runes, Prelate's Inferno Crozier", "Field boss. Chance to drop Fire Prelate Set."]
       - id: "7_18"
         data: ["Magma Wyrm", "Fort Laiedd (South)", "19,000 runes, Dragon Heart, Unlocks Magma Breath (Dragon Communion Incantation)", ""]
         cords: [1925, 3007]

--- a/data/checklists/gestures.yaml
+++ b/data/checklists/gestures.yaml
@@ -89,7 +89,7 @@ sections:
         icon: "/img/icons/gestures/07016.png"
         map_icon: "/map/icons/shadows/gestures/07016.png"
         map_icon_size: 40
-        data: ["Calm Down!", "Murkwater Cave", "Patches", "Open Patches's special chest after he's set up his shop in the cave, then go talk to him about it."]
+        data: ["Calm Down!", "Murkwater Cave", "Patches", "Open Patches's special chest after he's set up his shop in the cave, then go talk to him about it. If you miss it, you can also get this gesture from him in Mt. Gelmir by returning to him after he kicks you off a cliff."]
         cords: [4040, 6960]
       - id: "1_7"
         icon: "/img/icons/gestures/07030.png"

--- a/data/checklists/memory_stones_talisman_pouches.yaml
+++ b/data/checklists/memory_stones_talisman_pouches.yaml
@@ -13,7 +13,7 @@ sections:
         map_title: "Memory Stone"
       - id: "0_2"
         data: ["Purchasable from Twin Maiden Husks at the Roundtable Hold for 3,000 Runes."]
-        cords: [454, 8354]
+        cords: [463, 8363]
         map_title: "Memory Stone"
       - id: "0_3"
         data: ["Found in the Converted Tower, in the southwest of Liurnia of the Lakes."]

--- a/data/checklists/pots_bottles.yaml
+++ b/data/checklists/pots_bottles.yaml
@@ -73,7 +73,7 @@ sections:
         data: ["South-West of Southern Aeonia Swamp Bank Grace, South of the rot swamp. Sold by Nomadic Merchant for 1500 runes (NOTE: choosing Cracked Pots as a Keepsake gives you this pot early)"]
         cords: [5439, 7052]
         map_title: "Cracked Pot"
-      - "Altus Plateau"
+      - "Capital Outskirts"
       - id: "1_16"
         data: ["Auriza Side Tomb, just North-East of Leyndell: In the gated-off watery rooms at the bottom (NOTE: choosing Cracked Pots as a Keepsake gives you this pot early)"]
         cords: [4597, 3173]
@@ -90,7 +90,7 @@ sections:
         data: ["Auriza Side Tomb, just North-East of Leyndell: In the gated-off watery rooms at the bottom"]
         map_link: [4597, 3173]
         map_title: "Cracked Pot"
-      - "Leyndell"
+      - "Leyndell, Royal Capital"
       - id: "1_20"
         data: ["Northwest of the Avenue Balcony Site of Grace and one level below, through a couple doors, on a corpse"]
         cords: [4292, 3480]
@@ -117,7 +117,7 @@ sections:
         data: ["After Caria Manor, go West of the Manor then head South. Along the cliffs on the East side, you can jump down, back into Caria manor. Sold by Pidia for 1500 runes"]
         cords: [1822, 3733]
         map_title: "Ritual Pot"
-      - "Raya Lucaria"
+      - "Academy of Raya Lucaria"
       - id: "2_4"
         data: ["Near the Schoolhouse Classroom Site of Grace, in a chest guarded by mages and a giant Living Jar"]
         cords: [1900, 5036]
@@ -127,7 +127,7 @@ sections:
         data: ["Isolated Merchant's Shack in the North. Sold by the Isolated Merchant for 3000 runes"]
         cords: [5144, 6094]
         map_title: "Ritual Pot"
-      - "Altus Plateau"
+      - "Capital Outskirts"
       - id: "2_7"
         data: ["Auriza Side Tomb, just North-East of Leyndell: In a room with a giant Living Jar"]
         cords: [4606, 3184]
@@ -136,7 +136,7 @@ sections:
         data: ["Auriza Side Tomb, just North-East of Leyndell: In a room with a giant Living Jar"]
         map_link: [4606, 3184]
         map_title: "Ritual Pot"
-      - "Leyndell"
+      - "Leyndell, Royal Capital"
       - id: "2_9"
         data: ["In the Sewers at the end of the maze of tunnels, just before the elevator to the Forsaken Depths Grace."]
         cords: [4422, 3483]
@@ -177,16 +177,17 @@ sections:
         data: ["Shaded Castle, in the North-West: on a body atop a wall, accessible via the second swamp ladder"]
         cords: [2934, 2695]
         map_title: "Perfume Bottle"
-      - id: "3_8"
-        data: ["Hermit Merchant's Shack, on the cliff North-East from the Outer Wall Battleground Grace on the North side of the outer wall: sold by Hermit Merchant for 2000 runes"]
-        cords: [3974, 2945]
-        map_title: "Perfume Bottle"
       - "Mt. Gelmir"
       - id: "3_7"
         data: ["Volcano Manor: on a body in a room unlocked with the Drawing-Room Key"]
         cords: [2205, 2885]
         map_title: "Perfume Bottle"
-      - "Leyndell"
+      - "Capital Outskirts"
+      - id: "3_8"
+        data: ["Hermit Merchant's Shack, on the cliff North-East from the Outer Wall Battleground Grace on the North side of the outer wall: sold by Hermit Merchant for 2000 runes"]
+        cords: [3974, 2945]
+        map_title: "Perfume Bottle"
+      - "Leyndell, Royal Capital"
       - id: "3_9"
         data: ["Follow the path from the East Capital Rampart Grace along the rampart, into the tower, down the elevator, into the next tower, and up a ladder guarded by a Perfumer. It's in a chest in the room at the top"]
         cords: [4434, 3542]

--- a/data/checklists/quests.yaml
+++ b/data/checklists/quests.yaml
@@ -577,7 +577,7 @@ sections:
         - id: "31_20_1"
           data: ["If you choose the Red summon sign, you'll invade and kill Millicent. From her, you'll receive Millicent's Prothesis. Go back to Gowry's Shack, and he'll be dead as well, giving you the Flock's Canvas Talisman and his bell bearing."]
         - id: "31_20_2"
-          data: ["If you use the Gold summon sign, you'll help her fight her invaders. Once you win, return to where the summon signs were to find her lying by the pool of rot. Be very careful dropping down to her, if you land on her, she'll die. Exhaust her dialogue for the Rotten Winged Sword Insignia then reload the area to get back the Unalloyed Gold Needle, which you can use on a flower in Malenia's boss arena for Somber Ancient Dragon Smithing Stone and Miquella's Needle, which is needed to cure yourself of the Frenzied Flame. Gowry will remain alive, kill him for his stuff"]
+          data: ["If you use the Gold summon sign, you'll help her fight her invaders. If you or she dies, you can try again. Once you win, return to where the summon signs were to find her lying by the pool of rot. Exhaust her dialogue for the Rotten Winged Sword Insignia then reload the area to get back the Unalloyed Gold Needle, which you can use on a flower in Malenia's boss arena for Somber Ancient Dragon Smithing Stone and Miquella's Needle, which is needed to cure yourself of the Frenzied Flame. Gowry will remain alive, but can finally be killed for his stuff"]
       - id: "31_21"
         data: ["Summons"]
       -
@@ -594,7 +594,7 @@ sections:
     link: "https://eldenring.wiki.fextralife.com/Miriel+Pastor+of+Vows"
     items:
       - id: "5_1"
-        data: ["Located at the Church of Vows in East Liurnia Lake. Teaches sorceries and incantations, and accepts scrolls and prayerbooks. Never moves or dies, unless you're the worst kind of person, so is a good candidate to give them all to."]
+        data: ["Located at the Church of Vows in East Liurnia of the Lakes. Teaches sorceries and incantations, and accepts scrolls and prayerbooks. Never moves or dies, unless you're the worst kind of person, so is a good candidate to give them all to."]
       - id: "5_2"
         data: ["Gives you the hint needed for Brother Corhyn and Goldmasks questline in Leyndell"]
       - id: "5_3"
@@ -647,11 +647,11 @@ sections:
       - id: "29_2"
         data: ["Reload and talk to him again for some dialogue and buy some stuff from him. Reload and come back and he will offer you his chest, open it for a fun time."]
       - id: "29_8"
-        data: ["Make your way back to him and he'll give you another gesture (Note: he won't give the gesture if you've been to Liurnia Lake)"]
+        data: ["Make your way back to him and he'll give you another gesture (Note: he won't give the gesture if you've been to Liurnia of the Lakes)"]
       - id: "29_3"
-        data: ["He'll next be found at the Scenic Isle Grace in Liurnia Lake and will inform you about an Iron Virgin deep at the bottom of Raya Lucaria that will teleport you to the Erdtree if you let it eat you"]
+        data: ["He'll next be found at the Scenic Isle Grace in Liurnia of the Lakes and will inform you about an Iron Virgin deep at the bottom of Raya Lucaria that will teleport you to the Erdtree if you let it eat you"]
       - id: "29_4"
-        data: ["Missable: His next new location is near the First Mt. Gelmir Campfire Site of Grace. Follow the cliff edge westward until you reach the corner, and read the message he's left. You can find him nearby, squatting in a bush. He'll say you should totally check out what those Rainbow Stones are leading to. Wander over, with your back turned and your defenses lowered, to the tall ledge"]
+        data: ["Missable: His next new location is near the First Mt. Gelmir Campfire Site of Grace. Follow the cliff edge westward until you reach the corner, and read the message he's left. You can find him nearby, squatting in a bush. He'll say you should totally check out what those Rainbow Stones are leading to. Wander over, with your back turned and your defenses lowered, to the tall ledge. (If you missed the Calm Down gesture before, you can get it again from him now by making your way back to him before he moves on)"]
       - id: "29_5"
         data: ["Once you join Volcano Manor, you'll find him inside"]
       - id: "29_6"

--- a/data/checklists/stonesword_keys.yaml
+++ b/data/checklists/stonesword_keys.yaml
@@ -1,0 +1,522 @@
+title: "Stonesword Keys & Imp Seals"
+id: stonesword
+icon: "/img/icons/keys/00228.png"
+description: "Stonesword Keys are consumable key items that open Imp Statue Seals, which typically guard loot, dungeons, or optional paths. A maximum of 80 Stonesword Keys can be found in the game, plus 2 if chosen as a Keepsake. However, only 46 are required to open every Imp Statue Seal. Imp Statues each require either 1 or 2 keys, and the only way to tell the difference is by visual examination: most Imp Statues already have one key in them when you find them, meaning you only need one more."
+sections:
+  -
+    title: "Stonesword Keys"
+    icon: "/img/icons/keys/00228.png"
+    map_icon: "/map/icons/shadows/keys/00228.png"
+    items:
+      - id: "k1"
+        data: ["Can choose two as a keepsake"]
+      - id: "k2"
+        data: ["Can choose two as a keepsake"]
+      #
+      - "Limgrave"
+      - id: "k3"
+        data: ["In a tiny intact room in the center of Dragon-Burnt Ruins, on a body guarded by a single rat"]
+        cords: [3939, 7352]
+        map_title: "Stonesword Key"
+      - id: "k4"
+        data: ["Sold by Patches for 5000 runes in Murkwater Cave (and thereafter)"]
+        cords: [4015, 6975]
+        map_title: "Stonesword Key"
+      - id: "k5"
+        data: ["On the front of Stormhill Shack, on a body atop the little staircase of wooden platforms"]
+        cords: [3485, 6762]
+        map_title: "Stonesword Key"
+      - id: "k6"
+        data: ["In Fringefolk Hero's Grave, on the ledge from which you can shoot down the jars to destroy the chariot"]
+        cords: [3757, 7304]
+        map_title: "Stonesword Key"
+      #
+      - "Roundtable Hold"
+      - id: "k7"
+        data: ["Sold by Twin Maiden Husks for 4000 runes"]
+        cords: [451, 8385]
+        map_title: "Stonesword Key x3"
+      - id: "k8"
+        data: ["Sold by Twin Maiden Husks for 4000 runes"]
+        map_link: [451, 8385]
+        map_title: "Stonesword Key"
+      - id: "k9"
+        data: ["Sold by Twin Maiden Husks for 4000 runes"]
+        map_link: [451, 8385]
+        map_title: "Stonesword Key"
+      #
+      - "Weeping Peninsula"
+      - id: "k10"
+        data: ["On the Bridge of Sacrifice on a body behind the ballista"]
+        cords: [4350, 7756]
+        map_title: "Stonesword Key"
+      - id: "k11"
+        data: ["On the northern tip of the high ledge in the northeast, on a body sitting in a chair"]
+        cords: [4435, 7826]
+        map_title: "Stonesword Key"
+      - id: "k12"
+        data: ["Sold by the Nomadic Merchant in Weeping Peninsula for 2000 runes"]
+        cords: [4307, 8185]
+        map_title: "Stonesword Key"
+      - id: "k13"
+        data: ["Sold by the Isolated Merchant in Weeping Peninsula for 2000 runes"]
+        cords: [3450, 8230]
+        map_title: "Stonesword Key x3"
+      - id: "k14"
+        data: ["Sold by the Isolated Merchant in Weeping Peninsula for 2000 runes"]
+        map_link: [3450, 8230]
+        map_title: "Stonesword Key"
+      - id: "k15"
+        data: ["Sold by the Isolated Merchant in Weeping Peninsula for 2000 runes"]
+        map_link: [3450, 8230]
+        map_title: "Stonesword Key"
+      - id: "k16"
+        data: ["From the Behind the Castle Site of Grace in Castle Morne, descend down a couple ledges to the first rooftop, then walk forward and drop off to a wooden platform halfway down with the key on a body"]
+        cords: [3973, 8699]
+        map_title: "Stonesword Key"
+      #
+      - "Stormveil Castle"
+      - id: "k17"
+        data: ["From Rampart Tower, follow the path up the central spiral staircase and to the rooftops; from the stack of sandbags, follow the ledge to the south tower, then turn east and hop to the next crumbling tower, and drop down inside it to find it on a body"]
+        cords: [3104, 6709]
+        map_title: "Stonesword Key"
+      - id: "k18"
+        data: ["On a body on the wooden platform above the Grafted Scion (down the shortcut elevator from Rampart Tower)"]
+        cords: [3132, 6698]
+        map_title: "Stonesword Key"
+      - id: "k19"
+        data: ["On a body in the pit with the Ulcerated Tree Spirit, just past the first big roots on the left"]
+        cords: [3078, 6662]
+        map_title: "Stonesword Key"
+      #
+      - "Liurnia of the Lakes"
+      - id: "k20"
+        data: ["In Academy Crystal Cave, stick to the left past the rats and the Sages to find a small side room in the back, containing the key on a body in a cage"]
+        cords: [1733, 4883]
+        map_title: "Stonesword Key"
+      - id: "k21"
+        data: ["On the island directly east of the South Raya Lucaria Gate Site of Grace, accessible from Gate Town North; it's in a chest in a small tower sticking out of the water, requiring Torrent's double jump to reach"]
+        cords: [2102, 5056]
+        map_title: "Stonesword Key"
+      - id: "k22"
+        data: ["Outside Raya Lucaria at the base of its northeastern corner, up an incline leading to an area with many Wraith Callers and a body sitting in a chair with the key"]
+        cords: [1948, 4840]
+        map_title: "Stonesword Key"
+      - id: "k23"
+        data: ["Sold by the Isolated Merchant inside the South Raya Lucaria Gate for 3000 runes"]
+        cords: [2028, 4957]
+        map_title: "Stonesword Key x3"
+      - id: "k24"
+        data: ["Sold by the Isolated Merchant inside the South Raya Lucaria Gate for 3000 runes"]
+        map_link: [2028, 4957]
+        map_title: "Stonesword Key"
+      - id: "k25"
+        data: ["Sold by the Isolated Merchant inside the South Raya Lucaria Gate for 3000 runes"]
+        map_link: [2028, 4957]
+        map_title: "Stonesword Key"
+      - id: "k26"
+        data: ["As far north as it's possible to go from the Ainsel River Well before the cliff wall cuts off the path, on a body in a chair in a small patch of flowers"]
+        cords: [2782, 4459]
+        map_title: "Stonesword Key"
+      - id: "k27"
+        data: ["Atop the western wall of Frenzied Flame Village"]
+        cords: [2573, 4200]
+        map_title: "Stonesword Key"
+      - id: "k28"
+        data: ["From Three Sisters above Caria Manor, follow the path along the rooftops, dropping down when necessary, all the way to the rampart overlooking the Main Gate, with a Giant Crab on top guarding a body with the key"]
+        cords: [1885, 3832]
+        map_title: "Stonesword Key"
+      #
+      - "Academy of Raya Lucaria"
+      - id: "k29"
+        data: ["Past the illusory bookshelf directly before the Debate Parlor (Red Wolf of Radagon), on the other side of the altar behind the chest"]
+        cords: [1923, 5008]
+        map_title: "Stonesword Key"
+      - id: "k30"
+        data: ["In the courtyard directly after the Debate Parlor, on a body draped on the central fountain"]
+        cords: [1949, 4942]
+        map_title: "Stonesword Key"
+      #
+      - "Caelid"
+      - id: "k31"
+        data: ["In Gaol Cave, on a body in a cell"]
+        cords: [4921, 6764]
+        map_title: "Stonesword Key"
+      - id: "k32"
+        data: ["Sold by the Nomadic Merchant in south Caelid for 4000 runes"]
+        cords: [5416, 7067]
+        map_title: "Stonesword Key"
+      - id: "k33"
+        data: ["From the Dragonbarrow West grace, head to the Divine Tower of Caelid and jump onto the high tree branch, then to the first ledge with a ladder and a sentry with a torch; don't climb the ladder but face southeast from it and follow the arch to find the key on a body on the next landing, guarded by a knight"]
+        cords: [5569, 6091]
+        map_title: "Stonesword Key"
+      - id: "k34"
+        data: ["In Sellia, Town of Sorcery, on a body slumped atop an archway connecting two buildings at the southern entrance of town; passing northward through the arch underneath, turn right to see rubble with a rotted tree through it, an easy way up on horseback"]
+        cords: [5628, 6618]
+        map_title: "Stonesword Key"
+      - id: "k35"
+        data: ["From Fort Faroth, face west and climb the hulking white rock in the distance; it's in a body on a chair"]
+        cords: [5747, 6449]
+        map_title: "Stonesword Key"
+      - id: "k36"
+        data: ["South of the Deep Siofra Well, past the large bear, on a body sitting on the cliff"]
+        cords: [5353, 6421]
+        map_title: "Stonesword Key"
+      #
+      - "Altus Plateau"
+      - id: "k37"
+        data: ["Early on the road northeast from the Grand Lift of Dectus, in the small encampment of Misbegottens on the right, on a body against a tent"]
+        cords: [2940, 3670]
+        map_title: "Stonesword Key"
+      - id: "k38"
+        data: ["In Sage's Cave, proceed down the linear path, through illusory walls when necessary, until a more open room with a bonfire, many stalactites, and a larger skeleton wielding the Executioner's Greataxe; on the left, being stared at by another skeleton, is an illusory wall hiding a nook with a chest with the key inside"]
+        cords: [2528, 3269]
+        map_title: "Stonesword Key"
+      - id: "k39"
+        data: ["Sold by the Nomadic Merchant for 4000 runes"]
+        cords: [3321, 3074]
+        map_title: "Stonesword Key x3"
+      - id: "k40"
+        data: ["Sold by the Nomadic Merchant for 4000 runes"]
+        map_link: [3321, 3074]
+        map_title: "Stonesword Key"
+      - id: "k41"
+        data: ["Sold by the Nomadic Merchant for 4000 runes"]
+        map_link: [3321, 3074]
+        map_title: "Stonesword Key"
+      - id: "k42"
+        data: ["On the eastern side of the raised plateau in the center of Altus with perpetual lightning storms, on a body slumped on a stone platform"]
+        cords: [3429, 3295]
+        map_title: "Stonesword Key"
+      - id: "k43"
+        data: ["From the Shaded Castle Ramparts grace, go back down the little stairs and turn left, following the rampart around to find a Perfumer near a ramp down to the swamp below. The wall of the rampart is broken near this ramp, providing a way up, so get on the wall and follow it back a bit the way you came (south) until you can hop to the right onto the large stone barrier. Carefully climb up the stones with a few precise jumps, until a ledge wraps slightly around to the right, from where you can see a lower landing ahead that you can jump to. Then turn left and hop over the rock in the way (it's a bit tricky to get over it) and drop down to the other side of it, onto a small ledge with a body holding the key, with three slugs looking up at you from below."]
+        cords: [2972, 2711]
+        map_title: "Stonesword Key"
+      #
+      - "Mt. Gelmir"
+      - id: "k44"
+        data: ["In Gelmir Hero's Grave, past the first chariot, a few Nobles and Pages, and a fire trap, you'll find a second chariot through an archway; instead of turning left to go down the incline and progress through the dungeon, turn right and run up into a dead end to find the key, though beware it's very difficult to get back on track without being killed by the chariot, as it will suddenly go all the way up the incline on its way back, so you may need to make a suicide run for it"]
+        cords: [2530, 2915]
+        map_title: "Stonesword Key"
+      - id: "k45"
+        data: ["On the broken bridge just west of Corpse-Stench Shack"]
+        cords: [2513, 2700]
+        map_title: "Stonesword Key"
+      - id: "k46"
+        data: ["Sold by the Nomadic Merchant for 5000 runes"]
+        cords: [2438, 2633]
+        map_title: "Stonesword Key"
+      - id: "k47"
+        data: ["North of Fort Laiedd, in the corner with gravestones and jellyfish, on a body against a large tree"]
+        cords: [1957, 2722]
+        map_title: "Stonesword Key"
+      #
+      - "Volcano Manor"
+      - id: "k48"
+        data: ["From the Prison Town Church grace, descend into the town square with an Omenkiller by a bonfire. Go through the doorway near the Omenkiller's initial position, proceed through another archway with a dog, and turn right. Go down the stairs to the broken gap. Instead of dropping all the way down (you can survive that fall), if you take a running jump, you can just barely reach the other end of the gap and land on the wooden platform, which has the key."]
+        cords: [2063, 2983]
+        map_title: "Stonesword Key"
+      - id: "k49"
+        data: ["Exit southeast from the room Rya moves to deep in Volcano Manor later in her questline, hop over the thin lava stream, and jump up the ledge through an open window to find the key on a body on a cot"]
+        cords: [2224, 2976]
+        map_title: "Stonesword Key"
+      #
+      - "Capital Outskirts"
+      - id: "k50"
+        data: ["In Sealed Tunnel, when you emerge into an open room navigable by tree branches and containing many Vulgar Militia and an Iron Maiden, use the branches to get to the platform on the right side, which has a short dead-end path with the key on a body"]
+        cords: [3914, 3668]
+        map_title: "Stonesword Key"
+      - id: "k51"
+        data: ["In Auriza Hero's Grave in the room with two chariots running opposite each other, on a body in an alcove in the center of their paths"]
+        cords: [4556, 3311]
+        map_title: "Stonesword Key"
+      #
+      - "Leyndell, Royal Capital"
+      - id: "k52"
+        data: ["From East Capital Rampart, follow the rampart all the way south until just before the door into a building filled with plants, drop off the side of the rampart onto the rooftops, and hop between rooftops all the way back north, until you find the key on a body next to two Imps"]
+        cords: [4431, 3459]
+        map_title: "Stonesword Key"
+      - id: "k53"
+        data: ["From West Capital Rampart, drop down to ground level and face northwest, then climb the petrified dragon foot and leap from its extended claw to the roof of a barn, and from there into the second floor of an adjacent building, with the key on a body draped over a windowsill"]
+        cords: [4225, 3565]
+        map_title: "Stonesword Key"
+      - id: "k54"
+        data: ["From Avenue Balcony, head down the stairs and hook around them to the right, then down the ladder into a room with many enemies throwing lightning pots, and open the little cell on the ground floor to find a chest with the key inside"]
+        cords: [4301, 3495]
+        map_title: "Stonesword Key"
+      - id: "k55"
+        data: ["From the previous, head out the door on the ground floor, and continue forward until you can hook around a little set of stairs up and right, to see two Skeletal Militiamen and a Putrid Corpse praying at a grave bearing a body with the key"]
+        cords: [4334, 3488]
+        map_title: "Stonesword Key"
+      - id: "k56"
+        data: ["From Lower Capital Church, exit the church and wrap around the building to the right; climb the long ladder and the following ladder to emerge at a gazebo; hook right again before the gazebo, then turn left and follow the tight path until you can climb a large staircase on your left; finally, from the top of the staircase, face directly east and run and jump on top of the gazebo to loot the key from the body"]
+        cords: [4338, 3595]
+        map_title: "Stonesword Key"
+      - id: "k57"
+        data: ["Subterranean Shunning-Grounds: From Underground Roadside, head northeast and drop through the gap in the floor grate, turn northwest and go into the tunnel in the right wall, drop into the first hole surrounded by Slugs, and follow the path from there into a room with three Wraith Callers and the key on a body"]
+        cords: [4364, 3366]
+        map_title: "Stonesword Key"
+      #
+      - "Mountaintops of the Giants"
+      - id: "k58"
+        data: ["Sold by the Hermit Merchant for 5000 runes"]
+        cords: [5960, 2238]
+        map_title: "Stonesword Key x3"
+      - id: "k59"
+        data: ["Sold by the Hermit Merchant for 5000 runes"]
+        map_link: [5960, 2238]
+        map_title: "Stonesword Key"
+      - id: "k60"
+        data: ["Sold by the Hermit Merchant for 5000 runes"]
+        map_link: [5960, 2238]
+        map_title: "Stonesword Key"
+      - id: "k61"
+        data: ["In Castle Sol, from the Church of the Eclipse, exit to the north, climb the ladder to the east, go all the way north, cross the wooden bridge, and climb the stairs on the right to find a body slumped over the wall on the left with the key"]
+        cords: [6037, 1724]
+        map_title: "Stonesword Key"
+      - id: "k62"
+        data: ["On a body right behind the Fire Prelate outside Guardians' Garrison"]
+        cords: [6275, 2393]
+        map_title: "Stonesword Key"
+      #
+      - "Consecrated Snowfield"
+      - id: "k63"
+        data: ["From Inner Consecrated Snowfield, travel exactly one notch north of West until you find a hill guarded by two lightning balls; on top is a chair with a corpse with the key"]
+        cords: [5194, 2247]
+        map_title: "Stonesword Key"
+      - id: "k64"
+        data: ["In the northwest of Yelough Anix Ruins, in a tiny crumbling room packed with four frenzied rats"]
+        cords: [5012, 2341]
+        map_title: "Stonesword Key"
+      #
+      - "Miquella's Haligtree"
+      - id: "k65"
+        data: ["Directly south of Haligtree Canopy on a body at the tip of the same branch"]
+        cords: [5610, 1351]
+        map_title: "Stonesword Key"
+      - id: "k66"
+        data: ["From Haligtree Canopy, head east, dropping down when necessary to reach the first Large Oracle Envoy; follow the branch from there east/northeast until you can reach a large central branch with Giant Ants patrolling; follow the large branch south until its first offshoot on the left, which you can follow around in a large ascending circle onto a wide branch above with a scarlot rot flavored Giant Miranda Sprout; face northwest and walk along this branch until its first offshoot at a sharp left angle, at the end of which is an Oracle Envoy and a body with the key"]
+        cords: [5713, 1309]
+        map_title: "Stonesword Key"
+      #
+      - "Crumbling Farum Azula"
+      - id: "k67" #TODO: Verify
+        data: ["In the back of the Dragon Temple to the east, on a body near a ledge"]
+        cords: [8530, 4410]
+        map_title: "Stonesword Key"
+      #
+      - "Siofra River"
+      - id: "k68"
+        data: ["Sold by the Abandoned Merchant for 2000 runes"]
+        cords: [6289, 14256]
+        map_title: "Stonesword Key x3"
+      - id: "k69"
+        data: ["Sold by the Abandoned Merchant for 2000 runes"]
+        map_link: [6289, 14256]
+        map_title: "Stonesword Key"
+      - id: "k70"
+        data: ["Sold by the Abandoned Merchant for 2000 runes"]
+        map_link: [6289, 14256]
+        map_title: "Stonesword Key"
+      - id: "k71"
+        data: ["At the end of the long bridge/wall protruding from the southwest of Siofra River, accessed via a spiritspring in front of it"]
+        cords: [6495, 14564]
+        map_title: "Stonesword Key"
+      - id: "k72"
+        data: ["From the Below the Well grace, travel southwest along the right cliffside until you find a bridge leading to the other side near a Golden Tree; turn left at the other side and hop onto the pillar there, then run down the attached beam to the next pillar, which hides a body with a key"]
+        cords: [6434, 14046]
+        map_title: "Stonesword Key"
+      #
+      - "Nokron, Eternal City"
+      - id: "k73"
+        data: ["On a body just south of the Aqueduct-Facing Cliffs grace, right outside the cave, where you drop down from the ledge above with the jellyfish to reach it"]
+        cords: [6221, 14108]
+        map_title: "Stonesword Key"
+      #
+      - "Ainsel River"
+      - id: "k74"
+        data: ["On a body in water surrounded by many frenzied Miranda Sprouts, near the waterfall just southwest of Uld Palace Ruins"]
+        cords: [3930, 12022]
+        map_title: "Stonesword Key"
+      - id: "k75"
+        data: ["In Nokstella, Eternal City, directly north of the elevator to Nokstella Waterfall Basin, on a cliff under a ledge"]
+        cords: [3356, 11846]
+        map_title: "Stonesword Key"
+      #
+      - "Deeproot Depths"
+      - id: "k76"
+        data: ["Atop the very tall square building directly southeast of Crucible Knight Siluria, reached via the spiritspring next to the building"]
+        cords: [5249, 10856]
+        map_title: "Stonesword Key"
+      #
+      - "Mohgwyn Palace"
+      - id: "k77"
+        data: ["On the south end of the area with many Giant Crows, on a body on the ground in the open"]
+        cords: [6952, 14489]
+        map_title: "Stonesword Key"
+      - id: "k78"
+        data: ["Along the path up from Dynasty Mausoleum Entrance, just past the Giant Skeletal Slime, turn right for a dead end side path with many praying Putrid Corpses and a key on a body against a rock"]
+        cords: [6913, 14428]
+        map_title: "Stonesword Key"
+      - id: "k79"
+        data: ["Sold by the Imprisoned Merchant for 5000 runes"]
+        cords: [6793, 14474]
+        map_title: "Stonesword Key x5"
+      - id: "k80"
+        data: ["Sold by the Imprisoned Merchant for 5000 runes"]
+        map_link: [6793, 14474]
+        map_title: "Stonesword Key"
+      - id: "k81"
+        data: ["Sold by the Imprisoned Merchant for 5000 runes"]
+        map_link: [6793, 14474]
+        map_title: "Stonesword Key"
+      - id: "k82"
+        data: ["Sold by the Imprisoned Merchant for 5000 runes"]
+        map_link: [6793, 14474]
+        map_title: "Stonesword Key"
+      - id: "k83"
+        data: ["Sold by the Imprisoned Merchant for 5000 runes"]
+        map_link: [6793, 14474]
+        map_title: "Stonesword Key"
+  -
+    title: "Imp Statue Seals"
+    items:
+      - "Limgrave"
+      - id: "s1"
+        data: ["2 keys: The entrance to Fringefolk Hero's Grave"]
+        # cords: [3727, 7368]
+        map_title: "Imp Statue Seal (2 keys)"
+      - id: "s2"
+        data: ["1 key: A cellar in eastern Summonwater Village containing the Green Turtle Talisman"]
+        # cords: [4496, 6510]
+        map_title: "Imp Statue Seal (1 key)"
+      #
+      - "Roundtable Hold"
+      - id: "s3"
+        data: ["1 key: A small room down the stairs near Smithing Master Hewg containing Crepus's Black-Key Crossbow and another Imp Statue Seal"]
+        # cords: [631, 8321]
+        map_title: "Imp Statue Seal (1 key)"
+      - id: "s4"
+        data: ["2 keys: A small room accessed via the previous, containing the Assassin's Prayerbook"]
+        # cords: [642, 8325]
+        map_title: "Imp Statue Seal (2 keys)"
+      #
+      - "Weeping Peninsula"
+      - id: "s5"
+        data: ["1 key: A small room in Tombsward Catacombs containing Nomadic Warrior's Cookbook [9]"]
+        map_title: "Imp Statue Seal (1 key)"
+      - id: "s6"
+        data: ["1 key: Unlocks Weeping Evergaol"]
+        map_title: "Imp Statue Seal (1 key)"
+      #
+      - "Stormveil Castle"
+      - id: "s7"
+        data: ["1 key: A cellar down some stairs in the main courtyard near Liftside Chamber, containing the Godskin Prayerbook, the Godslayer's Seal, and a shortcut door"]
+        map_title: "Imp Statue Seal (1 key)"
+      - id: "s8"
+        data: ["1 key: A small room out the northwest of the main hall with the Grafted Scion, containing the Iron Whetblade, a Miséricorde, and a Hawk Crest Wooden Shield"]
+        map_title: "Imp Statue Seal (1 key)"
+      #
+      - "Liurnia of the Lakes"
+      - id: "s9"
+        data: ["1 key: A small room in Cliffbottom Catacombs containing the Nox Mirrorhelm"]
+        map_title: "Imp Statue Seal (1 key)"
+      - id: "s10"
+        data: ["2 keys: The entrance to Academy Crystal Cave"]
+        map_title: "Imp Statue Seal (2 keys)"
+      - id: "s11"
+        data: ["1 key: A small room in Black Knife Catacombs containing Rosus' Axe"]
+        map_title: "Imp Statue Seal (1 key)"
+      - id: "s12"
+        data: ["1 key: A cellar in Lunar Estate Ruins up by the Moonlight Altar accessed late in Ranni's questline. The Imp Statue appears to be by itself, with its seal located to its right underneath an illusory floor blocking a hidden basement. Contains the Cerulean Amber Medallion +2."]
+        map_title: "Imp Statue Seal (1 key)"
+      #
+      - "Caelid"
+      - id: "s13"
+        data: ["2 keys: The entrance to Gaol Cave"]
+        map_title: "Imp Statue Seal (2 keys)"
+      - id: "s14"
+        data: ["1 key: A cellar in Forsaken Ruins containing the Sword of St. Trina"]
+        map_title: "Imp Statue Seal (1 key)"
+      #
+      - "Altus Plateau"
+      - id: "s15"
+        data: ["1 key: Unlocks Golden Lineage Evergaol"]
+        map_title: "Imp Statue Seal (1 key)"
+      - id: "s16"
+        data: ["2 keys: The entrance to Unsightly Catacombs"]
+        map_title: "Imp Statue Seal (2 keys)"
+      - id: "s17"
+        data: ["1 key: A small room in Sainted Hero's Grave containing the Crimson Seed Talisman"]
+        map_title: "Imp Statue Seal (1 key)"
+      - id: "s18"
+        data: ["1 key: A small room much farther into Sainted Hero's Grave containing a Ghost Glovewort [5] and the Dragoncrest Shield Talisman +1"]
+        map_title: "Imp Statue Seal (1 key)"
+      - id: "s19"
+        data: ["2 keys: The entrance to Old Altus Tunnel"]
+        map_title: "Imp Statue Seal (2 keys)"
+      #
+      - "Mt. Gelmir"
+      - id: "s20"
+        data: ["2 keys: The entrance to Seethewater Cave"]
+        map_title: "Imp Statue Seal (2 keys)"
+      - id: "s21"
+        data: ["1 key: A cellar near the top of Wyndham Ruins containing the Pearldrake Talisman +1"]
+        map_title: "Imp Statue Seal (1 key)"
+      - id: "s22"
+        data: ["1 key: A small room in Wyndham Catacombs containing the Lightning Scorpion Charm"]
+        map_title: "Imp Statue Seal (1 key)"
+      #
+      - "Volcano Manor"
+      - id: "s23"
+        data: ["1 key: A building with an Abductor Virgin and a spiral staircase to the Crimson Amber Medallion +1"]
+        map_title: "Imp Statue Seal (1 key)"
+      - id: "s24"
+        data: ["2 keys: A large room with hanging cages that leads to the Dagger Talisman, a Seedbed Curse, a Somber Smithing Stone [7], and eventually a shortcut door"]
+        map_title: "Imp Statue Seal (2 keys)"
+      #
+      - "Capital Outskirts"
+      - id: "s25"
+        data: ["1 key: A small room in Auriza Hero's Grave containing the Golden Epitaph"]
+        map_title: "Imp Statue Seal (1 key)"
+      #
+      - "Mountaintops of the Giants"
+      - id: "s26"
+        data: ["2 keys: The entrance to Spiritcaller Cave"]
+        map_title: "Imp Statue Seal (2 keys)"
+      - id: "s27"
+        data: ["1 key: A small room in Giant-Conquering Hero's Grave containing Flame, Protect Me"]
+        map_title: "Imp Statue Seal (1 key)"
+      #
+      - "Consecrated Snowfield"
+      - id: "s28"
+        data: ["2 keys: The entrance to Cave of the Forlorn"]
+        map_title: "Imp Statue Seal (2 keys)"
+      #
+      - "Elphael, Brace of the Haligtree"
+      - id: "s29"
+        data: ["1 key: A small room containing Triple Rings of Light"]
+        map_title: "Imp Statue Seal (1 key)"
+      - id: "s30"
+        data: ["1 key: A small room containing the Marika's Soreseal"]
+        map_title: "Imp Statue Seal (1 key)"
+      #
+      - "Crumbling Farum Azula"
+      - id: "s31"
+        data: ["2 keys: The Dragon Temple Lift"]
+        map_title: "Imp Statue Seal (2 keys)"
+      #
+      - "Siofra River"
+      - id: "s32"
+        data: ["2 keys: The elevator up to Deep Siofra Well"]
+        map_title: "Imp Statue Seal (2 keys)"
+      #
+      - "Nokron, Eternal City"
+      - id: "s33"
+        data: ["1 key: A small room in Night's Sacred Ground containing the Mimic Tear Ashes"]
+        map_title: "Imp Statue Seal (1 key)"
+      #
+      - "Ainsel River"
+      - id: "s34"
+        data: ["1 key: A small room at the top of Nokstella, Eternal City, containing the Nightmaiden & Swordstress Puppets"]
+        map_title: "Imp Statue Seal (1 key)"

--- a/data/pages.yaml
+++ b/data/pages.yaml
@@ -42,6 +42,7 @@ dropdowns:
     pages:
       - "remembrances.yaml" #Remembrances & Mausoleums
       - "greatrunes.yaml" #Great Runes
+      - "stonesword_keys.yaml" #Stonesword Keys & Seals
       - "dragon_hearts_death_roots.yaml" #Dragon Hearts & Deathroots
       - "tears_dews.yaml" #Larval Tears & Celestial Dews
       - "paintings.yaml" #Paintings
@@ -286,7 +287,7 @@ item_links:
   - link_all: [bosses_7_13, caves_5_3, talismans_7_5] #KINDRED OF ROT (X2)/SEETHEWATER CAVE/KINDRED OF ROT'S EXULTATION TALISMAN
   - link_all: [bosses_7_14, caves_5_1, spirit_ashes_6_1] #RED WOLF OF THE CHAMPION/GELMIR HERO'S GRAVE/BLOODHOUND KNIGHT FLOH ASHES
   - link_all: [bosses_7_15, weapons_6_9] #FULL-GROWN FALLINGSTAR BEAST/FALLINGSTAR BEAST JAW COLOSSAL WEAPON
-  - link_all: [bosses_7_17, weapons_6_1, weapons_27_2] #FIRE PRELATE/PRELATE'S INFERNO CROZIER COLOSSAL WEAPON/THORNED WHIP
+  - link_all: [bosses_7_17, weapons_6_1] #FIRE PRELATE/PRELATE'S INFERNO CROZIER
   - link_all: [bosses_7_18, dragon_hearts_death_roots_0_11] #MAGMA WYRM (FORT LAIEDD)/DRAGON HEART
   - link_all: [bosses_7_19, memory_stones_talisman_pouches_0_8] #DEMI-HUMAN QUEEN MAGGIE/MEMORY STONE
   - link_all: [bosses_7_27, weapons_19_7] #ANASTASIA/BUTCHERING KNIFE GREATAXE

--- a/docs/checklists/achievements.html
+++ b/docs/checklists/achievements.html
@@ -150,6 +150,9 @@
                   <a class="dropdown-item show-buttons" href="/checklists/great_runes.html">Great Runes</a>
                 </li>
                 <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/stonesword_keys_imp_seals.html">Stonesword Keys &amp; Imp Seals</a>
+                </li>
+                <li class="tab-li">
                   <a class="dropdown-item show-buttons" href="/checklists/dragon_hearts_deathroots.html">Dragon Hearts &amp; Deathroots</a>
                 </li>
                 <li class="tab-li">

--- a/docs/checklists/ancient_dragon_smithing_stones.html
+++ b/docs/checklists/ancient_dragon_smithing_stones.html
@@ -150,6 +150,9 @@
                   <a class="dropdown-item show-buttons" href="/checklists/great_runes.html">Great Runes</a>
                 </li>
                 <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/stonesword_keys_imp_seals.html">Stonesword Keys &amp; Imp Seals</a>
+                </li>
+                <li class="tab-li">
                   <a class="dropdown-item show-buttons" href="/checklists/dragon_hearts_deathroots.html">Dragon Hearts &amp; Deathroots</a>
                 </li>
                 <li class="tab-li">

--- a/docs/checklists/armor.html
+++ b/docs/checklists/armor.html
@@ -150,6 +150,9 @@
                   <a class="dropdown-item show-buttons" href="/checklists/great_runes.html">Great Runes</a>
                 </li>
                 <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/stonesword_keys_imp_seals.html">Stonesword Keys &amp; Imp Seals</a>
+                </li>
+                <li class="tab-li">
                   <a class="dropdown-item show-buttons" href="/checklists/dragon_hearts_deathroots.html">Dragon Hearts &amp; Deathroots</a>
                 </li>
                 <li class="tab-li">

--- a/docs/checklists/ashesof_war.html
+++ b/docs/checklists/ashesof_war.html
@@ -150,6 +150,9 @@
                   <a class="dropdown-item show-buttons" href="/checklists/great_runes.html">Great Runes</a>
                 </li>
                 <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/stonesword_keys_imp_seals.html">Stonesword Keys &amp; Imp Seals</a>
+                </li>
+                <li class="tab-li">
                   <a class="dropdown-item show-buttons" href="/checklists/dragon_hearts_deathroots.html">Dragon Hearts &amp; Deathroots</a>
                 </li>
                 <li class="tab-li">

--- a/docs/checklists/bell_bearings.html
+++ b/docs/checklists/bell_bearings.html
@@ -150,6 +150,9 @@
                   <a class="dropdown-item show-buttons" href="/checklists/great_runes.html">Great Runes</a>
                 </li>
                 <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/stonesword_keys_imp_seals.html">Stonesword Keys &amp; Imp Seals</a>
+                </li>
+                <li class="tab-li">
                   <a class="dropdown-item show-buttons" href="/checklists/dragon_hearts_deathroots.html">Dragon Hearts &amp; Deathroots</a>
                 </li>
                 <li class="tab-li">
@@ -195,7 +198,7 @@
           <label class="form-check-label" for="toggleHideCompleted">Hide Completed</label>
         </div>
       </div>
-      <p>Bell bearings should be given to the Twin Maiden Husks at the Roundtable Hold. Each one found unlocks a unique selection of items for the shop, either adding it to the base stock or creating a new special sub-inventory within "Bell bearing shops." Some are found in the world or as boss drops; additionally, every NPC who sells items will drop a bell bearing if they die so that you can still access what they sell. Some bell bearings, including all from the unnamed Merchants of the world, can only be collected by murder, the only benefit to which is the convenience of their inventory being available in the Roundtable Hold instead of going and finding them if you want to buy from them again. All bell bearings reset upon NG+.</p>
+      <p>Bell bearings should be given to the Twin Maiden Husks at the Roundtable Hold. Each one found unlocks a unique selection of items for the shop, either adding it to the base stock or creating a new special sub-inventory within "Bell bearing shops." Some are found in the world or as boss drops; additionally, every NPC who sells items will drop a bell bearing if they die so that you can still access what they sell. Some bell bearings, including all from the unnamed Merchants of the world, can only be collected by murder, the only benefit to which is the convenience of their inventory being available in the Roundtable Hold. Bell bearings from merchants and NPCs reset upon NG+, but the others don't.</p>
       <nav class="text-muted toc d-print-none">
         <strong class="d-block h5">
           <a class="toc-button" data-bs-toggle="collapse" href="#toc_bell_bearings" role="button">

--- a/docs/checklists/bosses.html
+++ b/docs/checklists/bosses.html
@@ -150,6 +150,9 @@
                   <a class="dropdown-item show-buttons" href="/checklists/great_runes.html">Great Runes</a>
                 </li>
                 <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/stonesword_keys_imp_seals.html">Stonesword Keys &amp; Imp Seals</a>
+                </li>
+                <li class="tab-li">
                   <a class="dropdown-item show-buttons" href="/checklists/dragon_hearts_deathroots.html">Dragon Hearts &amp; Deathroots</a>
                 </li>
                 <li class="tab-li">
@@ -6113,7 +6116,7 @@
                           <label class="form-check-label item_content ms-0 ps-0" for="bosses_7_17">Fort Laiedd</label>
                         </div>
                         <div class="ms-0 ps-0 d-flex align-items-center col-md-4">
-                          <label class="form-check-label item_content ms-0 ps-0" for="bosses_7_17">1309 runes, Prelate's Inferno Crozier Colossal Weapon, Thorned Whip</label>
+                          <label class="form-check-label item_content ms-0 ps-0" for="bosses_7_17">1309 runes, Prelate's Inferno Crozier</label>
                         </div>
                         <div class="ms-0 ps-0 d-flex align-items-center col-md-4">
                           <label class="form-check-label item_content ms-0 ps-0" for="bosses_7_17">Field boss. Chance to drop Fire Prelate Set.</label>
@@ -6124,7 +6127,7 @@
                       <label class="form-check-label item_content ms-0 ps-0" for="bosses_7_17">
                         <strong class="me-1">Name: </strong>Fire Prelate<br>
                         <strong class="me-1">Location: </strong>Fort Laiedd<br>
-                        <strong class="me-1">Drops: </strong>1309 runes, Prelate's Inferno Crozier Colossal Weapon, Thorned Whip<br>
+                        <strong class="me-1">Drops: </strong>1309 runes, Prelate's Inferno Crozier<br>
                         <strong class="me-1">Notes: </strong>Field boss. Chance to drop Fire Prelate Set.<br>
                       </label>
                     </div>

--- a/docs/checklists/cookbooks.html
+++ b/docs/checklists/cookbooks.html
@@ -150,6 +150,9 @@
                   <a class="dropdown-item show-buttons" href="/checklists/great_runes.html">Great Runes</a>
                 </li>
                 <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/stonesword_keys_imp_seals.html">Stonesword Keys &amp; Imp Seals</a>
+                </li>
+                <li class="tab-li">
                   <a class="dropdown-item show-buttons" href="/checklists/dragon_hearts_deathroots.html">Dragon Hearts &amp; Deathroots</a>
                 </li>
                 <li class="tab-li">

--- a/docs/checklists/dragon_hearts_deathroots.html
+++ b/docs/checklists/dragon_hearts_deathroots.html
@@ -150,6 +150,9 @@
                   <a class="dropdown-item show-buttons" href="/checklists/great_runes.html">Great Runes</a>
                 </li>
                 <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/stonesword_keys_imp_seals.html">Stonesword Keys &amp; Imp Seals</a>
+                </li>
+                <li class="tab-li">
                   <a class="dropdown-item show-buttons active" href="/checklists/dragon_hearts_deathroots.html">Dragon Hearts &amp; Deathroots</a>
                 </li>
                 <li class="tab-li">

--- a/docs/checklists/flaskof_wondrous_physick.html
+++ b/docs/checklists/flaskof_wondrous_physick.html
@@ -150,6 +150,9 @@
                   <a class="dropdown-item show-buttons" href="/checklists/great_runes.html">Great Runes</a>
                 </li>
                 <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/stonesword_keys_imp_seals.html">Stonesword Keys &amp; Imp Seals</a>
+                </li>
+                <li class="tab-li">
                   <a class="dropdown-item show-buttons" href="/checklists/dragon_hearts_deathroots.html">Dragon Hearts &amp; Deathroots</a>
                 </li>
                 <li class="tab-li">

--- a/docs/checklists/gestures.html
+++ b/docs/checklists/gestures.html
@@ -150,6 +150,9 @@
                   <a class="dropdown-item show-buttons" href="/checklists/great_runes.html">Great Runes</a>
                 </li>
                 <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/stonesword_keys_imp_seals.html">Stonesword Keys &amp; Imp Seals</a>
+                </li>
+                <li class="tab-li">
                   <a class="dropdown-item show-buttons" href="/checklists/dragon_hearts_deathroots.html">Dragon Hearts &amp; Deathroots</a>
                 </li>
                 <li class="tab-li">
@@ -619,7 +622,7 @@
                           <label class="form-check-label item_content ms-0 ps-0" for="gestures_1_6">Patches</label>
                         </div>
                         <div class="ms-0 ps-0 d-flex align-items-center col-md-5">
-                          <label class="form-check-label item_content ms-0 ps-0" for="gestures_1_6">Open Patches's special chest after he's set up his shop in the cave, then go talk to him about it.</label>
+                          <label class="form-check-label item_content ms-0 ps-0" for="gestures_1_6">Open Patches's special chest after he's set up his shop in the cave, then go talk to him about it. If you miss it, you can also get this gesture from him in Mt. Gelmir by returning to him after he kicks you off a cliff.</label>
                         </div>
                       </div>
                     </div>
@@ -629,7 +632,7 @@
                         <strong class="me-1">Name: </strong>Calm Down!<br>
                         <strong class="me-1">Location: </strong>Murkwater Cave<br>
                         <strong class="me-1">Questline: </strong>Patches<br>
-                        <strong class="me-1">Description: </strong>Open Patches's special chest after he's set up his shop in the cave, then go talk to him about it.<br>
+                        <strong class="me-1">Description: </strong>Open Patches's special chest after he's set up his shop in the cave, then go talk to him about it. If you miss it, you can also get this gesture from him in Mt. Gelmir by returning to him after he kicks you off a cliff.<br>
                       </label>
                     </div>
                   </div>

--- a/docs/checklists/golden_seeds_sacred_tears.html
+++ b/docs/checklists/golden_seeds_sacred_tears.html
@@ -150,6 +150,9 @@
                   <a class="dropdown-item show-buttons" href="/checklists/great_runes.html">Great Runes</a>
                 </li>
                 <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/stonesword_keys_imp_seals.html">Stonesword Keys &amp; Imp Seals</a>
+                </li>
+                <li class="tab-li">
                   <a class="dropdown-item show-buttons" href="/checklists/dragon_hearts_deathroots.html">Dragon Hearts &amp; Deathroots</a>
                 </li>
                 <li class="tab-li">

--- a/docs/checklists/great_runes.html
+++ b/docs/checklists/great_runes.html
@@ -150,6 +150,9 @@
                   <a class="dropdown-item show-buttons active" href="/checklists/great_runes.html">Great Runes</a>
                 </li>
                 <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/stonesword_keys_imp_seals.html">Stonesword Keys &amp; Imp Seals</a>
+                </li>
+                <li class="tab-li">
                   <a class="dropdown-item show-buttons" href="/checklists/dragon_hearts_deathroots.html">Dragon Hearts &amp; Deathroots</a>
                 </li>
                 <li class="tab-li">

--- a/docs/checklists/illusory_walls_invisible_paths.html
+++ b/docs/checklists/illusory_walls_invisible_paths.html
@@ -150,6 +150,9 @@
                   <a class="dropdown-item show-buttons" href="/checklists/great_runes.html">Great Runes</a>
                 </li>
                 <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/stonesword_keys_imp_seals.html">Stonesword Keys &amp; Imp Seals</a>
+                </li>
+                <li class="tab-li">
                   <a class="dropdown-item show-buttons" href="/checklists/dragon_hearts_deathroots.html">Dragon Hearts &amp; Deathroots</a>
                 </li>
                 <li class="tab-li">

--- a/docs/checklists/incantations.html
+++ b/docs/checklists/incantations.html
@@ -150,6 +150,9 @@
                   <a class="dropdown-item show-buttons" href="/checklists/great_runes.html">Great Runes</a>
                 </li>
                 <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/stonesword_keys_imp_seals.html">Stonesword Keys &amp; Imp Seals</a>
+                </li>
+                <li class="tab-li">
                   <a class="dropdown-item show-buttons" href="/checklists/dragon_hearts_deathroots.html">Dragon Hearts &amp; Deathroots</a>
                 </li>
                 <li class="tab-li">

--- a/docs/checklists/landmarks_locations.html
+++ b/docs/checklists/landmarks_locations.html
@@ -150,6 +150,9 @@
                   <a class="dropdown-item show-buttons" href="/checklists/great_runes.html">Great Runes</a>
                 </li>
                 <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/stonesword_keys_imp_seals.html">Stonesword Keys &amp; Imp Seals</a>
+                </li>
+                <li class="tab-li">
                   <a class="dropdown-item show-buttons" href="/checklists/dragon_hearts_deathroots.html">Dragon Hearts &amp; Deathroots</a>
                 </li>
                 <li class="tab-li">

--- a/docs/checklists/larval_tears_celestial_dews.html
+++ b/docs/checklists/larval_tears_celestial_dews.html
@@ -150,6 +150,9 @@
                   <a class="dropdown-item show-buttons" href="/checklists/great_runes.html">Great Runes</a>
                 </li>
                 <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/stonesword_keys_imp_seals.html">Stonesword Keys &amp; Imp Seals</a>
+                </li>
+                <li class="tab-li">
                   <a class="dropdown-item show-buttons" href="/checklists/dragon_hearts_deathroots.html">Dragon Hearts &amp; Deathroots</a>
                 </li>
                 <li class="tab-li">

--- a/docs/checklists/legendaries.html
+++ b/docs/checklists/legendaries.html
@@ -150,6 +150,9 @@
                   <a class="dropdown-item show-buttons" href="/checklists/great_runes.html">Great Runes</a>
                 </li>
                 <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/stonesword_keys_imp_seals.html">Stonesword Keys &amp; Imp Seals</a>
+                </li>
+                <li class="tab-li">
                   <a class="dropdown-item show-buttons" href="/checklists/dragon_hearts_deathroots.html">Dragon Hearts &amp; Deathroots</a>
                 </li>
                 <li class="tab-li">

--- a/docs/checklists/memory_stones_talisman_pouches.html
+++ b/docs/checklists/memory_stones_talisman_pouches.html
@@ -150,6 +150,9 @@
                   <a class="dropdown-item show-buttons" href="/checklists/great_runes.html">Great Runes</a>
                 </li>
                 <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/stonesword_keys_imp_seals.html">Stonesword Keys &amp; Imp Seals</a>
+                </li>
+                <li class="tab-li">
                   <a class="dropdown-item show-buttons" href="/checklists/dragon_hearts_deathroots.html">Dragon Hearts &amp; Deathroots</a>
                 </li>
                 <li class="tab-li">

--- a/docs/checklists/npc_questlines.html
+++ b/docs/checklists/npc_questlines.html
@@ -150,6 +150,9 @@
                   <a class="dropdown-item show-buttons" href="/checklists/great_runes.html">Great Runes</a>
                 </li>
                 <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/stonesword_keys_imp_seals.html">Stonesword Keys &amp; Imp Seals</a>
+                </li>
+                <li class="tab-li">
                   <a class="dropdown-item show-buttons" href="/checklists/dragon_hearts_deathroots.html">Dragon Hearts &amp; Deathroots</a>
                 </li>
                 <li class="tab-li">
@@ -2184,7 +2187,7 @@
                   <li class="list-group-item searchable ps-0" data-id="npc_quests_31_20_2" id="item_31_20_2">
                     <div class="form-check checkbox d-flex align-items-center">
                       <input class="form-check-input" data-section-idx="27" id="npc_quests_31_20_2" type="checkbox" value="">
-                      <label class="form-check-label item_content" for="npc_quests_31_20_2">If you use the Gold summon sign, you'll help her fight her invaders. Once you win, return to where the summon signs were to find her lying by the pool of rot. Be very careful dropping down to her, if you land on her, she'll die. Exhaust her dialogue for the Rotten Winged Sword Insignia then reload the area to get back the Unalloyed Gold Needle, which you can use on a flower in Malenia's boss arena for Somber Ancient Dragon Smithing Stone and Miquella's Needle, which is needed to cure yourself of the Frenzied Flame. Gowry will remain alive, kill him for his stuff</label>
+                      <label class="form-check-label item_content" for="npc_quests_31_20_2">If you use the Gold summon sign, you'll help her fight her invaders. If you or she dies, you can try again. Once you win, return to where the summon signs were to find her lying by the pool of rot. Exhaust her dialogue for the Rotten Winged Sword Insignia then reload the area to get back the Unalloyed Gold Needle, which you can use on a flower in Malenia's boss arena for Somber Ancient Dragon Smithing Stone and Miquella's Needle, which is needed to cure yourself of the Frenzied Flame. Gowry will remain alive, but can finally be killed for his stuff</label>
                     </div>
                   </li>
                 </ul>
@@ -2238,7 +2241,7 @@
                 <li class="list-group-item searchable ps-0" data-id="npc_quests_5_1" id="item_5_1">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="28" id="npc_quests_5_1" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="npc_quests_5_1">Located at the Church of Vows in East Liurnia Lake. Teaches sorceries and incantations, and accepts scrolls and prayerbooks. Never moves or dies, unless you're the worst kind of person, so is a good candidate to give them all to.</label>
+                    <label class="form-check-label item_content" for="npc_quests_5_1">Located at the Church of Vows in East Liurnia of the Lakes. Teaches sorceries and incantations, and accepts scrolls and prayerbooks. Never moves or dies, unless you're the worst kind of person, so is a good candidate to give them all to.</label>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="npc_quests_5_2" id="item_5_2">
@@ -2398,19 +2401,19 @@
                 <li class="list-group-item searchable ps-0" data-id="npc_quests_29_8" id="item_29_8">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="30" id="npc_quests_29_8" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="npc_quests_29_8">Make your way back to him and he'll give you another gesture (Note: he won't give the gesture if you've been to Liurnia Lake)</label>
+                    <label class="form-check-label item_content" for="npc_quests_29_8">Make your way back to him and he'll give you another gesture (Note: he won't give the gesture if you've been to Liurnia of the Lakes)</label>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="npc_quests_29_3" id="item_29_3">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="30" id="npc_quests_29_3" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="npc_quests_29_3">He'll next be found at the Scenic Isle Grace in Liurnia Lake and will inform you about an Iron Virgin deep at the bottom of Raya Lucaria that will teleport you to the Erdtree if you let it eat you</label>
+                    <label class="form-check-label item_content" for="npc_quests_29_3">He'll next be found at the Scenic Isle Grace in Liurnia of the Lakes and will inform you about an Iron Virgin deep at the bottom of Raya Lucaria that will teleport you to the Erdtree if you let it eat you</label>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="npc_quests_29_4" id="item_29_4">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="30" id="npc_quests_29_4" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="npc_quests_29_4">Missable: His next new location is near the First Mt. Gelmir Campfire Site of Grace. Follow the cliff edge westward until you reach the corner, and read the message he's left. You can find him nearby, squatting in a bush. He'll say you should totally check out what those Rainbow Stones are leading to. Wander over, with your back turned and your defenses lowered, to the tall ledge</label>
+                    <label class="form-check-label item_content" for="npc_quests_29_4">Missable: His next new location is near the First Mt. Gelmir Campfire Site of Grace. Follow the cliff edge westward until you reach the corner, and read the message he's left. You can find him nearby, squatting in a bush. He'll say you should totally check out what those Rainbow Stones are leading to. Wander over, with your back turned and your defenses lowered, to the tall ledge. (If you missed the Calm Down gesture before, you can get it again from him now by making your way back to him before he moves on)</label>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="npc_quests_29_5" id="item_29_5">

--- a/docs/checklists/paintings.html
+++ b/docs/checklists/paintings.html
@@ -150,6 +150,9 @@
                   <a class="dropdown-item show-buttons" href="/checklists/great_runes.html">Great Runes</a>
                 </li>
                 <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/stonesword_keys_imp_seals.html">Stonesword Keys &amp; Imp Seals</a>
+                </li>
+                <li class="tab-li">
                   <a class="dropdown-item show-buttons" href="/checklists/dragon_hearts_deathroots.html">Dragon Hearts &amp; Deathroots</a>
                 </li>
                 <li class="tab-li">

--- a/docs/checklists/pots_bottles.html
+++ b/docs/checklists/pots_bottles.html
@@ -150,6 +150,9 @@
                   <a class="dropdown-item show-buttons" href="/checklists/great_runes.html">Great Runes</a>
                 </li>
                 <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/stonesword_keys_imp_seals.html">Stonesword Keys &amp; Imp Seals</a>
+                </li>
+                <li class="tab-li">
                   <a class="dropdown-item show-buttons" href="/checklists/dragon_hearts_deathroots.html">Dragon Hearts &amp; Deathroots</a>
                 </li>
                 <li class="tab-li">
@@ -384,7 +387,7 @@
                   </div>
                 </li>
               </ul>
-              <h5>Altus Plateau</h5>
+              <h5>Capital Outskirts</h5>
               <ul class="list-group-flush mb-0">
                 <li class="list-group-item searchable ps-0" data-id="pots_bottles_1_16" id="item_1_16">
                   <div class="form-check checkbox d-flex align-items-center">
@@ -423,7 +426,7 @@
                   </div>
                 </li>
               </ul>
-              <h5>Leyndell</h5>
+              <h5>Leyndell, Royal Capital</h5>
               <ul class="list-group-flush mb-0">
                 <li class="list-group-item searchable ps-0" data-id="pots_bottles_1_20" id="item_1_20">
                   <div class="form-check checkbox d-flex align-items-center">
@@ -488,7 +491,7 @@
                   </div>
                 </li>
               </ul>
-              <h5>Raya Lucaria</h5>
+              <h5>Academy of Raya Lucaria</h5>
               <ul class="list-group-flush mb-0">
                 <li class="list-group-item searchable ps-0" data-id="pots_bottles_2_4" id="item_2_4">
                   <div class="form-check checkbox d-flex align-items-center">
@@ -512,7 +515,7 @@
                   </div>
                 </li>
               </ul>
-              <h5>Altus Plateau</h5>
+              <h5>Capital Outskirts</h5>
               <ul class="list-group-flush mb-0">
                 <li class="list-group-item searchable ps-0" data-id="pots_bottles_2_7" id="item_2_7">
                   <div class="form-check checkbox d-flex align-items-center">
@@ -533,7 +536,7 @@
                   </div>
                 </li>
               </ul>
-              <h5>Leyndell</h5>
+              <h5>Leyndell, Royal Capital</h5>
               <ul class="list-group-flush mb-0">
                 <li class="list-group-item searchable ps-0" data-id="pots_bottles_2_9" id="item_2_9">
                   <div class="form-check checkbox d-flex align-items-center">
@@ -630,15 +633,6 @@
                     </a>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="pots_bottles_3_8" id="item_3_8">
-                  <div class="form-check checkbox d-flex align-items-center">
-                    <input class="form-check-input" data-section-idx="2" id="pots_bottles_3_8" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="pots_bottles_3_8">Hermit Merchant's Shack, on the cliff North-East from the Outer Wall Battleground Grace on the North side of the outer wall: sold by Hermit Merchant for 2000 runes</label>
-                    <a class="ms-2" href="/map.html?target=pots_bottles_3_8&amp;id=pots_bottles_3_8&amp;link=/checklists/pots_bottles.html%23item_3_8&amp;title=Perfume Bottle">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
-                  </div>
-                </li>
               </ul>
               <h5>Mt. Gelmir</h5>
               <ul class="list-group-flush mb-0">
@@ -652,7 +646,19 @@
                   </div>
                 </li>
               </ul>
-              <h5>Leyndell</h5>
+              <h5>Capital Outskirts</h5>
+              <ul class="list-group-flush mb-0">
+                <li class="list-group-item searchable ps-0" data-id="pots_bottles_3_8" id="item_3_8">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="2" id="pots_bottles_3_8" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="pots_bottles_3_8">Hermit Merchant's Shack, on the cliff North-East from the Outer Wall Battleground Grace on the North side of the outer wall: sold by Hermit Merchant for 2000 runes</label>
+                    <a class="ms-2" href="/map.html?target=pots_bottles_3_8&amp;id=pots_bottles_3_8&amp;link=/checklists/pots_bottles.html%23item_3_8&amp;title=Perfume Bottle">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+              </ul>
+              <h5>Leyndell, Royal Capital</h5>
               <ul class="list-group-flush mb-0">
                 <li class="list-group-item searchable ps-0" data-id="pots_bottles_3_9" id="item_3_9">
                   <div class="form-check checkbox d-flex align-items-center">

--- a/docs/checklists/remembrances_mausoleums.html
+++ b/docs/checklists/remembrances_mausoleums.html
@@ -150,6 +150,9 @@
                   <a class="dropdown-item show-buttons" href="/checklists/great_runes.html">Great Runes</a>
                 </li>
                 <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/stonesword_keys_imp_seals.html">Stonesword Keys &amp; Imp Seals</a>
+                </li>
+                <li class="tab-li">
                   <a class="dropdown-item show-buttons" href="/checklists/dragon_hearts_deathroots.html">Dragon Hearts &amp; Deathroots</a>
                 </li>
                 <li class="tab-li">

--- a/docs/checklists/scrollsand_prayerbooks.html
+++ b/docs/checklists/scrollsand_prayerbooks.html
@@ -150,6 +150,9 @@
                   <a class="dropdown-item show-buttons" href="/checklists/great_runes.html">Great Runes</a>
                 </li>
                 <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/stonesword_keys_imp_seals.html">Stonesword Keys &amp; Imp Seals</a>
+                </li>
+                <li class="tab-li">
                   <a class="dropdown-item show-buttons" href="/checklists/dragon_hearts_deathroots.html">Dragon Hearts &amp; Deathroots</a>
                 </li>
                 <li class="tab-li">

--- a/docs/checklists/sitesof_grace.html
+++ b/docs/checklists/sitesof_grace.html
@@ -150,6 +150,9 @@
                   <a class="dropdown-item show-buttons" href="/checklists/great_runes.html">Great Runes</a>
                 </li>
                 <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/stonesword_keys_imp_seals.html">Stonesword Keys &amp; Imp Seals</a>
+                </li>
+                <li class="tab-li">
                   <a class="dropdown-item show-buttons" href="/checklists/dragon_hearts_deathroots.html">Dragon Hearts &amp; Deathroots</a>
                 </li>
                 <li class="tab-li">

--- a/docs/checklists/sorceries.html
+++ b/docs/checklists/sorceries.html
@@ -150,6 +150,9 @@
                   <a class="dropdown-item show-buttons" href="/checklists/great_runes.html">Great Runes</a>
                 </li>
                 <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/stonesword_keys_imp_seals.html">Stonesword Keys &amp; Imp Seals</a>
+                </li>
+                <li class="tab-li">
                   <a class="dropdown-item show-buttons" href="/checklists/dragon_hearts_deathroots.html">Dragon Hearts &amp; Deathroots</a>
                 </li>
                 <li class="tab-li">

--- a/docs/checklists/spirit_ashes.html
+++ b/docs/checklists/spirit_ashes.html
@@ -150,6 +150,9 @@
                   <a class="dropdown-item show-buttons" href="/checklists/great_runes.html">Great Runes</a>
                 </li>
                 <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/stonesword_keys_imp_seals.html">Stonesword Keys &amp; Imp Seals</a>
+                </li>
+                <li class="tab-li">
                   <a class="dropdown-item show-buttons" href="/checklists/dragon_hearts_deathroots.html">Dragon Hearts &amp; Deathroots</a>
                 </li>
                 <li class="tab-li">

--- a/docs/checklists/stonesword_keys_imp_seals.html
+++ b/docs/checklists/stonesword_keys_imp_seals.html
@@ -1,0 +1,1368 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Stonesword Keys &amp; Imp Seals | Roundtable Guides</title>
+    <meta charset="UTF-8">
+    <meta content="width=device-width, initial-scale=1.0" name="viewport">
+    <link href="/img/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180">
+    <link href="/img/favicon-32x32.png" rel="icon" sizes="32x32" type="image/png">
+    <link href="/img/favicon-16x16.png" rel="icon" sizes="16x16" type="image/png">
+    <link href="/img/site.webmanifest" rel="manifest">
+    <meta content="#ffffff" name="theme-color">
+    <meta content="yes" name="apple-mobile-web-app-capable">
+    <meta content="yes" name="mobile-web-app-capable">
+    <meta content="Cheat sheet for Elden Ring. Checklist of things to do, items to get etc." name="description">
+    <meta content="Ben Lambeth" name="author">
+    <meta content="yes" name="mobile-web-app-capable">
+    <link href="/css/bootstrap.min.css" id="bootstrap" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css" rel="stylesheet">
+    <link href="/css/main.css" rel="stylesheet">
+  </head>
+  <body>
+    <nav class="navbar navbar-expand-xl bg-dark navbar-dark d-print-none sticky-top" id="top_nav">
+      <div class="container-fluid">
+        <button aria-controls="nav-collapse" aria-expanded="false" aria-label="Toggle navigation" class="navbar-toggler" data-bs-target="#nav-collapse" data-bs-toggle="collapse" type="button">
+          <span class="navbar-toggler-icon"></span>
+        </button>
+        <a class="navbar-brand me-auto ms-2" href="/index.html">Roundtable Guides</a>
+        <form class="d-none d-sm-flex order-2 order-xl-3">
+          <input aria-label="search" class="form-control me-2" name="search" placeholder="Search" type="search">
+          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit">
+            <i class="bi bi-search"></i>
+          </button>
+        </form>
+        <div class="d-sm-none order-2">
+          <a class="nav-link me-0" href="/search.html">
+            <i class="bi bi-search sb-icon-search"></i>
+          </a>
+        </div>
+        <div class="collapse navbar-collapse order-3 order-xl-2 ms-xl-2" id="nav-collapse">
+          <ul class="nav navbar-nav navbar-nav-scroll mr-auto">
+            <li class="dropdown nav-item">
+              <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle" data-bs-toggle="dropdown" href="#">Guides
+                <span class="caret"></span>
+              </a>
+              <ul class="dropdown-menu">
+                <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/walkthrough.html">Walkthrough</a>
+                </li>
+                <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/tldr_all_npc_quest_stepsin_order.html"> TL;DR All NPC Quest Steps in Order</a>
+                </li>
+                <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/npc_questlines.html">NPC Questlines</a>
+                </li>
+                <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/achievements.html">Achievements</a>
+                </li>
+                <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/legendaries.html">Legendaries</a>
+                </li>
+              </ul>
+            </li>
+            <li class="dropdown nav-item">
+              <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle" data-bs-toggle="dropdown" href="#">Locations
+                <span class="caret"></span>
+              </a>
+              <ul class="dropdown-menu">
+                <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/bosses.html">Bosses</a>
+                </li>
+                <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/landmarks_locations.html">Landmarks &amp; Locations</a>
+                </li>
+                <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/sitesof_grace.html">Sites of Grace</a>
+                </li>
+                <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/illusory_walls_invisible_paths.html">Illusory Walls &amp; Invisible Paths</a>
+                </li>
+              </ul>
+            </li>
+            <li class="dropdown nav-item">
+              <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle" data-bs-toggle="dropdown" href="#">Equipment
+                <span class="caret"></span>
+              </a>
+              <ul class="dropdown-menu">
+                <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/weapons.html">Weapons</a>
+                </li>
+                <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/armor.html">Armor</a>
+                </li>
+                <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/talismans.html">Talismans</a>
+                </li>
+                <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/sorceries.html">Sorceries</a>
+                </li>
+                <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/incantations.html">Incantations</a>
+                </li>
+                <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/ashesof_war.html">Ashes of War</a>
+                </li>
+                <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/spirit_ashes.html">Spirit Ashes</a>
+                </li>
+              </ul>
+            </li>
+            <li class="dropdown nav-item">
+              <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle" data-bs-toggle="dropdown" href="#">Upgrades &amp; Unlocks
+                <span class="caret"></span>
+              </a>
+              <ul class="dropdown-menu">
+                <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/golden_seeds_sacred_tears.html">Golden Seeds &amp; Sacred Tears</a>
+                </li>
+                <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/flaskof_wondrous_physick.html">Flask of Wondrous Physick</a>
+                </li>
+                <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/memory_stones_talisman_pouches.html">Memory Stones &amp; Talisman Pouches</a>
+                </li>
+                <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/scrollsand_prayerbooks.html">Scrolls and Prayerbooks</a>
+                </li>
+                <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/whetstones.html">Whetstones</a>
+                </li>
+                <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/bell_bearings.html">Bell Bearings</a>
+                </li>
+                <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/cookbooks.html">Cookbooks</a>
+                </li>
+                <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/ancient_dragon_smithing_stones.html">Ancient Dragon Smithing Stones</a>
+                </li>
+              </ul>
+            </li>
+            <li class="dropdown nav-item">
+              <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle active" data-bs-toggle="dropdown" href="#">Collectables
+                <span class="caret"></span>
+              </a>
+              <ul class="dropdown-menu">
+                <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/remembrances_mausoleums.html">Remembrances &amp; Mausoleums</a>
+                </li>
+                <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/great_runes.html">Great Runes</a>
+                </li>
+                <li class="tab-li">
+                  <a class="dropdown-item show-buttons active" href="/checklists/stonesword_keys_imp_seals.html">Stonesword Keys &amp; Imp Seals</a>
+                </li>
+                <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/dragon_hearts_deathroots.html">Dragon Hearts &amp; Deathroots</a>
+                </li>
+                <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/larval_tears_celestial_dews.html">Larval Tears &amp; Celestial Dews</a>
+                </li>
+                <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/paintings.html">Paintings</a>
+                </li>
+                <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/pots_bottles.html">Pots &amp; Bottles</a>
+                </li>
+                <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/tools_multiplayer.html">Tools &amp; Multiplayer</a>
+                </li>
+                <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/gestures.html">Gestures</a>
+                </li>
+              </ul>
+            </li>
+            <li class="nav-item tab-li">
+              <a class="nav-link hide-buttons" href="/map.html">
+                <i class="bi bi-map"></i> Map
+              </a>
+            </li>
+            <li class="nav-item tab-li">
+              <a class="nav-link hide-buttons" href="/options.html">
+                <i class="bi bi-gear-fill"></i> Options
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </nav>
+    <div class="container uncolor-links">
+      <div class="row text-center">
+        <h1 class="mt-4">Stonesword Keys &amp; Imp Seals
+          <span class="d-print-none" id="stonesword_overall_total"></span>
+        </h1>
+      </div>
+      <div class="mb-3 d-print-none" id="btnHideCompleted">
+        <div class="form-check form-switch">
+          <input class="form-check-input" id="toggleHideCompleted" type="checkbox">
+          <label class="form-check-label" for="toggleHideCompleted">Hide Completed</label>
+        </div>
+      </div>
+      <p>Stonesword Keys are consumable key items that open Imp Statue Seals, which typically guard loot, dungeons, or optional paths. A maximum of 80 Stonesword Keys can be found in the game, plus 2 if chosen as a Keepsake. However, only 46 are required to open every Imp Statue Seal. Imp Statues each require either 1 or 2 keys, and the only way to tell the difference is by visual examination: most Imp Statues already have one key in them when you find them, meaning you only need one more.</p>
+      <nav class="text-muted toc d-print-none">
+        <strong class="d-block h5">
+          <a class="toc-button" data-bs-toggle="collapse" href="#toc_stonesword" role="button">
+            <i class="bi bi-plus-lg"></i>Table Of Contents
+          </a>
+        </strong>
+        <ul class="toc_page collapse" id="toc_stonesword">
+          <li>
+            <a class="toc_link" href="#stonesword_section_0">Stonesword Keys</a>
+            <span id="stonesword_nav_totals_0"></span>
+          </li>
+          <li>
+            <a class="toc_link" href="#stonesword_section_1">Imp Statue Seals</a>
+            <span id="stonesword_nav_totals_1"></span>
+          </li>
+        </ul>
+      </nav>
+      <div class="input-group d-print-none">
+        <input class="form-control my-3" id="stonesword_search" placeholder="Start typing to filter results..." type="search">
+      </div>
+      <div id="stonesword_list">
+        <div class="card shadow-sm mb-3" id="stonesword_section_0">
+          <div class="card-body">
+            <h4 class="mt-1">
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#stonesword_0Col" data-bs-toggle="collapse" href="#stonesword_0Col" role="button">
+                <i class="bi bi-chevron-up d-print-none"></i>
+              </button>
+              <img class="me-1" data-src="/img/icons/keys/00228.png" loading="lazy" style="height: 70px; width: 70px">
+              <span class="d-print-inline">Stonesword Keys</span>
+              <span class="mt-0 badge rounded-pill d-print-none" id="stonesword_totals_0"></span>
+            </h4>
+            <div aria-expanded="true" class="collapse show" id="stonesword_0Col">
+              <ul class="list-group-flush mb-0 ps-0 ps-md-4">
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k1" id="item_k1">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k1" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k1">Can choose two as a keepsake</label>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k2" id="item_k2">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k2" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k2">Can choose two as a keepsake</label>
+                  </div>
+                </li>
+              </ul>
+              <h5>Limgrave</h5>
+              <ul class="list-group-flush mb-0">
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k3" id="item_k3">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k3" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k3">In a tiny intact room in the center of Dragon-Burnt Ruins, on a body guarded by a single rat</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k3&amp;id=stonesword_k3&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k3&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k4" id="item_k4">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k4" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k4">Sold by Patches for 5000 runes in Murkwater Cave (and thereafter)</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k4&amp;id=stonesword_k4&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k4&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k5" id="item_k5">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k5" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k5">On the front of Stormhill Shack, on a body atop the little staircase of wooden platforms</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k5&amp;id=stonesword_k5&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k5&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k6" id="item_k6">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k6" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k6">In Fringefolk Hero's Grave, on the ledge from which you can shoot down the jars to destroy the chariot</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k6&amp;id=stonesword_k6&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k6&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+              </ul>
+              <h5>Roundtable Hold</h5>
+              <ul class="list-group-flush mb-0">
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k7" id="item_k7">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k7" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k7">Sold by Twin Maiden Husks for 4000 runes</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k7&amp;id=stonesword_k7&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k7&amp;title=Stonesword Key x3">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k8" id="item_k8">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k8" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k8">Sold by Twin Maiden Husks for 4000 runes</label>
+                    <a class="ms-2" href="/map.html?x=451&amp;y=8385&amp;id=stonesword_k8&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k8&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k9" id="item_k9">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k9" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k9">Sold by Twin Maiden Husks for 4000 runes</label>
+                    <a class="ms-2" href="/map.html?x=451&amp;y=8385&amp;id=stonesword_k9&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k9&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+              </ul>
+              <h5>Weeping Peninsula</h5>
+              <ul class="list-group-flush mb-0">
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k10" id="item_k10">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k10" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k10">On the Bridge of Sacrifice on a body behind the ballista</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k10&amp;id=stonesword_k10&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k10&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k11" id="item_k11">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k11" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k11">On the northern tip of the high ledge in the northeast, on a body sitting in a chair</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k11&amp;id=stonesword_k11&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k11&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k12" id="item_k12">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k12" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k12">Sold by the Nomadic Merchant in Weeping Peninsula for 2000 runes</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k12&amp;id=stonesword_k12&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k12&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k13" id="item_k13">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k13" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k13">Sold by the Isolated Merchant in Weeping Peninsula for 2000 runes</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k13&amp;id=stonesword_k13&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k13&amp;title=Stonesword Key x3">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k14" id="item_k14">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k14" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k14">Sold by the Isolated Merchant in Weeping Peninsula for 2000 runes</label>
+                    <a class="ms-2" href="/map.html?x=3450&amp;y=8230&amp;id=stonesword_k14&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k14&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k15" id="item_k15">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k15" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k15">Sold by the Isolated Merchant in Weeping Peninsula for 2000 runes</label>
+                    <a class="ms-2" href="/map.html?x=3450&amp;y=8230&amp;id=stonesword_k15&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k15&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k16" id="item_k16">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k16" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k16">From the Behind the Castle Site of Grace in Castle Morne, descend down a couple ledges to the first rooftop, then walk forward and drop off to a wooden platform halfway down with the key on a body</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k16&amp;id=stonesword_k16&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k16&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+              </ul>
+              <h5>Stormveil Castle</h5>
+              <ul class="list-group-flush mb-0">
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k17" id="item_k17">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k17" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k17">From Rampart Tower, follow the path up the central spiral staircase and to the rooftops; from the stack of sandbags, follow the ledge to the south tower, then turn east and hop to the next crumbling tower, and drop down inside it to find it on a body</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k17&amp;id=stonesword_k17&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k17&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k18" id="item_k18">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k18" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k18">On a body on the wooden platform above the Grafted Scion (down the shortcut elevator from Rampart Tower)</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k18&amp;id=stonesword_k18&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k18&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k19" id="item_k19">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k19" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k19">On a body in the pit with the Ulcerated Tree Spirit, just past the first big roots on the left</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k19&amp;id=stonesword_k19&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k19&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+              </ul>
+              <h5>Liurnia of the Lakes</h5>
+              <ul class="list-group-flush mb-0">
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k20" id="item_k20">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k20" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k20">In Academy Crystal Cave, stick to the left past the rats and the Sages to find a small side room in the back, containing the key on a body in a cage</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k20&amp;id=stonesword_k20&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k20&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k21" id="item_k21">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k21" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k21">On the island directly east of the South Raya Lucaria Gate Site of Grace, accessible from Gate Town North; it's in a chest in a small tower sticking out of the water, requiring Torrent's double jump to reach</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k21&amp;id=stonesword_k21&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k21&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k22" id="item_k22">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k22" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k22">Outside Raya Lucaria at the base of its northeastern corner, up an incline leading to an area with many Wraith Callers and a body sitting in a chair with the key</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k22&amp;id=stonesword_k22&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k22&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k23" id="item_k23">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k23" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k23">Sold by the Isolated Merchant inside the South Raya Lucaria Gate for 3000 runes</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k23&amp;id=stonesword_k23&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k23&amp;title=Stonesword Key x3">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k24" id="item_k24">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k24" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k24">Sold by the Isolated Merchant inside the South Raya Lucaria Gate for 3000 runes</label>
+                    <a class="ms-2" href="/map.html?x=2028&amp;y=4957&amp;id=stonesword_k24&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k24&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k25" id="item_k25">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k25" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k25">Sold by the Isolated Merchant inside the South Raya Lucaria Gate for 3000 runes</label>
+                    <a class="ms-2" href="/map.html?x=2028&amp;y=4957&amp;id=stonesword_k25&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k25&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k26" id="item_k26">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k26" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k26">As far north as it's possible to go from the Ainsel River Well before the cliff wall cuts off the path, on a body in a chair in a small patch of flowers</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k26&amp;id=stonesword_k26&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k26&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k27" id="item_k27">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k27" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k27">Atop the western wall of Frenzied Flame Village</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k27&amp;id=stonesword_k27&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k27&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k28" id="item_k28">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k28" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k28">From Three Sisters above Caria Manor, follow the path along the rooftops, dropping down when necessary, all the way to the rampart overlooking the Main Gate, with a Giant Crab on top guarding a body with the key</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k28&amp;id=stonesword_k28&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k28&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+              </ul>
+              <h5>Academy of Raya Lucaria</h5>
+              <ul class="list-group-flush mb-0">
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k29" id="item_k29">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k29" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k29">Past the illusory bookshelf directly before the Debate Parlor (Red Wolf of Radagon), on the other side of the altar behind the chest</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k29&amp;id=stonesword_k29&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k29&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k30" id="item_k30">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k30" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k30">In the courtyard directly after the Debate Parlor, on a body draped on the central fountain</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k30&amp;id=stonesword_k30&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k30&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+              </ul>
+              <h5>Caelid</h5>
+              <ul class="list-group-flush mb-0">
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k31" id="item_k31">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k31" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k31">In Gaol Cave, on a body in a cell</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k31&amp;id=stonesword_k31&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k31&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k32" id="item_k32">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k32" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k32">Sold by the Nomadic Merchant in south Caelid for 4000 runes</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k32&amp;id=stonesword_k32&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k32&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k33" id="item_k33">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k33" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k33">From the Dragonbarrow West grace, head to the Divine Tower of Caelid and jump onto the high tree branch, then to the first ledge with a ladder and a sentry with a torch; don't climb the ladder but face southeast from it and follow the arch to find the key on a body on the next landing, guarded by a knight</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k33&amp;id=stonesword_k33&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k33&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k34" id="item_k34">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k34" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k34">In Sellia, Town of Sorcery, on a body slumped atop an archway connecting two buildings at the southern entrance of town; passing northward through the arch underneath, turn right to see rubble with a rotted tree through it, an easy way up on horseback</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k34&amp;id=stonesword_k34&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k34&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k35" id="item_k35">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k35" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k35">From Fort Faroth, face west and climb the hulking white rock in the distance; it's in a body on a chair</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k35&amp;id=stonesword_k35&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k35&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k36" id="item_k36">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k36" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k36">South of the Deep Siofra Well, past the large bear, on a body sitting on the cliff</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k36&amp;id=stonesword_k36&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k36&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+              </ul>
+              <h5>Altus Plateau</h5>
+              <ul class="list-group-flush mb-0">
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k37" id="item_k37">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k37" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k37">Early on the road northeast from the Grand Lift of Dectus, in the small encampment of Misbegottens on the right, on a body against a tent</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k37&amp;id=stonesword_k37&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k37&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k38" id="item_k38">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k38" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k38">In Sage's Cave, proceed down the linear path, through illusory walls when necessary, until a more open room with a bonfire, many stalactites, and a larger skeleton wielding the Executioner's Greataxe; on the left, being stared at by another skeleton, is an illusory wall hiding a nook with a chest with the key inside</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k38&amp;id=stonesword_k38&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k38&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k39" id="item_k39">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k39" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k39">Sold by the Nomadic Merchant for 4000 runes</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k39&amp;id=stonesword_k39&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k39&amp;title=Stonesword Key x3">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k40" id="item_k40">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k40" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k40">Sold by the Nomadic Merchant for 4000 runes</label>
+                    <a class="ms-2" href="/map.html?x=3321&amp;y=3074&amp;id=stonesword_k40&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k40&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k41" id="item_k41">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k41" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k41">Sold by the Nomadic Merchant for 4000 runes</label>
+                    <a class="ms-2" href="/map.html?x=3321&amp;y=3074&amp;id=stonesword_k41&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k41&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k42" id="item_k42">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k42" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k42">On the eastern side of the raised plateau in the center of Altus with perpetual lightning storms, on a body slumped on a stone platform</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k42&amp;id=stonesword_k42&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k42&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k43" id="item_k43">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k43" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k43">From the Shaded Castle Ramparts grace, go back down the little stairs and turn left, following the rampart around to find a Perfumer near a ramp down to the swamp below. The wall of the rampart is broken near this ramp, providing a way up, so get on the wall and follow it back a bit the way you came (south) until you can hop to the right onto the large stone barrier. Carefully climb up the stones with a few precise jumps, until a ledge wraps slightly around to the right, from where you can see a lower landing ahead that you can jump to. Then turn left and hop over the rock in the way (it's a bit tricky to get over it) and drop down to the other side of it, onto a small ledge with a body holding the key, with three slugs looking up at you from below.</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k43&amp;id=stonesword_k43&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k43&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+              </ul>
+              <h5>Mt. Gelmir</h5>
+              <ul class="list-group-flush mb-0">
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k44" id="item_k44">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k44" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k44">In Gelmir Hero's Grave, past the first chariot, a few Nobles and Pages, and a fire trap, you'll find a second chariot through an archway; instead of turning left to go down the incline and progress through the dungeon, turn right and run up into a dead end to find the key, though beware it's very difficult to get back on track without being killed by the chariot, as it will suddenly go all the way up the incline on its way back, so you may need to make a suicide run for it</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k44&amp;id=stonesword_k44&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k44&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k45" id="item_k45">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k45" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k45">On the broken bridge just west of Corpse-Stench Shack</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k45&amp;id=stonesword_k45&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k45&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k46" id="item_k46">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k46" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k46">Sold by the Nomadic Merchant for 5000 runes</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k46&amp;id=stonesword_k46&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k46&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k47" id="item_k47">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k47" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k47">North of Fort Laiedd, in the corner with gravestones and jellyfish, on a body against a large tree</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k47&amp;id=stonesword_k47&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k47&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+              </ul>
+              <h5>Volcano Manor</h5>
+              <ul class="list-group-flush mb-0">
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k48" id="item_k48">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k48" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k48">From the Prison Town Church grace, descend into the town square with an Omenkiller by a bonfire. Go through the doorway near the Omenkiller's initial position, proceed through another archway with a dog, and turn right. Go down the stairs to the broken gap. Instead of dropping all the way down (you can survive that fall), if you take a running jump, you can just barely reach the other end of the gap and land on the wooden platform, which has the key.</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k48&amp;id=stonesword_k48&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k48&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k49" id="item_k49">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k49" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k49">Exit southeast from the room Rya moves to deep in Volcano Manor later in her questline, hop over the thin lava stream, and jump up the ledge through an open window to find the key on a body on a cot</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k49&amp;id=stonesword_k49&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k49&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+              </ul>
+              <h5>Capital Outskirts</h5>
+              <ul class="list-group-flush mb-0">
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k50" id="item_k50">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k50" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k50">In Sealed Tunnel, when you emerge into an open room navigable by tree branches and containing many Vulgar Militia and an Iron Maiden, use the branches to get to the platform on the right side, which has a short dead-end path with the key on a body</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k50&amp;id=stonesword_k50&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k50&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k51" id="item_k51">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k51" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k51">In Auriza Hero's Grave in the room with two chariots running opposite each other, on a body in an alcove in the center of their paths</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k51&amp;id=stonesword_k51&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k51&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+              </ul>
+              <h5>Leyndell, Royal Capital</h5>
+              <ul class="list-group-flush mb-0">
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k52" id="item_k52">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k52" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k52">From East Capital Rampart, follow the rampart all the way south until just before the door into a building filled with plants, drop off the side of the rampart onto the rooftops, and hop between rooftops all the way back north, until you find the key on a body next to two Imps</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k52&amp;id=stonesword_k52&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k52&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k53" id="item_k53">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k53" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k53">From West Capital Rampart, drop down to ground level and face northwest, then climb the petrified dragon foot and leap from its extended claw to the roof of a barn, and from there into the second floor of an adjacent building, with the key on a body draped over a windowsill</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k53&amp;id=stonesword_k53&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k53&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k54" id="item_k54">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k54" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k54">From Avenue Balcony, head down the stairs and hook around them to the right, then down the ladder into a room with many enemies throwing lightning pots, and open the little cell on the ground floor to find a chest with the key inside</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k54&amp;id=stonesword_k54&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k54&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k55" id="item_k55">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k55" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k55">From the previous, head out the door on the ground floor, and continue forward until you can hook around a little set of stairs up and right, to see two Skeletal Militiamen and a Putrid Corpse praying at a grave bearing a body with the key</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k55&amp;id=stonesword_k55&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k55&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k56" id="item_k56">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k56" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k56">From Lower Capital Church, exit the church and wrap around the building to the right; climb the long ladder and the following ladder to emerge at a gazebo; hook right again before the gazebo, then turn left and follow the tight path until you can climb a large staircase on your left; finally, from the top of the staircase, face directly east and run and jump on top of the gazebo to loot the key from the body</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k56&amp;id=stonesword_k56&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k56&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k57" id="item_k57">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k57" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k57">Subterranean Shunning-Grounds: From Underground Roadside, head northeast and drop through the gap in the floor grate, turn northwest and go into the tunnel in the right wall, drop into the first hole surrounded by Slugs, and follow the path from there into a room with three Wraith Callers and the key on a body</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k57&amp;id=stonesword_k57&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k57&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+              </ul>
+              <h5>Mountaintops of the Giants</h5>
+              <ul class="list-group-flush mb-0">
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k58" id="item_k58">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k58" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k58">Sold by the Hermit Merchant for 5000 runes</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k58&amp;id=stonesword_k58&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k58&amp;title=Stonesword Key x3">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k59" id="item_k59">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k59" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k59">Sold by the Hermit Merchant for 5000 runes</label>
+                    <a class="ms-2" href="/map.html?x=5960&amp;y=2238&amp;id=stonesword_k59&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k59&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k60" id="item_k60">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k60" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k60">Sold by the Hermit Merchant for 5000 runes</label>
+                    <a class="ms-2" href="/map.html?x=5960&amp;y=2238&amp;id=stonesword_k60&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k60&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k61" id="item_k61">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k61" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k61">In Castle Sol, from the Church of the Eclipse, exit to the north, climb the ladder to the east, go all the way north, cross the wooden bridge, and climb the stairs on the right to find a body slumped over the wall on the left with the key</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k61&amp;id=stonesword_k61&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k61&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k62" id="item_k62">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k62" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k62">On a body right behind the Fire Prelate outside Guardians' Garrison</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k62&amp;id=stonesword_k62&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k62&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+              </ul>
+              <h5>Consecrated Snowfield</h5>
+              <ul class="list-group-flush mb-0">
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k63" id="item_k63">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k63" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k63">From Inner Consecrated Snowfield, travel exactly one notch north of West until you find a hill guarded by two lightning balls; on top is a chair with a corpse with the key</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k63&amp;id=stonesword_k63&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k63&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k64" id="item_k64">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k64" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k64">In the northwest of Yelough Anix Ruins, in a tiny crumbling room packed with four frenzied rats</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k64&amp;id=stonesword_k64&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k64&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+              </ul>
+              <h5>Miquella's Haligtree</h5>
+              <ul class="list-group-flush mb-0">
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k65" id="item_k65">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k65" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k65">Directly south of Haligtree Canopy on a body at the tip of the same branch</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k65&amp;id=stonesword_k65&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k65&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k66" id="item_k66">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k66" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k66">From Haligtree Canopy, head east, dropping down when necessary to reach the first Large Oracle Envoy; follow the branch from there east/northeast until you can reach a large central branch with Giant Ants patrolling; follow the large branch south until its first offshoot on the left, which you can follow around in a large ascending circle onto a wide branch above with a scarlot rot flavored Giant Miranda Sprout; face northwest and walk along this branch until its first offshoot at a sharp left angle, at the end of which is an Oracle Envoy and a body with the key</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k66&amp;id=stonesword_k66&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k66&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+              </ul>
+              <h5>Crumbling Farum Azula</h5>
+              <ul class="list-group-flush mb-0">
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k67" id="item_k67">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k67" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k67">In the back of the Dragon Temple to the east, on a body near a ledge</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k67&amp;id=stonesword_k67&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k67&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+              </ul>
+              <h5>Siofra River</h5>
+              <ul class="list-group-flush mb-0">
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k68" id="item_k68">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k68" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k68">Sold by the Abandoned Merchant for 2000 runes</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k68&amp;id=stonesword_k68&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k68&amp;title=Stonesword Key x3">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k69" id="item_k69">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k69" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k69">Sold by the Abandoned Merchant for 2000 runes</label>
+                    <a class="ms-2" href="/map.html?x=6289&amp;y=14256&amp;id=stonesword_k69&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k69&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k70" id="item_k70">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k70" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k70">Sold by the Abandoned Merchant for 2000 runes</label>
+                    <a class="ms-2" href="/map.html?x=6289&amp;y=14256&amp;id=stonesword_k70&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k70&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k71" id="item_k71">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k71" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k71">At the end of the long bridge/wall protruding from the southwest of Siofra River, accessed via a spiritspring in front of it</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k71&amp;id=stonesword_k71&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k71&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k72" id="item_k72">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k72" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k72">From the Below the Well grace, travel southwest along the right cliffside until you find a bridge leading to the other side near a Golden Tree; turn left at the other side and hop onto the pillar there, then run down the attached beam to the next pillar, which hides a body with a key</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k72&amp;id=stonesword_k72&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k72&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+              </ul>
+              <h5>Nokron, Eternal City</h5>
+              <ul class="list-group-flush mb-0">
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k73" id="item_k73">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k73" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k73">On a body just south of the Aqueduct-Facing Cliffs grace, right outside the cave, where you drop down from the ledge above with the jellyfish to reach it</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k73&amp;id=stonesword_k73&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k73&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+              </ul>
+              <h5>Ainsel River</h5>
+              <ul class="list-group-flush mb-0">
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k74" id="item_k74">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k74" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k74">On a body in water surrounded by many frenzied Miranda Sprouts, near the waterfall just southwest of Uld Palace Ruins</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k74&amp;id=stonesword_k74&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k74&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k75" id="item_k75">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k75" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k75">In Nokstella, Eternal City, directly north of the elevator to Nokstella Waterfall Basin, on a cliff under a ledge</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k75&amp;id=stonesword_k75&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k75&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+              </ul>
+              <h5>Deeproot Depths</h5>
+              <ul class="list-group-flush mb-0">
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k76" id="item_k76">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k76" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k76">Atop the very tall square building directly southeast of Crucible Knight Siluria, reached via the spiritspring next to the building</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k76&amp;id=stonesword_k76&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k76&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+              </ul>
+              <h5>Mohgwyn Palace</h5>
+              <ul class="list-group-flush mb-0">
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k77" id="item_k77">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k77" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k77">On the south end of the area with many Giant Crows, on a body on the ground in the open</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k77&amp;id=stonesword_k77&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k77&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k78" id="item_k78">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k78" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k78">Along the path up from Dynasty Mausoleum Entrance, just past the Giant Skeletal Slime, turn right for a dead end side path with many praying Putrid Corpses and a key on a body against a rock</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k78&amp;id=stonesword_k78&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k78&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k79" id="item_k79">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k79" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k79">Sold by the Imprisoned Merchant for 5000 runes</label>
+                    <a class="ms-2" href="/map.html?target=stonesword_k79&amp;id=stonesword_k79&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k79&amp;title=Stonesword Key x5">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k80" id="item_k80">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k80" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k80">Sold by the Imprisoned Merchant for 5000 runes</label>
+                    <a class="ms-2" href="/map.html?x=6793&amp;y=14474&amp;id=stonesword_k80&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k80&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k81" id="item_k81">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k81" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k81">Sold by the Imprisoned Merchant for 5000 runes</label>
+                    <a class="ms-2" href="/map.html?x=6793&amp;y=14474&amp;id=stonesword_k81&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k81&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k82" id="item_k82">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k82" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k82">Sold by the Imprisoned Merchant for 5000 runes</label>
+                    <a class="ms-2" href="/map.html?x=6793&amp;y=14474&amp;id=stonesword_k82&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k82&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_k83" id="item_k83">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="0" id="stonesword_k83" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_k83">Sold by the Imprisoned Merchant for 5000 runes</label>
+                    <a class="ms-2" href="/map.html?x=6793&amp;y=14474&amp;id=stonesword_k83&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k83&amp;title=Stonesword Key">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
+                  </div>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+        <div class="card shadow-sm mb-3" id="stonesword_section_1">
+          <div class="card-body">
+            <h4 class="mt-1">
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#stonesword_1Col" data-bs-toggle="collapse" href="#stonesword_1Col" role="button">
+                <i class="bi bi-chevron-up d-print-none"></i>
+              </button>
+              <span class="d-print-inline">Imp Statue Seals</span>
+              <span class="mt-0 badge rounded-pill d-print-none" id="stonesword_totals_1"></span>
+            </h4>
+            <div aria-expanded="true" class="collapse show" id="stonesword_1Col">
+              <h5>Limgrave</h5>
+              <ul class="list-group-flush mb-0 ps-0 ps-md-4">
+                <li class="list-group-item searchable ps-0" data-id="stonesword_s1" id="item_s1">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="1" id="stonesword_s1" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_s1">2 keys: The entrance to Fringefolk Hero's Grave</label>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_s2" id="item_s2">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="1" id="stonesword_s2" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_s2">1 key: A cellar in eastern Summonwater Village containing the Green Turtle Talisman</label>
+                  </div>
+                </li>
+              </ul>
+              <h5>Roundtable Hold</h5>
+              <ul class="list-group-flush mb-0">
+                <li class="list-group-item searchable ps-0" data-id="stonesword_s3" id="item_s3">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="1" id="stonesword_s3" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_s3">1 key: A small room down the stairs near Smithing Master Hewg containing Crepus's Black-Key Crossbow and another Imp Statue Seal</label>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_s4" id="item_s4">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="1" id="stonesword_s4" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_s4">2 keys: A small room accessed via the previous, containing the Assassin's Prayerbook</label>
+                  </div>
+                </li>
+              </ul>
+              <h5>Weeping Peninsula</h5>
+              <ul class="list-group-flush mb-0">
+                <li class="list-group-item searchable ps-0" data-id="stonesword_s5" id="item_s5">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="1" id="stonesword_s5" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_s5">1 key: A small room in Tombsward Catacombs containing Nomadic Warrior's Cookbook [9]</label>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_s6" id="item_s6">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="1" id="stonesword_s6" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_s6">1 key: Unlocks Weeping Evergaol</label>
+                  </div>
+                </li>
+              </ul>
+              <h5>Stormveil Castle</h5>
+              <ul class="list-group-flush mb-0">
+                <li class="list-group-item searchable ps-0" data-id="stonesword_s7" id="item_s7">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="1" id="stonesword_s7" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_s7">1 key: A cellar down some stairs in the main courtyard near Liftside Chamber, containing the Godskin Prayerbook, the Godslayer's Seal, and a shortcut door</label>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_s8" id="item_s8">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="1" id="stonesword_s8" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_s8">1 key: A small room out the northwest of the main hall with the Grafted Scion, containing the Iron Whetblade, a Miséricorde, and a Hawk Crest Wooden Shield</label>
+                  </div>
+                </li>
+              </ul>
+              <h5>Liurnia of the Lakes</h5>
+              <ul class="list-group-flush mb-0">
+                <li class="list-group-item searchable ps-0" data-id="stonesword_s9" id="item_s9">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="1" id="stonesword_s9" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_s9">1 key: A small room in Cliffbottom Catacombs containing the Nox Mirrorhelm</label>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_s10" id="item_s10">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="1" id="stonesword_s10" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_s10">2 keys: The entrance to Academy Crystal Cave</label>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_s11" id="item_s11">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="1" id="stonesword_s11" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_s11">1 key: A small room in Black Knife Catacombs containing Rosus' Axe</label>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_s12" id="item_s12">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="1" id="stonesword_s12" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_s12">1 key: A cellar in Lunar Estate Ruins up by the Moonlight Altar accessed late in Ranni's questline. The Imp Statue appears to be by itself, with its seal located to its right underneath an illusory floor blocking a hidden basement. Contains the Cerulean Amber Medallion +2.</label>
+                  </div>
+                </li>
+              </ul>
+              <h5>Caelid</h5>
+              <ul class="list-group-flush mb-0">
+                <li class="list-group-item searchable ps-0" data-id="stonesword_s13" id="item_s13">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="1" id="stonesword_s13" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_s13">2 keys: The entrance to Gaol Cave</label>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_s14" id="item_s14">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="1" id="stonesword_s14" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_s14">1 key: A cellar in Forsaken Ruins containing the Sword of St. Trina</label>
+                  </div>
+                </li>
+              </ul>
+              <h5>Altus Plateau</h5>
+              <ul class="list-group-flush mb-0">
+                <li class="list-group-item searchable ps-0" data-id="stonesword_s15" id="item_s15">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="1" id="stonesword_s15" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_s15">1 key: Unlocks Golden Lineage Evergaol</label>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_s16" id="item_s16">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="1" id="stonesword_s16" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_s16">2 keys: The entrance to Unsightly Catacombs</label>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_s17" id="item_s17">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="1" id="stonesword_s17" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_s17">1 key: A small room in Sainted Hero's Grave containing the Crimson Seed Talisman</label>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_s18" id="item_s18">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="1" id="stonesword_s18" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_s18">1 key: A small room much farther into Sainted Hero's Grave containing a Ghost Glovewort [5] and the Dragoncrest Shield Talisman +1</label>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_s19" id="item_s19">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="1" id="stonesword_s19" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_s19">2 keys: The entrance to Old Altus Tunnel</label>
+                  </div>
+                </li>
+              </ul>
+              <h5>Mt. Gelmir</h5>
+              <ul class="list-group-flush mb-0">
+                <li class="list-group-item searchable ps-0" data-id="stonesword_s20" id="item_s20">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="1" id="stonesword_s20" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_s20">2 keys: The entrance to Seethewater Cave</label>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_s21" id="item_s21">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="1" id="stonesword_s21" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_s21">1 key: A cellar near the top of Wyndham Ruins containing the Pearldrake Talisman +1</label>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_s22" id="item_s22">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="1" id="stonesword_s22" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_s22">1 key: A small room in Wyndham Catacombs containing the Lightning Scorpion Charm</label>
+                  </div>
+                </li>
+              </ul>
+              <h5>Volcano Manor</h5>
+              <ul class="list-group-flush mb-0">
+                <li class="list-group-item searchable ps-0" data-id="stonesword_s23" id="item_s23">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="1" id="stonesword_s23" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_s23">1 key: A building with an Abductor Virgin and a spiral staircase to the Crimson Amber Medallion +1</label>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_s24" id="item_s24">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="1" id="stonesword_s24" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_s24">2 keys: A large room with hanging cages that leads to the Dagger Talisman, a Seedbed Curse, a Somber Smithing Stone [7], and eventually a shortcut door</label>
+                  </div>
+                </li>
+              </ul>
+              <h5>Capital Outskirts</h5>
+              <ul class="list-group-flush mb-0">
+                <li class="list-group-item searchable ps-0" data-id="stonesword_s25" id="item_s25">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="1" id="stonesword_s25" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_s25">1 key: A small room in Auriza Hero's Grave containing the Golden Epitaph</label>
+                  </div>
+                </li>
+              </ul>
+              <h5>Mountaintops of the Giants</h5>
+              <ul class="list-group-flush mb-0">
+                <li class="list-group-item searchable ps-0" data-id="stonesword_s26" id="item_s26">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="1" id="stonesword_s26" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_s26">2 keys: The entrance to Spiritcaller Cave</label>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_s27" id="item_s27">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="1" id="stonesword_s27" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_s27">1 key: A small room in Giant-Conquering Hero's Grave containing Flame, Protect Me</label>
+                  </div>
+                </li>
+              </ul>
+              <h5>Consecrated Snowfield</h5>
+              <ul class="list-group-flush mb-0">
+                <li class="list-group-item searchable ps-0" data-id="stonesword_s28" id="item_s28">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="1" id="stonesword_s28" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_s28">2 keys: The entrance to Cave of the Forlorn</label>
+                  </div>
+                </li>
+              </ul>
+              <h5>Elphael, Brace of the Haligtree</h5>
+              <ul class="list-group-flush mb-0">
+                <li class="list-group-item searchable ps-0" data-id="stonesword_s29" id="item_s29">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="1" id="stonesword_s29" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_s29">1 key: A small room containing Triple Rings of Light</label>
+                  </div>
+                </li>
+                <li class="list-group-item searchable ps-0" data-id="stonesword_s30" id="item_s30">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="1" id="stonesword_s30" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_s30">1 key: A small room containing the Marika's Soreseal</label>
+                  </div>
+                </li>
+              </ul>
+              <h5>Crumbling Farum Azula</h5>
+              <ul class="list-group-flush mb-0">
+                <li class="list-group-item searchable ps-0" data-id="stonesword_s31" id="item_s31">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="1" id="stonesword_s31" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_s31">2 keys: The Dragon Temple Lift</label>
+                  </div>
+                </li>
+              </ul>
+              <h5>Siofra River</h5>
+              <ul class="list-group-flush mb-0">
+                <li class="list-group-item searchable ps-0" data-id="stonesword_s32" id="item_s32">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="1" id="stonesword_s32" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_s32">2 keys: The elevator up to Deep Siofra Well</label>
+                  </div>
+                </li>
+              </ul>
+              <h5>Nokron, Eternal City</h5>
+              <ul class="list-group-flush mb-0">
+                <li class="list-group-item searchable ps-0" data-id="stonesword_s33" id="item_s33">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="1" id="stonesword_s33" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_s33">1 key: A small room in Night's Sacred Ground containing the Mimic Tear Ashes</label>
+                  </div>
+                </li>
+              </ul>
+              <h5>Ainsel River</h5>
+              <ul class="list-group-flush mb-0">
+                <li class="list-group-item searchable ps-0" data-id="stonesword_s34" id="item_s34">
+                  <div class="form-check checkbox d-flex align-items-center">
+                    <input class="form-check-input" data-section-idx="1" id="stonesword_s34" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="stonesword_s34">1 key: A small room at the top of Nokstella, Eternal City, containing the Nightmaiden & Swordstress Puppets</label>
+                  </div>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <a class="btn btn-primary btn-sm fadingbutton back-to-top d-print-none">Back to Top&thinsp;
+      <span class="bi bi-arrow-up"></span>
+    </a>
+    <script>window.current_page_id = "stonesword";
+</script>
+    <script src="/js/jquery.min.js"></script>
+    <script src="/js/jstorage.min.js"></script>
+    <script src="/js/progress.js"></script>
+    <script src="/js/item_links.js"></script>
+    <script src="/js/common.js"></script>
+    <script src="/js/bootstrap.bundle.min.js"></script>
+    <script src="/js/jets.min.js"></script>
+    <script src="/js/jquery.highlight.js"></script>
+        <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-B7FMWDCTF5"></script>
+    <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-B7FMWDCTF5');
+    </script>
+    
+    <script type="text/javascript">
+            (function($) {
+                'use strict';
+                $(function() {
+                    var jet = new Jets({
+                        searchTag: "#stonesword_search",
+                        contentTag: "#stonesword_list ul",
+                        didSearch: function(search_phrase) {
+                            search_phrase = search_phrase.trim().toLowerCase().replace(/\s\s+/g, ' ').replace(/\\/g, '\\\\');
+                            $(".card").each(function(index, el) {
+                                if (!search_phrase) {
+                                    $(el).removeClass('d-none');
+                                    return;
+                                }
+                                var hasResults = $(el).find('.searchable').filter('[data-jets *= "' + search_phrase + '"]').length;
+                                if (! hasResults ) {
+                                    $(el).addClass('d-none');
+                                } else {
+                                    $(el).removeClass('d-none');
+                                }
+                            });
+                        }
+                    });
+                    $("#stonesword_search").keyup(function() {
+                        $("#stonesword_list").unhighlight();
+                        $("#stonesword_list").highlight($(this).val());
+                    });
+                });
+            })( jQuery );
+            </script>
+    <script src="/js/checklists.js"></script>
+  </body>
+</html>

--- a/docs/checklists/talismans.html
+++ b/docs/checklists/talismans.html
@@ -150,6 +150,9 @@
                   <a class="dropdown-item show-buttons" href="/checklists/great_runes.html">Great Runes</a>
                 </li>
                 <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/stonesword_keys_imp_seals.html">Stonesword Keys &amp; Imp Seals</a>
+                </li>
+                <li class="tab-li">
                   <a class="dropdown-item show-buttons" href="/checklists/dragon_hearts_deathroots.html">Dragon Hearts &amp; Deathroots</a>
                 </li>
                 <li class="tab-li">

--- a/docs/checklists/tldr_all_npc_quest_stepsin_order.html
+++ b/docs/checklists/tldr_all_npc_quest_stepsin_order.html
@@ -150,6 +150,9 @@
                   <a class="dropdown-item show-buttons" href="/checklists/great_runes.html">Great Runes</a>
                 </li>
                 <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/stonesword_keys_imp_seals.html">Stonesword Keys &amp; Imp Seals</a>
+                </li>
+                <li class="tab-li">
                   <a class="dropdown-item show-buttons" href="/checklists/dragon_hearts_deathroots.html">Dragon Hearts &amp; Deathroots</a>
                 </li>
                 <li class="tab-li">

--- a/docs/checklists/tools_multiplayer.html
+++ b/docs/checklists/tools_multiplayer.html
@@ -150,6 +150,9 @@
                   <a class="dropdown-item show-buttons" href="/checklists/great_runes.html">Great Runes</a>
                 </li>
                 <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/stonesword_keys_imp_seals.html">Stonesword Keys &amp; Imp Seals</a>
+                </li>
+                <li class="tab-li">
                   <a class="dropdown-item show-buttons" href="/checklists/dragon_hearts_deathroots.html">Dragon Hearts &amp; Deathroots</a>
                 </li>
                 <li class="tab-li">

--- a/docs/checklists/walkthrough.html
+++ b/docs/checklists/walkthrough.html
@@ -150,6 +150,9 @@
                   <a class="dropdown-item show-buttons" href="/checklists/great_runes.html">Great Runes</a>
                 </li>
                 <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/stonesword_keys_imp_seals.html">Stonesword Keys &amp; Imp Seals</a>
+                </li>
+                <li class="tab-li">
                   <a class="dropdown-item show-buttons" href="/checklists/dragon_hearts_deathroots.html">Dragon Hearts &amp; Deathroots</a>
                 </li>
                 <li class="tab-li">

--- a/docs/checklists/weapons.html
+++ b/docs/checklists/weapons.html
@@ -150,6 +150,9 @@
                   <a class="dropdown-item show-buttons" href="/checklists/great_runes.html">Great Runes</a>
                 </li>
                 <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/stonesword_keys_imp_seals.html">Stonesword Keys &amp; Imp Seals</a>
+                </li>
+                <li class="tab-li">
                   <a class="dropdown-item show-buttons" href="/checklists/dragon_hearts_deathroots.html">Dragon Hearts &amp; Deathroots</a>
                 </li>
                 <li class="tab-li">

--- a/docs/checklists/whetstones.html
+++ b/docs/checklists/whetstones.html
@@ -150,6 +150,9 @@
                   <a class="dropdown-item show-buttons" href="/checklists/great_runes.html">Great Runes</a>
                 </li>
                 <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/stonesword_keys_imp_seals.html">Stonesword Keys &amp; Imp Seals</a>
+                </li>
+                <li class="tab-li">
                   <a class="dropdown-item show-buttons" href="/checklists/dragon_hearts_deathroots.html">Dragon Hearts &amp; Deathroots</a>
                 </li>
                 <li class="tab-li">

--- a/docs/index.html
+++ b/docs/index.html
@@ -150,6 +150,9 @@
                   <a class="dropdown-item show-buttons" href="/checklists/great_runes.html">Great Runes</a>
                 </li>
                 <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/stonesword_keys_imp_seals.html">Stonesword Keys &amp; Imp Seals</a>
+                </li>
+                <li class="tab-li">
                   <a class="dropdown-item show-buttons" href="/checklists/dragon_hearts_deathroots.html">Dragon Hearts &amp; Deathroots</a>
                 </li>
                 <li class="tab-li">
@@ -399,6 +402,11 @@
                   <li class="tab-li">
                     <a href="/checklists/great_runes.html">Great Runes
                       <span class="d-print-none" id="great_runes_progress_total"></span>
+                    </a>
+                  </li>
+                  <li class="tab-li">
+                    <a href="/checklists/stonesword_keys_imp_seals.html">Stonesword Keys &amp; Imp Seals
+                      <span class="d-print-none" id="stonesword_progress_total"></span>
                     </a>
                   </li>
                   <li class="tab-li">

--- a/docs/js/index.js
+++ b/docs/js/index.js
@@ -3370,6 +3370,123 @@
 "spirit_ashes_9_2",
 "spirit_ashes_9_3",
 "spirit_ashes_9_4",
+"stonesword_k1",
+"stonesword_k10",
+"stonesword_k11",
+"stonesword_k12",
+"stonesword_k13",
+"stonesword_k14",
+"stonesword_k15",
+"stonesword_k16",
+"stonesword_k17",
+"stonesword_k18",
+"stonesword_k19",
+"stonesword_k2",
+"stonesword_k20",
+"stonesword_k21",
+"stonesword_k22",
+"stonesword_k23",
+"stonesword_k24",
+"stonesword_k25",
+"stonesword_k26",
+"stonesword_k27",
+"stonesword_k28",
+"stonesword_k29",
+"stonesword_k3",
+"stonesword_k30",
+"stonesword_k31",
+"stonesword_k32",
+"stonesword_k33",
+"stonesword_k34",
+"stonesword_k35",
+"stonesword_k36",
+"stonesword_k37",
+"stonesword_k38",
+"stonesword_k39",
+"stonesword_k4",
+"stonesword_k40",
+"stonesword_k41",
+"stonesword_k42",
+"stonesword_k43",
+"stonesword_k44",
+"stonesword_k45",
+"stonesword_k46",
+"stonesword_k47",
+"stonesword_k48",
+"stonesword_k49",
+"stonesword_k5",
+"stonesword_k50",
+"stonesword_k51",
+"stonesword_k52",
+"stonesword_k53",
+"stonesword_k54",
+"stonesword_k55",
+"stonesword_k56",
+"stonesword_k57",
+"stonesword_k58",
+"stonesword_k59",
+"stonesword_k6",
+"stonesword_k60",
+"stonesword_k61",
+"stonesword_k62",
+"stonesword_k63",
+"stonesword_k64",
+"stonesword_k65",
+"stonesword_k66",
+"stonesword_k67",
+"stonesword_k68",
+"stonesword_k69",
+"stonesword_k7",
+"stonesword_k70",
+"stonesword_k71",
+"stonesword_k72",
+"stonesword_k73",
+"stonesword_k74",
+"stonesword_k75",
+"stonesword_k76",
+"stonesword_k77",
+"stonesword_k78",
+"stonesword_k79",
+"stonesword_k8",
+"stonesword_k80",
+"stonesword_k81",
+"stonesword_k82",
+"stonesword_k83",
+"stonesword_k9",
+"stonesword_s1",
+"stonesword_s10",
+"stonesword_s11",
+"stonesword_s12",
+"stonesword_s13",
+"stonesword_s14",
+"stonesword_s15",
+"stonesword_s16",
+"stonesword_s17",
+"stonesword_s18",
+"stonesword_s19",
+"stonesword_s2",
+"stonesword_s20",
+"stonesword_s21",
+"stonesword_s22",
+"stonesword_s23",
+"stonesword_s24",
+"stonesword_s25",
+"stonesword_s26",
+"stonesword_s27",
+"stonesword_s28",
+"stonesword_s29",
+"stonesword_s3",
+"stonesword_s30",
+"stonesword_s31",
+"stonesword_s32",
+"stonesword_s33",
+"stonesword_s34",
+"stonesword_s4",
+"stonesword_s5",
+"stonesword_s6",
+"stonesword_s7",
+"stonesword_s8",
+"stonesword_s9",
 "talismans_10_1",
 "talismans_10_2",
 "talismans_10_3",
@@ -3993,6 +4110,8 @@ const remembrances_mausoleums_total = 52;
 var remembrances_mausoleums_checked = 0;
 const great_runes_total = 11;
 var great_runes_checked = 0;
+const stonesword_total = 117;
+var stonesword_checked = 0;
 const dragon_hearts_death_roots_total = 22;
 var dragon_hearts_death_roots_checked = 0;
 const tears_dews_total = 28;
@@ -4084,6 +4203,9 @@ remembrances_mausoleums_checked += 1;
 }
 if (id.startsWith("great_runes")) {
 great_runes_checked += 1;
+}
+if (id.startsWith("stonesword")) {
+stonesword_checked += 1;
 }
 if (id.startsWith("dragon_hearts_death_roots")) {
 dragon_hearts_death_roots_checked += 1;
@@ -4234,6 +4356,11 @@ if (great_runes_checked >= great_runes_total){
 $("#great_runes_progress_total").html("DONE");
 } else {
 $("#great_runes_progress_total").html(great_runes_checked + "/" + great_runes_total);
+}
+if (stonesword_checked >= stonesword_total){
+$("#stonesword_progress_total").html("DONE");
+} else {
+$("#stonesword_progress_total").html(stonesword_checked + "/" + stonesword_total);
 }
 if (dragon_hearts_death_roots_checked >= dragon_hearts_death_roots_total){
 $("#dragon_hearts_death_roots_progress_total").html("DONE");

--- a/docs/js/item_links.js
+++ b/docs/js/item_links.js
@@ -2020,7 +2020,6 @@ const item_links = {
   },
   "bosses_7_17": {
     "targets": [
-      "weapons_27_2",
       "weapons_6_1"
     ]
   },
@@ -5601,12 +5600,6 @@ const item_links = {
       "bosses_5_24"
     ]
   },
-  "weapons_27_2": {
-    "targets": [
-      "bosses_7_17",
-      "weapons_6_1"
-    ]
-  },
   "weapons_27_4": {
     "targets": [
       "armor_450",
@@ -5745,8 +5738,7 @@ const item_links = {
   },
   "weapons_6_1": {
     "targets": [
-      "bosses_7_17",
-      "weapons_27_2"
+      "bosses_7_17"
     ]
   },
   "weapons_6_10": {

--- a/docs/js/progress.js
+++ b/docs/js/progress.js
@@ -604,6 +604,13 @@ window.progress = {
       [0, 4],
     ],
   },
+  "stonesword": {
+    "total": [0, 117],
+    "sections": [
+      [0, 83],
+      [0, 34],
+    ],
+  },
   "dragon_hearts_death_roots": {
     "total": [0, 22],
     "sections": [

--- a/docs/map.html
+++ b/docs/map.html
@@ -154,6 +154,9 @@
                       <a class="dropdown-item show-buttons" href="/checklists/great_runes.html">Great Runes</a>
                     </li>
                     <li class="tab-li">
+                      <a class="dropdown-item show-buttons" href="/checklists/stonesword_keys_imp_seals.html">Stonesword Keys &amp; Imp Seals</a>
+                    </li>
+                    <li class="tab-li">
                       <a class="dropdown-item show-buttons" href="/checklists/dragon_hearts_deathroots.html">Dragon Hearts &amp; Deathroots</a>
                     </li>
                     <li class="tab-li">
@@ -284,6 +287,13 @@
             <label class="btn btn-sm btn-secondary w-100 text-start" for="remembrances_mausoleums">
               <img class="me-1" data-src="/img/icons/tools/remembrances/00163.png" height="25" loading="lazy" width="25">Remembrances &amp; Mausoleums
               <span id="remembrances_mausoleums_progress_total"></span>
+            </label>
+          </div>
+          <div class="form-check ps-0">
+            <input autocomplete="off" class="btn-check category-filter" id="stonesword" type="checkbox">
+            <label class="btn btn-sm btn-secondary w-100 text-start" for="stonesword">
+              <img class="me-1" data-src="/img/icons/keys/00228.png" height="25" loading="lazy" width="25">Stonesword Keys &amp; Imp Seals
+              <span id="stonesword_progress_total"></span>
             </label>
           </div>
           <div class="form-check ps-0">

--- a/docs/map/src/js/features.js
+++ b/docs/map/src/js/features.js
@@ -13961,8 +13961,8 @@ const feature_data = [
       {
         "geometry": {
           "coordinates": [
-            454,
-            8354
+            463,
+            8363
           ],
           "type": "Point"
         },
@@ -16182,6 +16182,1247 @@ const feature_data = [
       {
         "geometry": {
           "coordinates": [
+            3939,
+            7352
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k3",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k3",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k3",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            4015,
+            6975
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k4",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k4",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k4",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            3485,
+            6762
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k5",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k5",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k5",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            3757,
+            7304
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k6",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k6",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k6",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            451,
+            8385
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k7",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k7",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k7",
+          "title": "Stonesword Key x3"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            4350,
+            7756
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k10",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k10",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k10",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            4435,
+            7826
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k11",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k11",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k11",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            4307,
+            8185
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k12",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k12",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k12",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            3450,
+            8230
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k13",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k13",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k13",
+          "title": "Stonesword Key x3"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            3973,
+            8699
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k16",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k16",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k16",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            3104,
+            6709
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k17",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k17",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k17",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            3132,
+            6698
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k18",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k18",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k18",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            3078,
+            6662
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k19",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k19",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k19",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            1733,
+            4883
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k20",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k20",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k20",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            2102,
+            5056
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k21",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k21",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k21",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            1948,
+            4840
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k22",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k22",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k22",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            2028,
+            4957
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k23",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k23",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k23",
+          "title": "Stonesword Key x3"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            2782,
+            4459
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k26",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k26",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k26",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            2573,
+            4200
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k27",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k27",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k27",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            1885,
+            3832
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k28",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k28",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k28",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            1923,
+            5008
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k29",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k29",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k29",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            1949,
+            4942
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k30",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k30",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k30",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            4921,
+            6764
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k31",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k31",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k31",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            5416,
+            7067
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k32",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k32",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k32",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            5569,
+            6091
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k33",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k33",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k33",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            5628,
+            6618
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k34",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k34",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k34",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            5747,
+            6449
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k35",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k35",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k35",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            5353,
+            6421
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k36",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k36",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k36",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            2940,
+            3670
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k37",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k37",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k37",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            2528,
+            3269
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k38",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k38",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k38",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            3321,
+            3074
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k39",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k39",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k39",
+          "title": "Stonesword Key x3"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            3429,
+            3295
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k42",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k42",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k42",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            2972,
+            2711
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k43",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k43",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k43",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            2530,
+            2915
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k44",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k44",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k44",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            2513,
+            2700
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k45",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k45",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k45",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            2438,
+            2633
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k46",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k46",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k46",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            1957,
+            2722
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k47",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k47",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k47",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            2063,
+            2983
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k48",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k48",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k48",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            2224,
+            2976
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k49",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k49",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k49",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            3914,
+            3668
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k50",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k50",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k50",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            4556,
+            3311
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k51",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k51",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k51",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            4431,
+            3459
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k52",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k52",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k52",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            4225,
+            3565
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k53",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k53",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k53",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            4301,
+            3495
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k54",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k54",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k54",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            4334,
+            3488
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k55",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k55",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k55",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            4338,
+            3595
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k56",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k56",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k56",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            4364,
+            3366
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k57",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k57",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k57",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            5960,
+            2238
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k58",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k58",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k58",
+          "title": "Stonesword Key x3"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            6037,
+            1724
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k61",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k61",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k61",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            6275,
+            2393
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k62",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k62",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k62",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            5194,
+            2247
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k63",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k63",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k63",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            5012,
+            2341
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k64",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k64",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k64",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            5610,
+            1351
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k65",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k65",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k65",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            5713,
+            1309
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k66",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k66",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k66",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            8530,
+            4410
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k67",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k67",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k67",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            6289,
+            14256
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k68",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k68",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k68",
+          "title": "Stonesword Key x3"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            6495,
+            14564
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k71",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k71",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k71",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            6434,
+            14046
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k72",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k72",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k72",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            6221,
+            14108
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k73",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k73",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k73",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            3930,
+            12022
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k74",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k74",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k74",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            3356,
+            11846
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k75",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k75",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k75",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            5249,
+            10856
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k76",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k76",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k76",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            6952,
+            14489
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k77",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k77",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k77",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            6913,
+            14428
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k78",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k78",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k78",
+          "title": "Stonesword Key"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            6793,
+            14474
+          ],
+          "type": "Point"
+        },
+        "id": "stonesword_k79",
+        "properties": {
+          "group": "stonesword",
+          "icon": "/map/icons/shadows/keys/00228.png",
+          "icon_size": 35,
+          "id": "stonesword_k79",
+          "link": "/checklists/stonesword_keys_imp_seals.html#item_k79",
+          "title": "Stonesword Key x5"
+        },
+        "type": "Feature"
+      }
+    ],
+    "id": "stonesword",
+    "type": "FeatureCollection"
+  },
+  {
+    "features": [
+      {
+        "geometry": {
+          "coordinates": [
             3891,
             7227
           ],
@@ -17448,25 +18689,6 @@ const feature_data = [
       {
         "geometry": {
           "coordinates": [
-            3974,
-            2945
-          ],
-          "type": "Point"
-        },
-        "id": "pots_bottles_3_8",
-        "properties": {
-          "group": "pots_bottles",
-          "icon": "/map/icons/shadows/keys/00443.png",
-          "icon_size": 35,
-          "id": "pots_bottles_3_8",
-          "link": "/checklists/pots_bottles.html#item_3_8",
-          "title": "Perfume Bottle"
-        },
-        "type": "Feature"
-      },
-      {
-        "geometry": {
-          "coordinates": [
             2205,
             2885
           ],
@@ -17479,6 +18701,25 @@ const feature_data = [
           "icon_size": 35,
           "id": "pots_bottles_3_7",
           "link": "/checklists/pots_bottles.html#item_3_7",
+          "title": "Perfume Bottle"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
+            3974,
+            2945
+          ],
+          "type": "Point"
+        },
+        "id": "pots_bottles_3_8",
+        "properties": {
+          "group": "pots_bottles",
+          "icon": "/map/icons/shadows/keys/00443.png",
+          "icon_size": 35,
+          "id": "pots_bottles_3_8",
+          "link": "/checklists/pots_bottles.html#item_3_8",
           "title": "Perfume Bottle"
         },
         "type": "Feature"
@@ -18397,6 +19638,7 @@ const icon_urls = [
   "/map/icons/shadows/info/paintings/03210.png",
   "/map/icons/shadows/info/paintings/03211.png",
   "/map/icons/shadows/info/paintings/03212.png",
+  "/map/icons/shadows/keys/00228.png",
   "/map/icons/shadows/keys/00310.png",
   "/map/icons/shadows/keys/00311.png",
   "/map/icons/shadows/keys/00315.png",

--- a/docs/options.html
+++ b/docs/options.html
@@ -150,6 +150,9 @@
                   <a class="dropdown-item show-buttons" href="/checklists/great_runes.html">Great Runes</a>
                 </li>
                 <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/stonesword_keys_imp_seals.html">Stonesword Keys &amp; Imp Seals</a>
+                </li>
+                <li class="tab-li">
                   <a class="dropdown-item show-buttons" href="/checklists/dragon_hearts_deathroots.html">Dragon Hearts &amp; Deathroots</a>
                 </li>
                 <li class="tab-li">

--- a/docs/search.html
+++ b/docs/search.html
@@ -150,6 +150,9 @@
                   <a class="dropdown-item show-buttons" href="/checklists/great_runes.html">Great Runes</a>
                 </li>
                 <li class="tab-li">
+                  <a class="dropdown-item show-buttons" href="/checklists/stonesword_keys_imp_seals.html">Stonesword Keys &amp; Imp Seals</a>
+                </li>
+                <li class="tab-li">
                   <a class="dropdown-item show-buttons" href="/checklists/dragon_hearts_deathroots.html">Dragon Hearts &amp; Deathroots</a>
                 </li>
                 <li class="tab-li">
@@ -3567,7 +3570,7 @@
               <div class="d-flex align-items-center">If you choose the Red summon sign, you'll invade and kill Millicent. From her, you'll receive Millicent's Prothesis. Go back to Gowry's Shack, and he'll be dead as well, giving you the Flock's Canvas Talisman and his bell bearing.</div>
             </a>
             <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/npc_questlines.html#item_31_20_2" id="/checklists/npc_questlines.html#item_31_20_2">
-              <div class="d-flex align-items-center">If you use the Gold summon sign, you'll help her fight her invaders. Once you win, return to where the summon signs were to find her lying by the pool of rot. Be very careful dropping down to her, if you land on her, she'll die. Exhaust her dialogue for the Rotten Winged Sword Insignia then reload the area to get back the Unalloyed Gold Needle, which you can use on a flower in Malenia's boss arena for Somber Ancient Dragon Smithing Stone and Miquella's Needle, which is needed to cure yourself of the Frenzied Flame. Gowry will remain alive, kill him for his stuff</div>
+              <div class="d-flex align-items-center">If you use the Gold summon sign, you'll help her fight her invaders. If you or she dies, you can try again. Once you win, return to where the summon signs were to find her lying by the pool of rot. Exhaust her dialogue for the Rotten Winged Sword Insignia then reload the area to get back the Unalloyed Gold Needle, which you can use on a flower in Malenia's boss arena for Somber Ancient Dragon Smithing Stone and Miquella's Needle, which is needed to cure yourself of the Frenzied Flame. Gowry will remain alive, but can finally be killed for his stuff</div>
             </a>
             <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/npc_questlines.html#item_31_21" id="/checklists/npc_questlines.html#item_31_21">
               <div class="d-flex align-items-center">Summons</div>
@@ -3585,7 +3588,7 @@
               <div class="d-flex align-items-center">Can be summoned to fight the Black Blade Kindred just before the Grand Lift of Rold</div>
             </a>
             <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/npc_questlines.html#item_5_1" id="/checklists/npc_questlines.html#item_5_1">
-              <div class="d-flex align-items-center">Located at the Church of Vows in East Liurnia Lake. Teaches sorceries and incantations, and accepts scrolls and prayerbooks. Never moves or dies, unless you're the worst kind of person, so is a good candidate to give them all to.</div>
+              <div class="d-flex align-items-center">Located at the Church of Vows in East Liurnia of the Lakes. Teaches sorceries and incantations, and accepts scrolls and prayerbooks. Never moves or dies, unless you're the worst kind of person, so is a good candidate to give them all to.</div>
             </a>
             <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/npc_questlines.html#item_5_2" id="/checklists/npc_questlines.html#item_5_2">
               <div class="d-flex align-items-center">Gives you the hint needed for Brother Corhyn and Goldmasks questline in Leyndell</div>
@@ -3648,13 +3651,13 @@
               <div class="d-flex align-items-center">Reload and talk to him again for some dialogue and buy some stuff from him. Reload and come back and he will offer you his chest, open it for a fun time.</div>
             </a>
             <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/npc_questlines.html#item_29_8" id="/checklists/npc_questlines.html#item_29_8">
-              <div class="d-flex align-items-center">Make your way back to him and he'll give you another gesture (Note: he won't give the gesture if you've been to Liurnia Lake)</div>
+              <div class="d-flex align-items-center">Make your way back to him and he'll give you another gesture (Note: he won't give the gesture if you've been to Liurnia of the Lakes)</div>
             </a>
             <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/npc_questlines.html#item_29_3" id="/checklists/npc_questlines.html#item_29_3">
-              <div class="d-flex align-items-center">He'll next be found at the Scenic Isle Grace in Liurnia Lake and will inform you about an Iron Virgin deep at the bottom of Raya Lucaria that will teleport you to the Erdtree if you let it eat you</div>
+              <div class="d-flex align-items-center">He'll next be found at the Scenic Isle Grace in Liurnia of the Lakes and will inform you about an Iron Virgin deep at the bottom of Raya Lucaria that will teleport you to the Erdtree if you let it eat you</div>
             </a>
             <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/npc_questlines.html#item_29_4" id="/checklists/npc_questlines.html#item_29_4">
-              <div class="d-flex align-items-center">Missable: His next new location is near the First Mt. Gelmir Campfire Site of Grace. Follow the cliff edge westward until you reach the corner, and read the message he's left. You can find him nearby, squatting in a bush. He'll say you should totally check out what those Rainbow Stones are leading to. Wander over, with your back turned and your defenses lowered, to the tall ledge</div>
+              <div class="d-flex align-items-center">Missable: His next new location is near the First Mt. Gelmir Campfire Site of Grace. Follow the cliff edge westward until you reach the corner, and read the message he's left. You can find him nearby, squatting in a bush. He'll say you should totally check out what those Rainbow Stones are leading to. Wander over, with your back turned and your defenses lowered, to the tall ledge. (If you missed the Calm Down gesture before, you can get it again from him now by making your way back to him before he moves on)</div>
             </a>
             <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/npc_questlines.html#item_29_5" id="/checklists/npc_questlines.html#item_29_5">
               <div class="d-flex align-items-center">Once you join Volcano Manor, you'll find him inside</div>
@@ -7170,14 +7173,14 @@
               <div class="row d-md-flex d-none">
                 <div class="d-flex align-items-center col-md-2">Fire Prelate</div>
                 <div class="d-flex align-items-center col-md-2">Fort Laiedd</div>
-                <div class="d-flex align-items-center col-md-4">1309 runes, Prelate's Inferno Crozier Colossal Weapon, Thorned Whip</div>
+                <div class="d-flex align-items-center col-md-4">1309 runes, Prelate's Inferno Crozier</div>
                 <div class="d-flex align-items-center col-md-4">Field boss. Chance to drop Fire Prelate Set.</div>
               </div>
               <div class="row d-md-none">
                 <div class="col">
                   <strong class="me-1">Name: </strong>Fire Prelate<br>
                   <strong class="me-1">Location: </strong>Fort Laiedd<br>
-                  <strong class="me-1">Drops: </strong>1309 runes, Prelate's Inferno Crozier Colossal Weapon, Thorned Whip<br>
+                  <strong class="me-1">Drops: </strong>1309 runes, Prelate's Inferno Crozier<br>
                   <strong class="me-1">Notes: </strong>Field boss. Chance to drop Fire Prelate Set.<br>
                 </div>
               </div>
@@ -31382,6 +31385,357 @@
                 </div>
               </div>
             </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k1" id="/checklists/stonesword_keys_imp_seals.html#item_k1">
+              <div class="d-flex align-items-center">Can choose two as a keepsake</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k2" id="/checklists/stonesword_keys_imp_seals.html#item_k2">
+              <div class="d-flex align-items-center">Can choose two as a keepsake</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k3" id="/checklists/stonesword_keys_imp_seals.html#item_k3">
+              <div class="d-flex align-items-center">In a tiny intact room in the center of Dragon-Burnt Ruins, on a body guarded by a single rat</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k4" id="/checklists/stonesword_keys_imp_seals.html#item_k4">
+              <div class="d-flex align-items-center">Sold by Patches for 5000 runes in Murkwater Cave (and thereafter)</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k5" id="/checklists/stonesword_keys_imp_seals.html#item_k5">
+              <div class="d-flex align-items-center">On the front of Stormhill Shack, on a body atop the little staircase of wooden platforms</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k6" id="/checklists/stonesword_keys_imp_seals.html#item_k6">
+              <div class="d-flex align-items-center">In Fringefolk Hero's Grave, on the ledge from which you can shoot down the jars to destroy the chariot</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k7" id="/checklists/stonesword_keys_imp_seals.html#item_k7">
+              <div class="d-flex align-items-center">Sold by Twin Maiden Husks for 4000 runes</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k8" id="/checklists/stonesword_keys_imp_seals.html#item_k8">
+              <div class="d-flex align-items-center">Sold by Twin Maiden Husks for 4000 runes</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k9" id="/checklists/stonesword_keys_imp_seals.html#item_k9">
+              <div class="d-flex align-items-center">Sold by Twin Maiden Husks for 4000 runes</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k10" id="/checklists/stonesword_keys_imp_seals.html#item_k10">
+              <div class="d-flex align-items-center">On the Bridge of Sacrifice on a body behind the ballista</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k11" id="/checklists/stonesword_keys_imp_seals.html#item_k11">
+              <div class="d-flex align-items-center">On the northern tip of the high ledge in the northeast, on a body sitting in a chair</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k12" id="/checklists/stonesword_keys_imp_seals.html#item_k12">
+              <div class="d-flex align-items-center">Sold by the Nomadic Merchant in Weeping Peninsula for 2000 runes</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k13" id="/checklists/stonesword_keys_imp_seals.html#item_k13">
+              <div class="d-flex align-items-center">Sold by the Isolated Merchant in Weeping Peninsula for 2000 runes</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k14" id="/checklists/stonesword_keys_imp_seals.html#item_k14">
+              <div class="d-flex align-items-center">Sold by the Isolated Merchant in Weeping Peninsula for 2000 runes</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k15" id="/checklists/stonesword_keys_imp_seals.html#item_k15">
+              <div class="d-flex align-items-center">Sold by the Isolated Merchant in Weeping Peninsula for 2000 runes</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k16" id="/checklists/stonesword_keys_imp_seals.html#item_k16">
+              <div class="d-flex align-items-center">From the Behind the Castle Site of Grace in Castle Morne, descend down a couple ledges to the first rooftop, then walk forward and drop off to a wooden platform halfway down with the key on a body</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k17" id="/checklists/stonesword_keys_imp_seals.html#item_k17">
+              <div class="d-flex align-items-center">From Rampart Tower, follow the path up the central spiral staircase and to the rooftops; from the stack of sandbags, follow the ledge to the south tower, then turn east and hop to the next crumbling tower, and drop down inside it to find it on a body</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k18" id="/checklists/stonesword_keys_imp_seals.html#item_k18">
+              <div class="d-flex align-items-center">On a body on the wooden platform above the Grafted Scion (down the shortcut elevator from Rampart Tower)</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k19" id="/checklists/stonesword_keys_imp_seals.html#item_k19">
+              <div class="d-flex align-items-center">On a body in the pit with the Ulcerated Tree Spirit, just past the first big roots on the left</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k20" id="/checklists/stonesword_keys_imp_seals.html#item_k20">
+              <div class="d-flex align-items-center">In Academy Crystal Cave, stick to the left past the rats and the Sages to find a small side room in the back, containing the key on a body in a cage</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k21" id="/checklists/stonesword_keys_imp_seals.html#item_k21">
+              <div class="d-flex align-items-center">On the island directly east of the South Raya Lucaria Gate Site of Grace, accessible from Gate Town North; it's in a chest in a small tower sticking out of the water, requiring Torrent's double jump to reach</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k22" id="/checklists/stonesword_keys_imp_seals.html#item_k22">
+              <div class="d-flex align-items-center">Outside Raya Lucaria at the base of its northeastern corner, up an incline leading to an area with many Wraith Callers and a body sitting in a chair with the key</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k23" id="/checklists/stonesword_keys_imp_seals.html#item_k23">
+              <div class="d-flex align-items-center">Sold by the Isolated Merchant inside the South Raya Lucaria Gate for 3000 runes</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k24" id="/checklists/stonesword_keys_imp_seals.html#item_k24">
+              <div class="d-flex align-items-center">Sold by the Isolated Merchant inside the South Raya Lucaria Gate for 3000 runes</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k25" id="/checklists/stonesword_keys_imp_seals.html#item_k25">
+              <div class="d-flex align-items-center">Sold by the Isolated Merchant inside the South Raya Lucaria Gate for 3000 runes</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k26" id="/checklists/stonesword_keys_imp_seals.html#item_k26">
+              <div class="d-flex align-items-center">As far north as it's possible to go from the Ainsel River Well before the cliff wall cuts off the path, on a body in a chair in a small patch of flowers</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k27" id="/checklists/stonesword_keys_imp_seals.html#item_k27">
+              <div class="d-flex align-items-center">Atop the western wall of Frenzied Flame Village</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k28" id="/checklists/stonesword_keys_imp_seals.html#item_k28">
+              <div class="d-flex align-items-center">From Three Sisters above Caria Manor, follow the path along the rooftops, dropping down when necessary, all the way to the rampart overlooking the Main Gate, with a Giant Crab on top guarding a body with the key</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k29" id="/checklists/stonesword_keys_imp_seals.html#item_k29">
+              <div class="d-flex align-items-center">Past the illusory bookshelf directly before the Debate Parlor (Red Wolf of Radagon), on the other side of the altar behind the chest</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k30" id="/checklists/stonesword_keys_imp_seals.html#item_k30">
+              <div class="d-flex align-items-center">In the courtyard directly after the Debate Parlor, on a body draped on the central fountain</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k31" id="/checklists/stonesword_keys_imp_seals.html#item_k31">
+              <div class="d-flex align-items-center">In Gaol Cave, on a body in a cell</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k32" id="/checklists/stonesword_keys_imp_seals.html#item_k32">
+              <div class="d-flex align-items-center">Sold by the Nomadic Merchant in south Caelid for 4000 runes</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k33" id="/checklists/stonesword_keys_imp_seals.html#item_k33">
+              <div class="d-flex align-items-center">From the Dragonbarrow West grace, head to the Divine Tower of Caelid and jump onto the high tree branch, then to the first ledge with a ladder and a sentry with a torch; don't climb the ladder but face southeast from it and follow the arch to find the key on a body on the next landing, guarded by a knight</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k34" id="/checklists/stonesword_keys_imp_seals.html#item_k34">
+              <div class="d-flex align-items-center">In Sellia, Town of Sorcery, on a body slumped atop an archway connecting two buildings at the southern entrance of town; passing northward through the arch underneath, turn right to see rubble with a rotted tree through it, an easy way up on horseback</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k35" id="/checklists/stonesword_keys_imp_seals.html#item_k35">
+              <div class="d-flex align-items-center">From Fort Faroth, face west and climb the hulking white rock in the distance; it's in a body on a chair</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k36" id="/checklists/stonesword_keys_imp_seals.html#item_k36">
+              <div class="d-flex align-items-center">South of the Deep Siofra Well, past the large bear, on a body sitting on the cliff</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k37" id="/checklists/stonesword_keys_imp_seals.html#item_k37">
+              <div class="d-flex align-items-center">Early on the road northeast from the Grand Lift of Dectus, in the small encampment of Misbegottens on the right, on a body against a tent</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k38" id="/checklists/stonesword_keys_imp_seals.html#item_k38">
+              <div class="d-flex align-items-center">In Sage's Cave, proceed down the linear path, through illusory walls when necessary, until a more open room with a bonfire, many stalactites, and a larger skeleton wielding the Executioner's Greataxe; on the left, being stared at by another skeleton, is an illusory wall hiding a nook with a chest with the key inside</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k39" id="/checklists/stonesword_keys_imp_seals.html#item_k39">
+              <div class="d-flex align-items-center">Sold by the Nomadic Merchant for 4000 runes</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k40" id="/checklists/stonesword_keys_imp_seals.html#item_k40">
+              <div class="d-flex align-items-center">Sold by the Nomadic Merchant for 4000 runes</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k41" id="/checklists/stonesword_keys_imp_seals.html#item_k41">
+              <div class="d-flex align-items-center">Sold by the Nomadic Merchant for 4000 runes</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k42" id="/checklists/stonesword_keys_imp_seals.html#item_k42">
+              <div class="d-flex align-items-center">On the eastern side of the raised plateau in the center of Altus with perpetual lightning storms, on a body slumped on a stone platform</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k43" id="/checklists/stonesword_keys_imp_seals.html#item_k43">
+              <div class="d-flex align-items-center">From the Shaded Castle Ramparts grace, go back down the little stairs and turn left, following the rampart around to find a Perfumer near a ramp down to the swamp below. The wall of the rampart is broken near this ramp, providing a way up, so get on the wall and follow it back a bit the way you came (south) until you can hop to the right onto the large stone barrier. Carefully climb up the stones with a few precise jumps, until a ledge wraps slightly around to the right, from where you can see a lower landing ahead that you can jump to. Then turn left and hop over the rock in the way (it's a bit tricky to get over it) and drop down to the other side of it, onto a small ledge with a body holding the key, with three slugs looking up at you from below.</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k44" id="/checklists/stonesword_keys_imp_seals.html#item_k44">
+              <div class="d-flex align-items-center">In Gelmir Hero's Grave, past the first chariot, a few Nobles and Pages, and a fire trap, you'll find a second chariot through an archway; instead of turning left to go down the incline and progress through the dungeon, turn right and run up into a dead end to find the key, though beware it's very difficult to get back on track without being killed by the chariot, as it will suddenly go all the way up the incline on its way back, so you may need to make a suicide run for it</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k45" id="/checklists/stonesword_keys_imp_seals.html#item_k45">
+              <div class="d-flex align-items-center">On the broken bridge just west of Corpse-Stench Shack</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k46" id="/checklists/stonesword_keys_imp_seals.html#item_k46">
+              <div class="d-flex align-items-center">Sold by the Nomadic Merchant for 5000 runes</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k47" id="/checklists/stonesword_keys_imp_seals.html#item_k47">
+              <div class="d-flex align-items-center">North of Fort Laiedd, in the corner with gravestones and jellyfish, on a body against a large tree</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k48" id="/checklists/stonesword_keys_imp_seals.html#item_k48">
+              <div class="d-flex align-items-center">From the Prison Town Church grace, descend into the town square with an Omenkiller by a bonfire. Go through the doorway near the Omenkiller's initial position, proceed through another archway with a dog, and turn right. Go down the stairs to the broken gap. Instead of dropping all the way down (you can survive that fall), if you take a running jump, you can just barely reach the other end of the gap and land on the wooden platform, which has the key.</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k49" id="/checklists/stonesword_keys_imp_seals.html#item_k49">
+              <div class="d-flex align-items-center">Exit southeast from the room Rya moves to deep in Volcano Manor later in her questline, hop over the thin lava stream, and jump up the ledge through an open window to find the key on a body on a cot</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k50" id="/checklists/stonesword_keys_imp_seals.html#item_k50">
+              <div class="d-flex align-items-center">In Sealed Tunnel, when you emerge into an open room navigable by tree branches and containing many Vulgar Militia and an Iron Maiden, use the branches to get to the platform on the right side, which has a short dead-end path with the key on a body</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k51" id="/checklists/stonesword_keys_imp_seals.html#item_k51">
+              <div class="d-flex align-items-center">In Auriza Hero's Grave in the room with two chariots running opposite each other, on a body in an alcove in the center of their paths</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k52" id="/checklists/stonesword_keys_imp_seals.html#item_k52">
+              <div class="d-flex align-items-center">From East Capital Rampart, follow the rampart all the way south until just before the door into a building filled with plants, drop off the side of the rampart onto the rooftops, and hop between rooftops all the way back north, until you find the key on a body next to two Imps</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k53" id="/checklists/stonesword_keys_imp_seals.html#item_k53">
+              <div class="d-flex align-items-center">From West Capital Rampart, drop down to ground level and face northwest, then climb the petrified dragon foot and leap from its extended claw to the roof of a barn, and from there into the second floor of an adjacent building, with the key on a body draped over a windowsill</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k54" id="/checklists/stonesword_keys_imp_seals.html#item_k54">
+              <div class="d-flex align-items-center">From Avenue Balcony, head down the stairs and hook around them to the right, then down the ladder into a room with many enemies throwing lightning pots, and open the little cell on the ground floor to find a chest with the key inside</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k55" id="/checklists/stonesword_keys_imp_seals.html#item_k55">
+              <div class="d-flex align-items-center">From the previous, head out the door on the ground floor, and continue forward until you can hook around a little set of stairs up and right, to see two Skeletal Militiamen and a Putrid Corpse praying at a grave bearing a body with the key</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k56" id="/checklists/stonesword_keys_imp_seals.html#item_k56">
+              <div class="d-flex align-items-center">From Lower Capital Church, exit the church and wrap around the building to the right; climb the long ladder and the following ladder to emerge at a gazebo; hook right again before the gazebo, then turn left and follow the tight path until you can climb a large staircase on your left; finally, from the top of the staircase, face directly east and run and jump on top of the gazebo to loot the key from the body</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k57" id="/checklists/stonesword_keys_imp_seals.html#item_k57">
+              <div class="d-flex align-items-center">Subterranean Shunning-Grounds: From Underground Roadside, head northeast and drop through the gap in the floor grate, turn northwest and go into the tunnel in the right wall, drop into the first hole surrounded by Slugs, and follow the path from there into a room with three Wraith Callers and the key on a body</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k58" id="/checklists/stonesword_keys_imp_seals.html#item_k58">
+              <div class="d-flex align-items-center">Sold by the Hermit Merchant for 5000 runes</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k59" id="/checklists/stonesword_keys_imp_seals.html#item_k59">
+              <div class="d-flex align-items-center">Sold by the Hermit Merchant for 5000 runes</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k60" id="/checklists/stonesword_keys_imp_seals.html#item_k60">
+              <div class="d-flex align-items-center">Sold by the Hermit Merchant for 5000 runes</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k61" id="/checklists/stonesword_keys_imp_seals.html#item_k61">
+              <div class="d-flex align-items-center">In Castle Sol, from the Church of the Eclipse, exit to the north, climb the ladder to the east, go all the way north, cross the wooden bridge, and climb the stairs on the right to find a body slumped over the wall on the left with the key</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k62" id="/checklists/stonesword_keys_imp_seals.html#item_k62">
+              <div class="d-flex align-items-center">On a body right behind the Fire Prelate outside Guardians' Garrison</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k63" id="/checklists/stonesword_keys_imp_seals.html#item_k63">
+              <div class="d-flex align-items-center">From Inner Consecrated Snowfield, travel exactly one notch north of West until you find a hill guarded by two lightning balls; on top is a chair with a corpse with the key</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k64" id="/checklists/stonesword_keys_imp_seals.html#item_k64">
+              <div class="d-flex align-items-center">In the northwest of Yelough Anix Ruins, in a tiny crumbling room packed with four frenzied rats</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k65" id="/checklists/stonesword_keys_imp_seals.html#item_k65">
+              <div class="d-flex align-items-center">Directly south of Haligtree Canopy on a body at the tip of the same branch</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k66" id="/checklists/stonesword_keys_imp_seals.html#item_k66">
+              <div class="d-flex align-items-center">From Haligtree Canopy, head east, dropping down when necessary to reach the first Large Oracle Envoy; follow the branch from there east/northeast until you can reach a large central branch with Giant Ants patrolling; follow the large branch south until its first offshoot on the left, which you can follow around in a large ascending circle onto a wide branch above with a scarlot rot flavored Giant Miranda Sprout; face northwest and walk along this branch until its first offshoot at a sharp left angle, at the end of which is an Oracle Envoy and a body with the key</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k67" id="/checklists/stonesword_keys_imp_seals.html#item_k67">
+              <div class="d-flex align-items-center">In the back of the Dragon Temple to the east, on a body near a ledge</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k68" id="/checklists/stonesword_keys_imp_seals.html#item_k68">
+              <div class="d-flex align-items-center">Sold by the Abandoned Merchant for 2000 runes</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k69" id="/checklists/stonesword_keys_imp_seals.html#item_k69">
+              <div class="d-flex align-items-center">Sold by the Abandoned Merchant for 2000 runes</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k70" id="/checklists/stonesword_keys_imp_seals.html#item_k70">
+              <div class="d-flex align-items-center">Sold by the Abandoned Merchant for 2000 runes</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k71" id="/checklists/stonesword_keys_imp_seals.html#item_k71">
+              <div class="d-flex align-items-center">At the end of the long bridge/wall protruding from the southwest of Siofra River, accessed via a spiritspring in front of it</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k72" id="/checklists/stonesword_keys_imp_seals.html#item_k72">
+              <div class="d-flex align-items-center">From the Below the Well grace, travel southwest along the right cliffside until you find a bridge leading to the other side near a Golden Tree; turn left at the other side and hop onto the pillar there, then run down the attached beam to the next pillar, which hides a body with a key</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k73" id="/checklists/stonesword_keys_imp_seals.html#item_k73">
+              <div class="d-flex align-items-center">On a body just south of the Aqueduct-Facing Cliffs grace, right outside the cave, where you drop down from the ledge above with the jellyfish to reach it</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k74" id="/checklists/stonesword_keys_imp_seals.html#item_k74">
+              <div class="d-flex align-items-center">On a body in water surrounded by many frenzied Miranda Sprouts, near the waterfall just southwest of Uld Palace Ruins</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k75" id="/checklists/stonesword_keys_imp_seals.html#item_k75">
+              <div class="d-flex align-items-center">In Nokstella, Eternal City, directly north of the elevator to Nokstella Waterfall Basin, on a cliff under a ledge</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k76" id="/checklists/stonesword_keys_imp_seals.html#item_k76">
+              <div class="d-flex align-items-center">Atop the very tall square building directly southeast of Crucible Knight Siluria, reached via the spiritspring next to the building</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k77" id="/checklists/stonesword_keys_imp_seals.html#item_k77">
+              <div class="d-flex align-items-center">On the south end of the area with many Giant Crows, on a body on the ground in the open</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k78" id="/checklists/stonesword_keys_imp_seals.html#item_k78">
+              <div class="d-flex align-items-center">Along the path up from Dynasty Mausoleum Entrance, just past the Giant Skeletal Slime, turn right for a dead end side path with many praying Putrid Corpses and a key on a body against a rock</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k79" id="/checklists/stonesword_keys_imp_seals.html#item_k79">
+              <div class="d-flex align-items-center">Sold by the Imprisoned Merchant for 5000 runes</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k80" id="/checklists/stonesword_keys_imp_seals.html#item_k80">
+              <div class="d-flex align-items-center">Sold by the Imprisoned Merchant for 5000 runes</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k81" id="/checklists/stonesword_keys_imp_seals.html#item_k81">
+              <div class="d-flex align-items-center">Sold by the Imprisoned Merchant for 5000 runes</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k82" id="/checklists/stonesword_keys_imp_seals.html#item_k82">
+              <div class="d-flex align-items-center">Sold by the Imprisoned Merchant for 5000 runes</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_k83" id="/checklists/stonesword_keys_imp_seals.html#item_k83">
+              <div class="d-flex align-items-center">Sold by the Imprisoned Merchant for 5000 runes</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_s1" id="/checklists/stonesword_keys_imp_seals.html#item_s1">
+              <div class="d-flex align-items-center">2 keys: The entrance to Fringefolk Hero's Grave</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_s2" id="/checklists/stonesword_keys_imp_seals.html#item_s2">
+              <div class="d-flex align-items-center">1 key: A cellar in eastern Summonwater Village containing the Green Turtle Talisman</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_s3" id="/checklists/stonesword_keys_imp_seals.html#item_s3">
+              <div class="d-flex align-items-center">1 key: A small room down the stairs near Smithing Master Hewg containing Crepus's Black-Key Crossbow and another Imp Statue Seal</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_s4" id="/checklists/stonesword_keys_imp_seals.html#item_s4">
+              <div class="d-flex align-items-center">2 keys: A small room accessed via the previous, containing the Assassin's Prayerbook</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_s5" id="/checklists/stonesword_keys_imp_seals.html#item_s5">
+              <div class="d-flex align-items-center">1 key: A small room in Tombsward Catacombs containing Nomadic Warrior's Cookbook [9]</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_s6" id="/checklists/stonesword_keys_imp_seals.html#item_s6">
+              <div class="d-flex align-items-center">1 key: Unlocks Weeping Evergaol</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_s7" id="/checklists/stonesword_keys_imp_seals.html#item_s7">
+              <div class="d-flex align-items-center">1 key: A cellar down some stairs in the main courtyard near Liftside Chamber, containing the Godskin Prayerbook, the Godslayer's Seal, and a shortcut door</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_s8" id="/checklists/stonesword_keys_imp_seals.html#item_s8">
+              <div class="d-flex align-items-center">1 key: A small room out the northwest of the main hall with the Grafted Scion, containing the Iron Whetblade, a Miséricorde, and a Hawk Crest Wooden Shield</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_s9" id="/checklists/stonesword_keys_imp_seals.html#item_s9">
+              <div class="d-flex align-items-center">1 key: A small room in Cliffbottom Catacombs containing the Nox Mirrorhelm</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_s10" id="/checklists/stonesword_keys_imp_seals.html#item_s10">
+              <div class="d-flex align-items-center">2 keys: The entrance to Academy Crystal Cave</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_s11" id="/checklists/stonesword_keys_imp_seals.html#item_s11">
+              <div class="d-flex align-items-center">1 key: A small room in Black Knife Catacombs containing Rosus' Axe</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_s12" id="/checklists/stonesword_keys_imp_seals.html#item_s12">
+              <div class="d-flex align-items-center">1 key: A cellar in Lunar Estate Ruins up by the Moonlight Altar accessed late in Ranni's questline. The Imp Statue appears to be by itself, with its seal located to its right underneath an illusory floor blocking a hidden basement. Contains the Cerulean Amber Medallion +2.</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_s13" id="/checklists/stonesword_keys_imp_seals.html#item_s13">
+              <div class="d-flex align-items-center">2 keys: The entrance to Gaol Cave</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_s14" id="/checklists/stonesword_keys_imp_seals.html#item_s14">
+              <div class="d-flex align-items-center">1 key: A cellar in Forsaken Ruins containing the Sword of St. Trina</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_s15" id="/checklists/stonesword_keys_imp_seals.html#item_s15">
+              <div class="d-flex align-items-center">1 key: Unlocks Golden Lineage Evergaol</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_s16" id="/checklists/stonesword_keys_imp_seals.html#item_s16">
+              <div class="d-flex align-items-center">2 keys: The entrance to Unsightly Catacombs</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_s17" id="/checklists/stonesword_keys_imp_seals.html#item_s17">
+              <div class="d-flex align-items-center">1 key: A small room in Sainted Hero's Grave containing the Crimson Seed Talisman</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_s18" id="/checklists/stonesword_keys_imp_seals.html#item_s18">
+              <div class="d-flex align-items-center">1 key: A small room much farther into Sainted Hero's Grave containing a Ghost Glovewort [5] and the Dragoncrest Shield Talisman +1</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_s19" id="/checklists/stonesword_keys_imp_seals.html#item_s19">
+              <div class="d-flex align-items-center">2 keys: The entrance to Old Altus Tunnel</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_s20" id="/checklists/stonesword_keys_imp_seals.html#item_s20">
+              <div class="d-flex align-items-center">2 keys: The entrance to Seethewater Cave</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_s21" id="/checklists/stonesword_keys_imp_seals.html#item_s21">
+              <div class="d-flex align-items-center">1 key: A cellar near the top of Wyndham Ruins containing the Pearldrake Talisman +1</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_s22" id="/checklists/stonesword_keys_imp_seals.html#item_s22">
+              <div class="d-flex align-items-center">1 key: A small room in Wyndham Catacombs containing the Lightning Scorpion Charm</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_s23" id="/checklists/stonesword_keys_imp_seals.html#item_s23">
+              <div class="d-flex align-items-center">1 key: A building with an Abductor Virgin and a spiral staircase to the Crimson Amber Medallion +1</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_s24" id="/checklists/stonesword_keys_imp_seals.html#item_s24">
+              <div class="d-flex align-items-center">2 keys: A large room with hanging cages that leads to the Dagger Talisman, a Seedbed Curse, a Somber Smithing Stone [7], and eventually a shortcut door</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_s25" id="/checklists/stonesword_keys_imp_seals.html#item_s25">
+              <div class="d-flex align-items-center">1 key: A small room in Auriza Hero's Grave containing the Golden Epitaph</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_s26" id="/checklists/stonesword_keys_imp_seals.html#item_s26">
+              <div class="d-flex align-items-center">2 keys: The entrance to Spiritcaller Cave</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_s27" id="/checklists/stonesword_keys_imp_seals.html#item_s27">
+              <div class="d-flex align-items-center">1 key: A small room in Giant-Conquering Hero's Grave containing Flame, Protect Me</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_s28" id="/checklists/stonesword_keys_imp_seals.html#item_s28">
+              <div class="d-flex align-items-center">2 keys: The entrance to Cave of the Forlorn</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_s29" id="/checklists/stonesword_keys_imp_seals.html#item_s29">
+              <div class="d-flex align-items-center">1 key: A small room containing Triple Rings of Light</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_s30" id="/checklists/stonesword_keys_imp_seals.html#item_s30">
+              <div class="d-flex align-items-center">1 key: A small room containing the Marika's Soreseal</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_s31" id="/checklists/stonesword_keys_imp_seals.html#item_s31">
+              <div class="d-flex align-items-center">2 keys: The Dragon Temple Lift</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_s32" id="/checklists/stonesword_keys_imp_seals.html#item_s32">
+              <div class="d-flex align-items-center">2 keys: The elevator up to Deep Siofra Well</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_s33" id="/checklists/stonesword_keys_imp_seals.html#item_s33">
+              <div class="d-flex align-items-center">1 key: A small room in Night's Sacred Ground containing the Mimic Tear Ashes</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/stonesword_keys_imp_seals.html#item_s34" id="/checklists/stonesword_keys_imp_seals.html#item_s34">
+              <div class="d-flex align-items-center">1 key: A small room at the top of Nokstella, Eternal City, containing the Nightmaiden & Swordstress Puppets</div>
+            </a>
             <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/dragon_hearts_deathroots.html#item_0_1" id="/checklists/dragon_hearts_deathroots.html#item_0_1">
               <div class="d-flex align-items-center">Defeat Flying Dragon Agheel in Agheel Lake (x1)</div>
             </a>
@@ -31878,11 +32232,11 @@
             <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/pots_bottles.html#item_3_6" id="/checklists/pots_bottles.html#item_3_6">
               <div class="d-flex align-items-center">Shaded Castle, in the North-West: on a body atop a wall, accessible via the second swamp ladder</div>
             </a>
-            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/pots_bottles.html#item_3_8" id="/checklists/pots_bottles.html#item_3_8">
-              <div class="d-flex align-items-center">Hermit Merchant's Shack, on the cliff North-East from the Outer Wall Battleground Grace on the North side of the outer wall: sold by Hermit Merchant for 2000 runes</div>
-            </a>
             <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/pots_bottles.html#item_3_7" id="/checklists/pots_bottles.html#item_3_7">
               <div class="d-flex align-items-center">Volcano Manor: on a body in a room unlocked with the Drawing-Room Key</div>
+            </a>
+            <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/pots_bottles.html#item_3_8" id="/checklists/pots_bottles.html#item_3_8">
+              <div class="d-flex align-items-center">Hermit Merchant's Shack, on the cliff North-East from the Outer Wall Battleground Grace on the North side of the outer wall: sold by Hermit Merchant for 2000 runes</div>
             </a>
             <a class="d-none list-group-item list-group-item-action searchable" href="/checklists/pots_bottles.html#item_3_9" id="/checklists/pots_bottles.html#item_3_9">
               <div class="d-flex align-items-center">Follow the path from the East Capital Rampart Grace along the rampart, into the tower, down the elevator, into the next tower, and up a ladder guarded by a Perfumer. It's in a chest in the room at the top</div>
@@ -32679,7 +33033,7 @@
                 </div>
                 <div class="d-flex align-items-center col-md-2">Murkwater Cave</div>
                 <div class="d-flex align-items-center col-md-2">Patches</div>
-                <div class="d-flex align-items-center col-md-5">Open Patches's special chest after he's set up his shop in the cave, then go talk to him about it.</div>
+                <div class="d-flex align-items-center col-md-5">Open Patches's special chest after he's set up his shop in the cave, then go talk to him about it. If you miss it, you can also get this gesture from him in Mt. Gelmir by returning to him after he kicks you off a cliff.</div>
               </div>
               <div class="row d-md-none">
                 <div class="col">
@@ -32687,7 +33041,7 @@
                   <strong class="me-1">Name: </strong>Calm Down!<br>
                   <strong class="me-1">Location: </strong>Murkwater Cave<br>
                   <strong class="me-1">Questline: </strong>Patches<br>
-                  <strong class="me-1">Description: </strong>Open Patches's special chest after he's set up his shop in the cave, then go talk to him about it.<br>
+                  <strong class="me-1">Description: </strong>Open Patches's special chest after he's set up his shop in the cave, then go talk to him about it. If you miss it, you can also get this gesture from him in Mt. Gelmir by returning to him after he kicks you off a cliff.<br>
                 </div>
               </div>
             </a>

--- a/docs/search_index.json
+++ b/docs/search_index.json
@@ -4485,7 +4485,7 @@
   },
   {
     "id": "/checklists/npc_questlines.html#item_31_20_2",
-    "text": "If you use the Gold summon sign, you'll help her fight her invaders. Once you win, return to where the summon signs were to find her lying by the pool of rot. Be very careful dropping down to her, if you land on her, she'll die. Exhaust her dialogue for the Rotten Winged Sword Insignia then reload the area to get back the Unalloyed Gold Needle, which you can use on a flower in Malenia's boss arena for Somber Ancient Dragon Smithing Stone and Miquella's Needle, which is needed to cure yourself of the Frenzied Flame. Gowry will remain alive, kill him for his stuff"
+    "text": "If you use the Gold summon sign, you'll help her fight her invaders. If you or she dies, you can try again. Once you win, return to where the summon signs were to find her lying by the pool of rot. Exhaust her dialogue for the Rotten Winged Sword Insignia then reload the area to get back the Unalloyed Gold Needle, which you can use on a flower in Malenia's boss arena for Somber Ancient Dragon Smithing Stone and Miquella's Needle, which is needed to cure yourself of the Frenzied Flame. Gowry will remain alive, but can finally be killed for his stuff"
   },
   {
     "id": "/checklists/npc_questlines.html#item_31_21",
@@ -4509,7 +4509,7 @@
   },
   {
     "id": "/checklists/npc_questlines.html#item_5_1",
-    "text": "Located at the Church of Vows in East Liurnia Lake. Teaches sorceries and incantations, and accepts scrolls and prayerbooks. Never moves or dies, unless you're the worst kind of person, so is a good candidate to give them all to."
+    "text": "Located at the Church of Vows in East Liurnia of the Lakes. Teaches sorceries and incantations, and accepts scrolls and prayerbooks. Never moves or dies, unless you're the worst kind of person, so is a good candidate to give them all to."
   },
   {
     "id": "/checklists/npc_questlines.html#item_5_2",
@@ -4593,15 +4593,15 @@
   },
   {
     "id": "/checklists/npc_questlines.html#item_29_8",
-    "text": "Make your way back to him and he'll give you another gesture (Note: he won't give the gesture if you've been to Liurnia Lake)"
+    "text": "Make your way back to him and he'll give you another gesture (Note: he won't give the gesture if you've been to Liurnia of the Lakes)"
   },
   {
     "id": "/checklists/npc_questlines.html#item_29_3",
-    "text": "He'll next be found at the Scenic Isle Grace in Liurnia Lake and will inform you about an Iron Virgin deep at the bottom of Raya Lucaria that will teleport you to the Erdtree if you let it eat you"
+    "text": "He'll next be found at the Scenic Isle Grace in Liurnia of the Lakes and will inform you about an Iron Virgin deep at the bottom of Raya Lucaria that will teleport you to the Erdtree if you let it eat you"
   },
   {
     "id": "/checklists/npc_questlines.html#item_29_4",
-    "text": "Missable: His next new location is near the First Mt. Gelmir Campfire Site of Grace. Follow the cliff edge westward until you reach the corner, and read the message he's left. You can find him nearby, squatting in a bush. He'll say you should totally check out what those Rainbow Stones are leading to. Wander over, with your back turned and your defenses lowered, to the tall ledge"
+    "text": "Missable: His next new location is near the First Mt. Gelmir Campfire Site of Grace. Follow the cliff edge westward until you reach the corner, and read the message he's left. You can find him nearby, squatting in a bush. He'll say you should totally check out what those Rainbow Stones are leading to. Wander over, with your back turned and your defenses lowered, to the tall ledge. (If you missed the Calm Down gesture before, you can get it again from him now by making your way back to him before he moves on)"
   },
   {
     "id": "/checklists/npc_questlines.html#item_29_5",
@@ -5857,7 +5857,7 @@
   },
   {
     "id": "/checklists/bosses.html#item_7_17",
-    "text": "Fire Prelate Fort Laiedd 1309 runes, Prelate's Inferno Crozier Colossal Weapon, Thorned Whip Field boss. Chance to drop Fire Prelate Set."
+    "text": "Fire Prelate Fort Laiedd 1309 runes, Prelate's Inferno Crozier Field boss. Chance to drop Fire Prelate Set."
   },
   {
     "id": "/checklists/bosses.html#item_7_18",
@@ -14988,6 +14988,474 @@
     "text": "Mending Rune of Perfect Order Dropped by Goldmask after following his and Brother Corhyn's questline. Rune discovered by the noble Goldmask. A rune of transcendental ideology which will attempt to perfect the Golden Order."
   },
   {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k1",
+    "text": "Can choose two as a keepsake"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k2",
+    "text": "Can choose two as a keepsake"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k3",
+    "text": "In a tiny intact room in the center of Dragon-Burnt Ruins, on a body guarded by a single rat"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k4",
+    "text": "Sold by Patches for 5000 runes in Murkwater Cave (and thereafter)"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k5",
+    "text": "On the front of Stormhill Shack, on a body atop the little staircase of wooden platforms"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k6",
+    "text": "In Fringefolk Hero's Grave, on the ledge from which you can shoot down the jars to destroy the chariot"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k7",
+    "text": "Sold by Twin Maiden Husks for 4000 runes"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k8",
+    "text": "Sold by Twin Maiden Husks for 4000 runes"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k9",
+    "text": "Sold by Twin Maiden Husks for 4000 runes"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k10",
+    "text": "On the Bridge of Sacrifice on a body behind the ballista"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k11",
+    "text": "On the northern tip of the high ledge in the northeast, on a body sitting in a chair"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k12",
+    "text": "Sold by the Nomadic Merchant in Weeping Peninsula for 2000 runes"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k13",
+    "text": "Sold by the Isolated Merchant in Weeping Peninsula for 2000 runes"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k14",
+    "text": "Sold by the Isolated Merchant in Weeping Peninsula for 2000 runes"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k15",
+    "text": "Sold by the Isolated Merchant in Weeping Peninsula for 2000 runes"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k16",
+    "text": "From the Behind the Castle Site of Grace in Castle Morne, descend down a couple ledges to the first rooftop, then walk forward and drop off to a wooden platform halfway down with the key on a body"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k17",
+    "text": "From Rampart Tower, follow the path up the central spiral staircase and to the rooftops; from the stack of sandbags, follow the ledge to the south tower, then turn east and hop to the next crumbling tower, and drop down inside it to find it on a body"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k18",
+    "text": "On a body on the wooden platform above the Grafted Scion (down the shortcut elevator from Rampart Tower)"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k19",
+    "text": "On a body in the pit with the Ulcerated Tree Spirit, just past the first big roots on the left"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k20",
+    "text": "In Academy Crystal Cave, stick to the left past the rats and the Sages to find a small side room in the back, containing the key on a body in a cage"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k21",
+    "text": "On the island directly east of the South Raya Lucaria Gate Site of Grace, accessible from Gate Town North; it's in a chest in a small tower sticking out of the water, requiring Torrent's double jump to reach"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k22",
+    "text": "Outside Raya Lucaria at the base of its northeastern corner, up an incline leading to an area with many Wraith Callers and a body sitting in a chair with the key"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k23",
+    "text": "Sold by the Isolated Merchant inside the South Raya Lucaria Gate for 3000 runes"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k24",
+    "text": "Sold by the Isolated Merchant inside the South Raya Lucaria Gate for 3000 runes"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k25",
+    "text": "Sold by the Isolated Merchant inside the South Raya Lucaria Gate for 3000 runes"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k26",
+    "text": "As far north as it's possible to go from the Ainsel River Well before the cliff wall cuts off the path, on a body in a chair in a small patch of flowers"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k27",
+    "text": "Atop the western wall of Frenzied Flame Village"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k28",
+    "text": "From Three Sisters above Caria Manor, follow the path along the rooftops, dropping down when necessary, all the way to the rampart overlooking the Main Gate, with a Giant Crab on top guarding a body with the key"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k29",
+    "text": "Past the illusory bookshelf directly before the Debate Parlor (Red Wolf of Radagon), on the other side of the altar behind the chest"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k30",
+    "text": "In the courtyard directly after the Debate Parlor, on a body draped on the central fountain"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k31",
+    "text": "In Gaol Cave, on a body in a cell"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k32",
+    "text": "Sold by the Nomadic Merchant in south Caelid for 4000 runes"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k33",
+    "text": "From the Dragonbarrow West grace, head to the Divine Tower of Caelid and jump onto the high tree branch, then to the first ledge with a ladder and a sentry with a torch; don't climb the ladder but face southeast from it and follow the arch to find the key on a body on the next landing, guarded by a knight"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k34",
+    "text": "In Sellia, Town of Sorcery, on a body slumped atop an archway connecting two buildings at the southern entrance of town; passing northward through the arch underneath, turn right to see rubble with a rotted tree through it, an easy way up on horseback"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k35",
+    "text": "From Fort Faroth, face west and climb the hulking white rock in the distance; it's in a body on a chair"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k36",
+    "text": "South of the Deep Siofra Well, past the large bear, on a body sitting on the cliff"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k37",
+    "text": "Early on the road northeast from the Grand Lift of Dectus, in the small encampment of Misbegottens on the right, on a body against a tent"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k38",
+    "text": "In Sage's Cave, proceed down the linear path, through illusory walls when necessary, until a more open room with a bonfire, many stalactites, and a larger skeleton wielding the Executioner's Greataxe; on the left, being stared at by another skeleton, is an illusory wall hiding a nook with a chest with the key inside"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k39",
+    "text": "Sold by the Nomadic Merchant for 4000 runes"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k40",
+    "text": "Sold by the Nomadic Merchant for 4000 runes"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k41",
+    "text": "Sold by the Nomadic Merchant for 4000 runes"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k42",
+    "text": "On the eastern side of the raised plateau in the center of Altus with perpetual lightning storms, on a body slumped on a stone platform"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k43",
+    "text": "From the Shaded Castle Ramparts grace, go back down the little stairs and turn left, following the rampart around to find a Perfumer near a ramp down to the swamp below. The wall of the rampart is broken near this ramp, providing a way up, so get on the wall and follow it back a bit the way you came (south) until you can hop to the right onto the large stone barrier. Carefully climb up the stones with a few precise jumps, until a ledge wraps slightly around to the right, from where you can see a lower landing ahead that you can jump to. Then turn left and hop over the rock in the way (it's a bit tricky to get over it) and drop down to the other side of it, onto a small ledge with a body holding the key, with three slugs looking up at you from below."
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k44",
+    "text": "In Gelmir Hero's Grave, past the first chariot, a few Nobles and Pages, and a fire trap, you'll find a second chariot through an archway; instead of turning left to go down the incline and progress through the dungeon, turn right and run up into a dead end to find the key, though beware it's very difficult to get back on track without being killed by the chariot, as it will suddenly go all the way up the incline on its way back, so you may need to make a suicide run for it"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k45",
+    "text": "On the broken bridge just west of Corpse-Stench Shack"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k46",
+    "text": "Sold by the Nomadic Merchant for 5000 runes"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k47",
+    "text": "North of Fort Laiedd, in the corner with gravestones and jellyfish, on a body against a large tree"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k48",
+    "text": "From the Prison Town Church grace, descend into the town square with an Omenkiller by a bonfire. Go through the doorway near the Omenkiller's initial position, proceed through another archway with a dog, and turn right. Go down the stairs to the broken gap. Instead of dropping all the way down (you can survive that fall), if you take a running jump, you can just barely reach the other end of the gap and land on the wooden platform, which has the key."
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k49",
+    "text": "Exit southeast from the room Rya moves to deep in Volcano Manor later in her questline, hop over the thin lava stream, and jump up the ledge through an open window to find the key on a body on a cot"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k50",
+    "text": "In Sealed Tunnel, when you emerge into an open room navigable by tree branches and containing many Vulgar Militia and an Iron Maiden, use the branches to get to the platform on the right side, which has a short dead-end path with the key on a body"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k51",
+    "text": "In Auriza Hero's Grave in the room with two chariots running opposite each other, on a body in an alcove in the center of their paths"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k52",
+    "text": "From East Capital Rampart, follow the rampart all the way south until just before the door into a building filled with plants, drop off the side of the rampart onto the rooftops, and hop between rooftops all the way back north, until you find the key on a body next to two Imps"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k53",
+    "text": "From West Capital Rampart, drop down to ground level and face northwest, then climb the petrified dragon foot and leap from its extended claw to the roof of a barn, and from there into the second floor of an adjacent building, with the key on a body draped over a windowsill"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k54",
+    "text": "From Avenue Balcony, head down the stairs and hook around them to the right, then down the ladder into a room with many enemies throwing lightning pots, and open the little cell on the ground floor to find a chest with the key inside"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k55",
+    "text": "From the previous, head out the door on the ground floor, and continue forward until you can hook around a little set of stairs up and right, to see two Skeletal Militiamen and a Putrid Corpse praying at a grave bearing a body with the key"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k56",
+    "text": "From Lower Capital Church, exit the church and wrap around the building to the right; climb the long ladder and the following ladder to emerge at a gazebo; hook right again before the gazebo, then turn left and follow the tight path until you can climb a large staircase on your left; finally, from the top of the staircase, face directly east and run and jump on top of the gazebo to loot the key from the body"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k57",
+    "text": "Subterranean Shunning-Grounds: From Underground Roadside, head northeast and drop through the gap in the floor grate, turn northwest and go into the tunnel in the right wall, drop into the first hole surrounded by Slugs, and follow the path from there into a room with three Wraith Callers and the key on a body"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k58",
+    "text": "Sold by the Hermit Merchant for 5000 runes"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k59",
+    "text": "Sold by the Hermit Merchant for 5000 runes"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k60",
+    "text": "Sold by the Hermit Merchant for 5000 runes"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k61",
+    "text": "In Castle Sol, from the Church of the Eclipse, exit to the north, climb the ladder to the east, go all the way north, cross the wooden bridge, and climb the stairs on the right to find a body slumped over the wall on the left with the key"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k62",
+    "text": "On a body right behind the Fire Prelate outside Guardians' Garrison"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k63",
+    "text": "From Inner Consecrated Snowfield, travel exactly one notch north of West until you find a hill guarded by two lightning balls; on top is a chair with a corpse with the key"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k64",
+    "text": "In the northwest of Yelough Anix Ruins, in a tiny crumbling room packed with four frenzied rats"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k65",
+    "text": "Directly south of Haligtree Canopy on a body at the tip of the same branch"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k66",
+    "text": "From Haligtree Canopy, head east, dropping down when necessary to reach the first Large Oracle Envoy; follow the branch from there east/northeast until you can reach a large central branch with Giant Ants patrolling; follow the large branch south until its first offshoot on the left, which you can follow around in a large ascending circle onto a wide branch above with a scarlot rot flavored Giant Miranda Sprout; face northwest and walk along this branch until its first offshoot at a sharp left angle, at the end of which is an Oracle Envoy and a body with the key"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k67",
+    "text": "In the back of the Dragon Temple to the east, on a body near a ledge"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k68",
+    "text": "Sold by the Abandoned Merchant for 2000 runes"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k69",
+    "text": "Sold by the Abandoned Merchant for 2000 runes"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k70",
+    "text": "Sold by the Abandoned Merchant for 2000 runes"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k71",
+    "text": "At the end of the long bridge/wall protruding from the southwest of Siofra River, accessed via a spiritspring in front of it"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k72",
+    "text": "From the Below the Well grace, travel southwest along the right cliffside until you find a bridge leading to the other side near a Golden Tree; turn left at the other side and hop onto the pillar there, then run down the attached beam to the next pillar, which hides a body with a key"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k73",
+    "text": "On a body just south of the Aqueduct-Facing Cliffs grace, right outside the cave, where you drop down from the ledge above with the jellyfish to reach it"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k74",
+    "text": "On a body in water surrounded by many frenzied Miranda Sprouts, near the waterfall just southwest of Uld Palace Ruins"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k75",
+    "text": "In Nokstella, Eternal City, directly north of the elevator to Nokstella Waterfall Basin, on a cliff under a ledge"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k76",
+    "text": "Atop the very tall square building directly southeast of Crucible Knight Siluria, reached via the spiritspring next to the building"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k77",
+    "text": "On the south end of the area with many Giant Crows, on a body on the ground in the open"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k78",
+    "text": "Along the path up from Dynasty Mausoleum Entrance, just past the Giant Skeletal Slime, turn right for a dead end side path with many praying Putrid Corpses and a key on a body against a rock"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k79",
+    "text": "Sold by the Imprisoned Merchant for 5000 runes"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k80",
+    "text": "Sold by the Imprisoned Merchant for 5000 runes"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k81",
+    "text": "Sold by the Imprisoned Merchant for 5000 runes"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k82",
+    "text": "Sold by the Imprisoned Merchant for 5000 runes"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_k83",
+    "text": "Sold by the Imprisoned Merchant for 5000 runes"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_s1",
+    "text": "2 keys: The entrance to Fringefolk Hero's Grave"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_s2",
+    "text": "1 key: A cellar in eastern Summonwater Village containing the Green Turtle Talisman"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_s3",
+    "text": "1 key: A small room down the stairs near Smithing Master Hewg containing Crepus's Black-Key Crossbow and another Imp Statue Seal"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_s4",
+    "text": "2 keys: A small room accessed via the previous, containing the Assassin's Prayerbook"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_s5",
+    "text": "1 key: A small room in Tombsward Catacombs containing Nomadic Warrior's Cookbook [9]"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_s6",
+    "text": "1 key: Unlocks Weeping Evergaol"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_s7",
+    "text": "1 key: A cellar down some stairs in the main courtyard near Liftside Chamber, containing the Godskin Prayerbook, the Godslayer's Seal, and a shortcut door"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_s8",
+    "text": "1 key: A small room out the northwest of the main hall with the Grafted Scion, containing the Iron Whetblade, a Mis\u00e9ricorde, and a Hawk Crest Wooden Shield"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_s9",
+    "text": "1 key: A small room in Cliffbottom Catacombs containing the Nox Mirrorhelm"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_s10",
+    "text": "2 keys: The entrance to Academy Crystal Cave"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_s11",
+    "text": "1 key: A small room in Black Knife Catacombs containing Rosus' Axe"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_s12",
+    "text": "1 key: A cellar in Lunar Estate Ruins up by the Moonlight Altar accessed late in Ranni's questline. The Imp Statue appears to be by itself, with its seal located to its right underneath an illusory floor blocking a hidden basement. Contains the Cerulean Amber Medallion +2."
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_s13",
+    "text": "2 keys: The entrance to Gaol Cave"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_s14",
+    "text": "1 key: A cellar in Forsaken Ruins containing the Sword of St. Trina"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_s15",
+    "text": "1 key: Unlocks Golden Lineage Evergaol"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_s16",
+    "text": "2 keys: The entrance to Unsightly Catacombs"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_s17",
+    "text": "1 key: A small room in Sainted Hero's Grave containing the Crimson Seed Talisman"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_s18",
+    "text": "1 key: A small room much farther into Sainted Hero's Grave containing a Ghost Glovewort [5] and the Dragoncrest Shield Talisman +1"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_s19",
+    "text": "2 keys: The entrance to Old Altus Tunnel"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_s20",
+    "text": "2 keys: The entrance to Seethewater Cave"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_s21",
+    "text": "1 key: A cellar near the top of Wyndham Ruins containing the Pearldrake Talisman +1"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_s22",
+    "text": "1 key: A small room in Wyndham Catacombs containing the Lightning Scorpion Charm"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_s23",
+    "text": "1 key: A building with an Abductor Virgin and a spiral staircase to the Crimson Amber Medallion +1"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_s24",
+    "text": "2 keys: A large room with hanging cages that leads to the Dagger Talisman, a Seedbed Curse, a Somber Smithing Stone [7], and eventually a shortcut door"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_s25",
+    "text": "1 key: A small room in Auriza Hero's Grave containing the Golden Epitaph"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_s26",
+    "text": "2 keys: The entrance to Spiritcaller Cave"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_s27",
+    "text": "1 key: A small room in Giant-Conquering Hero's Grave containing Flame, Protect Me"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_s28",
+    "text": "2 keys: The entrance to Cave of the Forlorn"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_s29",
+    "text": "1 key: A small room containing Triple Rings of Light"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_s30",
+    "text": "1 key: A small room containing the Marika's Soreseal"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_s31",
+    "text": "2 keys: The Dragon Temple Lift"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_s32",
+    "text": "2 keys: The elevator up to Deep Siofra Well"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_s33",
+    "text": "1 key: A small room in Night's Sacred Ground containing the Mimic Tear Ashes"
+  },
+  {
+    "id": "/checklists/stonesword_keys_imp_seals.html#item_s34",
+    "text": "1 key: A small room at the top of Nokstella, Eternal City, containing the Nightmaiden & Swordstress Puppets"
+  },
+  {
     "id": "/checklists/dragon_hearts_deathroots.html#item_0_1",
     "text": "Defeat Flying Dragon Agheel in Agheel Lake (x1)"
   },
@@ -15388,12 +15856,12 @@
     "text": "Shaded Castle, in the North-West: on a body atop a wall, accessible via the second swamp ladder"
   },
   {
-    "id": "/checklists/pots_bottles.html#item_3_8",
-    "text": "Hermit Merchant's Shack, on the cliff North-East from the Outer Wall Battleground Grace on the North side of the outer wall: sold by Hermit Merchant for 2000 runes"
-  },
-  {
     "id": "/checklists/pots_bottles.html#item_3_7",
     "text": "Volcano Manor: on a body in a room unlocked with the Drawing-Room Key"
+  },
+  {
+    "id": "/checklists/pots_bottles.html#item_3_8",
+    "text": "Hermit Merchant's Shack, on the cliff North-East from the Outer Wall Battleground Grace on the North side of the outer wall: sold by Hermit Merchant for 2000 runes"
   },
   {
     "id": "/checklists/pots_bottles.html#item_3_9",
@@ -15621,7 +16089,7 @@
   },
   {
     "id": "/checklists/gestures.html#item_1_6",
-    "text": "Calm Down! Murkwater Cave Patches Open Patches's special chest after he's set up his shop in the cave, then go talk to him about it."
+    "text": "Calm Down! Murkwater Cave Patches Open Patches's special chest after he's set up his shop in the cave, then go talk to him about it. If you miss it, you can also get this gesture from him in Mt. Gelmir by returning to him after he kicks you off a cliff."
   },
   {
     "id": "/checklists/gestures.html#item_1_7",


### PR DESCRIPTION
- Added a page for all Stonesword Keys and Imp Statue Seals.
- Mapped all Stonesword Keys. Map locations (and a custom map icon) for Imp Statue Seals forthcoming.
- Unlinked Thorned Whip from the Fire Prelate miniboss in Fort Laiedd and removed it as a listed drop. (Resolves #262)
- Removed assertion that all bell bearings reset in NG+, since that was patched out with 1.05.
- Removed warning about accidentally killing Millicent by falling on her at the end of her questline, since that was patched out with 1.05.
- Added an unlisted opportunity to get the "Calm Down" gesture.
- Tidied up the organization of Pots & Bottles a bit.
- Tweaked some map icon locations in Roundtable Hold.