### PR TITLE
Set map locations for all walkthrough steps in Weeping Peninsula

### DIFF
--- a/data/checklists/walkthrough.yaml
+++ b/data/checklists/walkthrough.yaml
@@ -219,34 +219,49 @@ sections:
     items:
       - id: "70"
         data: ["Starting at the Agheel Lake South Grace in South-East Limgrave, follow the road South-East and cross the Bridge of Sacrifice to grab the Bridge of Sacrifice Grace."]
+        map_link: [4331,7806]
       - id: "71"
         data: ["Meet Irina next to the road nearby and exhaust her dialogue for Irina's Letter."]
+        map_link: [4378, 7843]
       - id: "72"
         data: ["Follow the road South and grab the Castle Morne Rampart Grace."]
+        map_link: [4306,8158]
       - id: "73"
         data: ["Follow the road going North-West to grab the South of the Lookout Tower Grace"]
+        map_link: [4209,7976]
       - id: "74"
         data: ["Cross the bridge to the West and follow the road going North to the Church of Pilgrimage and grab the Church of Pilgrimage Grace as well as a Sacred Tear in the church."]
+        map_link: [3858,7699]
       - id: "75"
         data: ["Rest at the Church of Pilgrimage Grace and talk to Melina until dialogue is exhausted."]
+        map_link: [3858,7699]
       - id: "76"
         data: ["Go back to the Castle Morne Rampart Grace and follow the road South to grab the Map (Weeping Peninsula) at the pillar and a Golden Seed from the Erdtree Sapling near it."]
+        map_link: [4222, 8334]
       - id: "77"
         data: ["Continue on the road South to reach Castle Morne and grab the Castle Morne Lift Grace."]
+        map_link: [4071,8580]
       - id: "78"
         data: ["Go up the lift and pass the praying enemies by sneaking around on the right side. Go into the room and then out through the other side. Climb the ladder to the top then climb the next ladder in front of you. Run to the other side and hop over the edge on the left to the wall below. Run across the bridge and go over the edge to the left again. Run past the enemies to the tower and at the top of that tower you will find Edgar."]
+        map_link: [4078, 8627]
       - id: "79"
         data: ["Talk to Edgar and exhaust his dialogue."]
+        map_link: [4078, 8627]
       - id: "80"
         data: ["Turn back and go past the enemies again. At the end of the path, hop the wall on your left to grab the Behind the Castle Grace."]
+        map_link: [4007,8692]
       - id: "81"
         data: ["Make your way down to the bottom, summon Edgar outside the boss room and then kill the boss Leonine Misbegotten to obtain the Legendary Weapon, the Grafted Greatsword."]
+        map_link: [3940,8834]
       - id: "82"
         data: ["Go back to Edgar where he was on the tower and exhaust his dialogue."]
+        map_link: [4078, 8627]
       - id: "83"
         data: ["Return to Irina's location near the Bridge of Sacrifice Grace, talk to Edgar and exhaust his dialogue."]
+        map_link: [4378, 7843]
       - id: "84"
         data: ["Weeping Peninsula is now 100% safe to explore! There should be no warnings required!"]
+        map_link: [4378, 7843]
   -
     title: "Margit/Roundtable Hold"
     items:

--- a/docs/checklists/walkthrough.html
+++ b/docs/checklists/walkthrough.html
@@ -1023,90 +1023,135 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="playthrough_70" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_70">Starting at the Agheel Lake South Grace in South-East Limgrave, follow the road South-East and cross the Bridge of Sacrifice to grab the Bridge of Sacrifice Grace.</label>
+                    <a class="ms-2" href="/map.html?x=4331&amp;y=7806&amp;id=playthrough_70&amp;link=/checklists/walkthrough.html%23item_70&amp;title=Starting at the Agheel Lake South Grace in South-East Limgrave, follow the road South-East and cross the Bridge of Sacrifice to grab the Bridge of Sacrifice Grace.">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_71" id="item_71">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="playthrough_71" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_71">Meet Irina next to the road nearby and exhaust her dialogue for Irina's Letter.</label>
+                    <a class="ms-2" href="/map.html?x=4378&amp;y=7843&amp;id=playthrough_71&amp;link=/checklists/walkthrough.html%23item_71&amp;title=Meet Irina next to the road nearby and exhaust her dialogue for Irina's Letter.">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_72" id="item_72">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="playthrough_72" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_72">Follow the road South and grab the Castle Morne Rampart Grace.</label>
+                    <a class="ms-2" href="/map.html?x=4306&amp;y=8158&amp;id=playthrough_72&amp;link=/checklists/walkthrough.html%23item_72&amp;title=Follow the road South and grab the Castle Morne Rampart Grace.">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_73" id="item_73">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="playthrough_73" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_73">Follow the road going North-West to grab the South of the Lookout Tower Grace</label>
+                    <a class="ms-2" href="/map.html?x=4209&amp;y=7976&amp;id=playthrough_73&amp;link=/checklists/walkthrough.html%23item_73&amp;title=Follow the road going North-West to grab the South of the Lookout Tower Grace">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_74" id="item_74">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="playthrough_74" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_74">Cross the bridge to the West and follow the road going North to the Church of Pilgrimage and grab the Church of Pilgrimage Grace as well as a Sacred Tear in the church.</label>
+                    <a class="ms-2" href="/map.html?x=3858&amp;y=7699&amp;id=playthrough_74&amp;link=/checklists/walkthrough.html%23item_74&amp;title=Cross the bridge to the West and follow the road going North to the Church of Pilgrimage and grab the Church of Pilgrimage Grace as well as a Sacred Tear in the church.">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_75" id="item_75">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="playthrough_75" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_75">Rest at the Church of Pilgrimage Grace and talk to Melina until dialogue is exhausted.</label>
+                    <a class="ms-2" href="/map.html?x=3858&amp;y=7699&amp;id=playthrough_75&amp;link=/checklists/walkthrough.html%23item_75&amp;title=Rest at the Church of Pilgrimage Grace and talk to Melina until dialogue is exhausted.">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_76" id="item_76">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="playthrough_76" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_76">Go back to the Castle Morne Rampart Grace and follow the road South to grab the Map (Weeping Peninsula) at the pillar and a Golden Seed from the Erdtree Sapling near it.</label>
+                    <a class="ms-2" href="/map.html?x=4222&amp;y=8334&amp;id=playthrough_76&amp;link=/checklists/walkthrough.html%23item_76&amp;title=Go back to the Castle Morne Rampart Grace and follow the road South to grab the Map (Weeping Peninsula) at the pillar and a Golden Seed from the Erdtree Sapling near it.">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_77" id="item_77">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="playthrough_77" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_77">Continue on the road South to reach Castle Morne and grab the Castle Morne Lift Grace.</label>
+                    <a class="ms-2" href="/map.html?x=4071&amp;y=8580&amp;id=playthrough_77&amp;link=/checklists/walkthrough.html%23item_77&amp;title=Continue on the road South to reach Castle Morne and grab the Castle Morne Lift Grace.">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_78" id="item_78">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="playthrough_78" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_78">Go up the lift and pass the praying enemies by sneaking around on the right side. Go into the room and then out through the other side. Climb the ladder to the top then climb the next ladder in front of you. Run to the other side and hop over the edge on the left to the wall below. Run across the bridge and go over the edge to the left again. Run past the enemies to the tower and at the top of that tower you will find Edgar.</label>
+                    <a class="ms-2" href="/map.html?x=4078&amp;y=8627&amp;id=playthrough_78&amp;link=/checklists/walkthrough.html%23item_78&amp;title=Go up the lift and pass the praying enemies by sneaking around on the right side. Go into the room and then out through the other side. Climb the ladder to the top then climb the next ladder in front of you. Run to the other side and hop over the edge on the left to the wall below. Run across the bridge and go over the edge to the left again. Run past the enemies to the tower and at the top of that tower you will find Edgar.">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_79" id="item_79">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="playthrough_79" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_79">Talk to Edgar and exhaust his dialogue.</label>
+                    <a class="ms-2" href="/map.html?x=4078&amp;y=8627&amp;id=playthrough_79&amp;link=/checklists/walkthrough.html%23item_79&amp;title=Talk to Edgar and exhaust his dialogue.">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_80" id="item_80">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="playthrough_80" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_80">Turn back and go past the enemies again. At the end of the path, hop the wall on your left to grab the Behind the Castle Grace.</label>
+                    <a class="ms-2" href="/map.html?x=4007&amp;y=8692&amp;id=playthrough_80&amp;link=/checklists/walkthrough.html%23item_80&amp;title=Turn back and go past the enemies again. At the end of the path, hop the wall on your left to grab the Behind the Castle Grace.">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_81" id="item_81">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="playthrough_81" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_81">Make your way down to the bottom, summon Edgar outside the boss room and then kill the boss Leonine Misbegotten to obtain the Legendary Weapon, the Grafted Greatsword.</label>
+                    <a class="ms-2" href="/map.html?x=3940&amp;y=8834&amp;id=playthrough_81&amp;link=/checklists/walkthrough.html%23item_81&amp;title=Make your way down to the bottom, summon Edgar outside the boss room and then kill the boss Leonine Misbegotten to obtain the Legendary Weapon, the Grafted Greatsword.">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_82" id="item_82">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="playthrough_82" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_82">Go back to Edgar where he was on the tower and exhaust his dialogue.</label>
+                    <a class="ms-2" href="/map.html?x=4078&amp;y=8627&amp;id=playthrough_82&amp;link=/checklists/walkthrough.html%23item_82&amp;title=Go back to Edgar where he was on the tower and exhaust his dialogue.">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_83" id="item_83">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="playthrough_83" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_83">Return to Irina's location near the Bridge of Sacrifice Grace, talk to Edgar and exhaust his dialogue.</label>
+                    <a class="ms-2" href="/map.html?x=4378&amp;y=7843&amp;id=playthrough_83&amp;link=/checklists/walkthrough.html%23item_83&amp;title=Return to Irina's location near the Bridge of Sacrifice Grace, talk to Edgar and exhaust his dialogue.">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_84" id="item_84">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="playthrough_84" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_84">Weeping Peninsula is now 100% safe to explore! There should be no warnings required!</label>
+                    <a class="ms-2" href="/map.html?x=4378&amp;y=7843&amp;id=playthrough_84&amp;link=/checklists/walkthrough.html%23item_84&amp;title=Weeping Peninsula is now 100% safe to explore! There should be no warnings required!">
+                      <i class="bi bi-geo-alt"></i>
+                    </a>
                   </div>
                 </li>
               </ul>


### PR DESCRIPTION
Added all map locations for Weeping Peninsula.

It would be nice to split some steps into smaller steps or have multiple coordinates in one step. For example:
> Starting at the Agheel Lake South Grace in South-East Limgrave, follow the road South-East and cross the Bridge of Sacrifice to grab the Bridge of Sacrifice Grace.

I've set the map_link to the Bridge of Sacrifice Grace, but it would be easier to follow if there were two pins or just two steps.