### PR TITLE
Adds coords for Fallingstar Beast at Altus Plateau

### DIFF
--- a/data/checklists/bosses.yaml
+++ b/data/checklists/bosses.yaml
@@ -456,6 +456,7 @@ sections:
         data: ["Omenkiller & Miranda, the Blighted Bloom", "Perfumer's Grotto", "8500 runes, Great Omenkiller Cleaver", ""]
       - id: "6_13"
         data: ["Fallingstar Beast", "South Altus Plateau Crater", "11,000 runes, Somber Smithing Stone [5], Smithing Stone [6] (x5), Gravity Stone Fan, Gravity Stone Chunk", ""]
+        cords: [3497, 3608]
       - id: "6_14"
         data: ["Ancient Dragon Lansseax (Part 2)", "Rampartside (Southeast)", "60,000 runes, Lansseax's Glaive Incantation", "Part 1 of this encounter takes place in Mt. Gelmir."]
       - id: "6_15"

--- a/docs/checklists/bosses.html
+++ b/docs/checklists/bosses.html
@@ -5479,7 +5479,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="bosses_6_13" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_6_13&amp;id=bosses_6_13&amp;link=/checklists/bosses.html%23item_6_13&amp;title=Fallingstar Beast">
+                      <a class="" href="/map.html?target=bosses_6_13&amp;id=bosses_6_13&amp;link=/checklists/bosses.html%23item_6_13&amp;title=Fallingstar Beast">
                         <i class="bi bi-geo-alt"></i>
                       </a>
                     </div>

--- a/docs/map/src/js/features.js
+++ b/docs/map/src/js/features.js
@@ -2189,6 +2189,25 @@ const feature_data = [
       {
         "geometry": {
           "coordinates": [
+            3497,
+            3608
+          ],
+          "type": "Point"
+        },
+        "id": "bosses_6_13",
+        "properties": {
+          "group": "bosses",
+          "icon": "/map/icons/MENU_MAP_memo_20.png",
+          "icon_size": 35,
+          "id": "bosses_6_13",
+          "link": "/checklists/bosses.html#item_6_13",
+          "title": "Fallingstar Beast"
+        },
+        "type": "Feature"
+      },
+      {
+        "geometry": {
+          "coordinates": [
             2647,
             3224
           ],


### PR DESCRIPTION
Fixes #275

![image](https://user-images.githubusercontent.com/11976750/228565477-9725fbaa-d793-4666-81c9-ba7ceb1f85c4.png)
Source: https://eldenring.wiki.fextralife.com/Interactive+Map?id=5797&lat=-104.57&lng=95.74&zoom=8&code=mapA