### PR TITLE
Fixes for item links

### DIFF
--- a/data/checklists/bosses.yaml
+++ b/data/checklists/bosses.yaml
@@ -447,7 +447,7 @@ sections:
       - id: "6_10"
         data: ["Black Knife Assassin", "Sainted Hero's Grave (Entrance)", "10,800 runes, Black Knife Dagger", ""]
       - id: "6_20"
-        data: ["Duelist (Shadow)", "Sainted Hero's Grave", "Duelist Greataxe", "In the room with Prattling Pate. Must be defeated to unlock the boss door."] #TODO: ADD RUNES
+        data: ["Duelist (Shadow)", "Sainted Hero's Grave", "", "In the room with Prattling Pate. Must be defeated to unlock the boss door."] #TODO: ADD RUNES
       - id: "6_11"
         data: ["Ancient Hero of Zamor", "Sainted Hero's Grave", "24,000 runes, Ancient Dragon Knight Kristoff Ashes (Legendary)", ""]
       - id: "6_18"

--- a/data/pages.yaml
+++ b/data/pages.yaml
@@ -266,7 +266,6 @@ item_links:
   - link_all: [bosses_6_7, crystal_tears_4_2, crystal_tears_4_3] #WORMFACE/SPECKLED HARDTEAR/CRIMSONSPILL CRYSTAL TEAR
   - link_all: [bosses_6_8, weapons_18_3, incantations_9_6] #GODSKIN APOSTLE/GODSKIN PEELER TWINBLADE/SCOURING BLACK FLAME INCANTATION
   - link_all: [bosses_6_9, caves_4_2, bell_bearings_2_2] #CRYSTALIAN (SPEAR & RINGBLADE)/ALTUS TUNNEL/SOMBERSTONE MINER'S BELL BEARING [2]
-  - link_all: [bosses_6_20, weapons_6_5] #DUELIST/DUELIST GREATAXE
   - source: caves_4_4
     target: [bosses_6_11] #SAINTED HERO'S GRAVE/ANCIENT HERO OF ZAMOR
   - source_and: [bosses_6_10, bosses_6_11]

--- a/data/pages.yaml
+++ b/data/pages.yaml
@@ -257,7 +257,7 @@ item_links:
     target: caves_5_2 #NECROMANCER GARRIS & BLACK KNIFE ASSASSIN/SAGE'S CAVE
   - link_all: [bosses_7_4, weapons_21_4] #NECROMANCER GARRIS/FAMILY HEADS FLAIL
   - link_all: [bosses_6_17, talismans_6_10] #BLACK KNIFE ASSASSIN (SAGE'S CAVE)/CONCEILING VEIL TALISMAN
-  - link_all: [bosses_7_6, caves_4_1, weapons_22_2] #STONEDIGGER TROLL/OLD ALTUS TUNNEL/GREAT CLUB
+  - link_all: [bosses_7_6, caves_4_1, weapons_6_3] #STONEDIGGER TROLL/OLD ALTUS TUNNEL/GREAT CLUB
   - link_all: [bosses_6_2, ashesofwar_12_10] #NIGHT'S CAVALRY/AOW: SHARED ORDER
   - link_all: [bosses_6_3, talismans_6_3] #DEMI-HUMAN QUEEN GILIKA/RITUAL SWORD TALISMAN (CHEST IN NEXT ROOM)
   - link_all: [bosses_6_4, crystal_tears_4_1, weapons_18_6] #ELEONORA/PURIFYING CRYSTAL TEAR/ELEONORA'S POLEBLADE

--- a/docs/checklists/bosses.html
+++ b/docs/checklists/bosses.html
@@ -5350,7 +5350,7 @@
                           <label class="form-check-label item_content ms-0 ps-0" for="bosses_6_20">Sainted Hero's Grave</label>
                         </div>
                         <div class="ms-0 ps-0 d-flex align-items-center col-md-4">
-                          <label class="form-check-label item_content ms-0 ps-0" for="bosses_6_20">Duelist Greataxe</label>
+                          <label class="form-check-label item_content ms-0 ps-0" for="bosses_6_20"></label>
                         </div>
                         <div class="ms-0 ps-0 d-flex align-items-center col-md-4">
                           <label class="form-check-label item_content ms-0 ps-0" for="bosses_6_20">In the room with Prattling Pate. Must be defeated to unlock the boss door.</label>
@@ -5361,7 +5361,6 @@
                       <label class="form-check-label item_content ms-0 ps-0" for="bosses_6_20">
                         <strong class="me-1">Name: </strong>Duelist (Shadow)<br>
                         <strong class="me-1">Location: </strong>Sainted Hero's Grave<br>
-                        <strong class="me-1">Drops: </strong>Duelist Greataxe<br>
                         <strong class="me-1">Notes: </strong>In the room with Prattling Pate. Must be defeated to unlock the boss door.<br>
                       </label>
                     </div>

--- a/docs/js/item_links.js
+++ b/docs/js/item_links.js
@@ -1943,11 +1943,6 @@ const item_links = {
       "ashesofwar_12_10"
     ]
   },
-  "bosses_6_20": {
-    "targets": [
-      "weapons_6_5"
-    ]
-  },
   "bosses_6_3": {
     "targets": [
       "talismans_6_3"
@@ -2102,7 +2097,7 @@ const item_links = {
   "bosses_7_6": {
     "targets": [
       "caves_4_1",
-      "weapons_22_2"
+      "weapons_6_3"
     ]
   },
   "bosses_7_7": {
@@ -2499,7 +2494,7 @@ const item_links = {
   "caves_4_1": {
     "targets": [
       "bosses_7_6",
-      "weapons_22_2"
+      "weapons_6_3"
     ]
   },
   "caves_4_2": {
@@ -5541,12 +5536,6 @@ const item_links = {
       "legendaries_1_1"
     ]
   },
-  "weapons_22_2": {
-    "targets": [
-      "bosses_7_6",
-      "caves_4_1"
-    ]
-  },
   "weapons_23_11": {
     "targets": [
       "bosses_7_20"
@@ -5756,9 +5745,10 @@ const item_links = {
       "bosses_7_21"
     ]
   },
-  "weapons_6_5": {
+  "weapons_6_3": {
     "targets": [
-      "bosses_6_20"
+      "bosses_7_6",
+      "caves_4_1"
     ]
   },
   "weapons_6_6": {

--- a/docs/search.html
+++ b/docs/search.html
@@ -6984,14 +6984,13 @@
               <div class="row d-md-flex d-none">
                 <div class="d-flex align-items-center col-md-2">Duelist (Shadow)</div>
                 <div class="d-flex align-items-center col-md-2">Sainted Hero's Grave</div>
-                <div class="d-flex align-items-center col-md-4">Duelist Greataxe</div>
+                <div class="d-flex align-items-center col-md-4"></div>
                 <div class="d-flex align-items-center col-md-4">In the room with Prattling Pate. Must be defeated to unlock the boss door.</div>
               </div>
               <div class="row d-md-none">
                 <div class="col">
                   <strong class="me-1">Name: </strong>Duelist (Shadow)<br>
                   <strong class="me-1">Location: </strong>Sainted Hero's Grave<br>
-                  <strong class="me-1">Drops: </strong>Duelist Greataxe<br>
                   <strong class="me-1">Notes: </strong>In the room with Prattling Pate. Must be defeated to unlock the boss door.<br>
                 </div>
               </div>

--- a/docs/search_index.json
+++ b/docs/search_index.json
@@ -5945,7 +5945,7 @@
   },
   {
     "id": "/checklists/bosses.html#item_6_20",
-    "text": "Duelist (Shadow) Sainted Hero's Grave Duelist Greataxe In the room with Prattling Pate. Must be defeated to unlock the boss door."
+    "text": "Duelist (Shadow) Sainted Hero's Grave  In the room with Prattling Pate. Must be defeated to unlock the boss door."
   },
   {
     "id": "/checklists/bosses.html#item_6_11",


### PR DESCRIPTION
This PR has a couple of fixes for item links:
-  The stonedigger troll in Old Altus Tunnel drops the Great Club not the Curved Great Club
- The Duelist (Shadow) in Sainted Hero's Grave does not drop the Duelist Greataxe