### PR TITLE
Add DLC filter to Cookbooks page

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.png binary
+
+docs/checklists/*.html linguist-generated=true

--- a/.gitatttributes
+++ b/.gitatttributes
@@ -1,1 +1,0 @@
-*.png binary

--- a/.github/workflows/check-generated.yml
+++ b/.github/workflows/check-generated.yml
@@ -1,0 +1,42 @@
+name: Check generated HTML is up to date
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  check:
+    name: Regenerate and diff
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run generator
+        run: python generate.py
+
+      - name: Fail if generated files differ from committed files
+        run: |
+          if ! git diff --exit-code docs/; then
+            echo ""
+            echo "──────────────────────────────────────────────────────"
+            echo "ERROR: The generated HTML files are out of sync."
+            echo "You edited a YAML file but did not re-run generate.py."
+            echo ""
+            echo "Fix: run  python generate.py  locally, then commit the"
+            echo "updated files in docs/ together with your YAML changes."
+            echo "──────────────────────────────────────────────────────"
+            exit 1
+          fi

--- a/.github/workflows/check-generated.yml
+++ b/.github/workflows/check-generated.yml
@@ -1,4 +1,4 @@
-name: Check generated HTML is up to date
+name: Keep generated HTML in sync
 
 on:
   pull_request:
@@ -6,14 +6,22 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
-  check:
-    name: Regenerate and diff
+  sync:
+    name: Regenerate HTML if needed
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          # Check out the actual branch, not the merge commit,
+          # so we can push back to it if needed.
+          ref: ${{ github.head_ref || github.ref_name }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -27,16 +35,15 @@ jobs:
       - name: Run generator
         run: python generate.py
 
-      - name: Fail if generated files differ from committed files
+      - name: Commit regenerated HTML if out of sync
         run: |
-          if ! git diff --exit-code docs/; then
-            echo ""
-            echo "──────────────────────────────────────────────────────"
-            echo "ERROR: The generated HTML files are out of sync."
-            echo "You edited a YAML file but did not re-run generate.py."
-            echo ""
-            echo "Fix: run  python generate.py  locally, then commit the"
-            echo "updated files in docs/ together with your YAML changes."
-            echo "──────────────────────────────────────────────────────"
-            exit 1
+          if ! git diff --exit-code docs/ > /dev/null 2>&1; then
+            git config user.name  "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add docs/
+            git commit -m "Auto-regenerate HTML from YAML changes [skip ci]"
+            git push
+            echo "Regenerated and committed updated HTML."
+          else
+            echo "HTML is already in sync, nothing to commit."
           fi

--- a/data/checklists/cookbooks.yaml
+++ b/data/checklists/cookbooks.yaml
@@ -280,6 +280,7 @@ sections:
         map_title: "Frenzied's Cookbook [2]"
   -
     title: Forager Brood Cookbook
+    dlc: true
     icon: "/img/icons/keys/cookbooks/edited/03855.png"
     items:
       - id: "10_1"
@@ -298,6 +299,7 @@ sections:
         data: ["7. Acquired by selecting the option \"Talk to Moore\" when speaking with Moore. Requires having all of the other Forager Brood Cookbooks.<br><span style=\"color: #ff0000;\">NOTE:</span><strong> </strong>You can lock yourself out of the Forager Brood Cookbooks if Moore dies during his questline, and will not be able to pick them up anymore."]
   -
     title: Igon's Cookbook
+    dlc: true
     icon: "/img/icons/keys/cookbooks/edited/03840.png"
     items:
       - id: "11_1"
@@ -306,6 +308,7 @@ sections:
         data: ["2. Can be found at the edge of a cliff near the Jagged Peak Mountainside site of grace."]
   -
     title: Finger-Weaver's Cookbook
+    dlc: true
     icon: "/img/icons/keys/cookbooks/edited/01384.png"
     items:
       - id: "12_1"
@@ -314,6 +317,7 @@ sections:
         data: ["2. Found on a corpse before the bell in Finger Ruins of Miyr. Only accessible after progressing Ymir's questline and finding the secret path under the Catherdal."]
   -
     title: Greater Potentate's Cookbook
+    dlc: true
     icon: "/img/icons/keys/cookbooks/edited/03842.png"
     items:
       - id: "13_1"
@@ -346,6 +350,7 @@ sections:
         data: ["14. Going through the north-west path from the Charo's Hidden Grave grace, hug the water to the left until you stumble upon a corpse holding the cookbook, guarded by a large poison Miranda Flower and several smaller Miranda Flowers."]
   -
     title: Ancient Dragon Knight's Cookbook
+    dlc: true
     icon: "/img/icons/keys/cookbooks/edited/03837.png"
     items:
       - id: "14_1"
@@ -354,6 +359,7 @@ sections:
         data: ["2. Found in a chest in <strong>Scorpion River Catacombs</strong>. Right after the room with the annoying elevated sorcerer and two imps, you'll come across a bridge patrolled by more death eyes. You can drop off the side onto a path which eventually leads to the chest for this."]
   -
     title: Mad Craftsman's Cookbook
+    dlc: true
     icon: "/img/icons/keys/cookbooks/edited/03843.png"
     items:
       - id: "15_1"
@@ -364,6 +370,7 @@ sections:
         data: ["3. Found in Midra's Manse, just before the second site of grace. Walk across the rafters and jump into a room filled with frenzy rats. The cookbook is found on a body in that room."]
   -
     title: St. Trina Disciple's Cookbook
+    dlc: true
     icon: "/img/icons/keys/cookbooks/edited/03841.png"
     items:
       - id: "16_1"
@@ -374,6 +381,7 @@ sections:
         data: ["3. Found in the Garden of Deep Purple after defeating the Putrescent Knight. The cookbook is inside the small cave nearby."]
   -
     title: Fire Knight's Cookbook
+    dlc: true
     icon: "/img/icons/keys/cookbooks/edited/03836.png"
     items:
       - id: "17_1"
@@ -382,12 +390,14 @@ sections:
         data: ["2. In the soldier camp past Ellac Greatbridge, found inside one of the tents. Beware of the black knight in the area."]
   -
     title: Loyal Knight's Cookbook
+    dlc: true
     icon: "/img/icons/keys/cookbooks/edited/03838.png"
     items:
       - id: "18_1"
         data: ["The Loyal Knight's Cookbook can be found inside a chest. The chest is located inside an armory room."]
   -
     title: Battlefield Priest's Cookbook
+    dlc: true
     icon: "/img/icons/keys/cookbooks/edited/03839.png"
     items:
       - id: "19_1"
@@ -400,6 +410,7 @@ sections:
         data: ["4. Shadow Keep: Take the left lift down from the Storehouse, first floor site of grace. take the first exit to the right and continue forwad until the end of thehallway. Kill the enemy, and take the left route, hit the wall to reveal a path. The Battlefield Priest's Cookbook 4] is on a corpse, after the revealed hidden door."]
   -
     title: Grave Keeper's Cookbook
+    dlc: true
     icon: "/img/icons/keys/cookbooks/edited/03844.png"
     items:
       - id: "20_1"
@@ -408,6 +419,7 @@ sections:
         data: ["2. Located shortly after entering Charo's Hidden Grave. It's by a pile of rocks and turtles when you first reach the water."]
   -
     title: Antiquity Scholar's Cookbook
+    dlc: true
     icon: "/img/icons/keys/cookbooks/edited/03845.png"
     items:
       - id: "21_1"
@@ -416,6 +428,7 @@ sections:
         data: ["2. From the entrance of the Ancient Ruins of Rauh, head north towards the edge, and head west, you will find an area with an item below in which you can jump."]
   -
     title: Tibia's Cookbook
+    dlc: true
     icon: "/img/icons/keys/cookbooks/edited/03852.png"
     items:
       - id: "22_1"

--- a/docs/checklists/achievements.html
+++ b/docs/checklists/achievements.html
@@ -27,14 +27,10 @@
         <a class="navbar-brand me-auto ms-2" href="/index.html">Roundtable Guides</a>
         <form class="d-none d-sm-flex order-2 order-xl-3">
           <input aria-label="search" class="form-control me-2" name="search" placeholder="Search" type="search">
-          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit">
-            <i class="bi bi-search"></i>
-          </button>
+          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit"><i class="bi bi-search"></i></button>
         </form>
         <div class="d-sm-none order-2">
-          <a class="nav-link me-0" href="/search.html">
-            <i class="bi bi-search sb-icon-search"></i>
-          </a>
+          <a class="nav-link me-0" href="/search.html"><i class="bi bi-search sb-icon-search"></i></a>
         </div>
         <div class="collapse navbar-collapse order-3 order-xl-2 ms-xl-2" id="nav-collapse">
           <ul class="nav navbar-nav navbar-nav-scroll mr-auto">
@@ -179,14 +175,10 @@
               </ul>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/map.html">
-                <i class="bi bi-map"></i> Map
-              </a>
+              <a class="nav-link hide-buttons" href="/map.html"><i class="bi bi-map"></i> Map</a>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/options.html">
-                <i class="bi bi-gear-fill"></i> Options
-              </a>
+              <a class="nav-link hide-buttons" href="/options.html"><i class="bi bi-gear-fill"></i> Options</a>
             </li>
           </ul>
         </div>
@@ -206,9 +198,7 @@
       </div>
       <nav class="text-muted toc d-print-none">
         <strong class="d-block h5">
-          <a class="toc-button" data-bs-toggle="collapse" href="#toc_achievements" role="button">
-            <i class="bi bi-plus-lg"></i>Table Of Contents
-          </a>
+          <a class="toc-button" data-bs-toggle="collapse" href="#toc_achievements" role="button"><i class="bi bi-plus-lg"></i>Table Of Contents</a>
         </strong>
         <ul class="toc_page collapse" id="toc_achievements">
           <li>
@@ -236,9 +226,7 @@
         <div class="card shadow-sm mb-3" id="achievements_section_0">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#achievements_0Col" data-bs-toggle="collapse" href="#achievements_0Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#achievements_0Col" data-bs-toggle="collapse" href="#achievements_0Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Shardbearers</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="achievements_totals_0"></span>
             </h4>
@@ -250,9 +238,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -281,9 +267,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="achievements_1_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=achievements_1_1&amp;id=achievements_1_1&amp;link=/checklists/achievements.html%23item_1_1&amp;title=Shardbearer Godrick">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=achievements_1_1&amp;id=achievements_1_1&amp;link=/checklists/achievements.html%23item_1_1&amp;title=Shardbearer Godrick"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -316,9 +300,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="achievements_1_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=achievements_1_2&amp;id=achievements_1_2&amp;link=/checklists/achievements.html%23item_1_2&amp;title=Shardbearer Radahn">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=achievements_1_2&amp;id=achievements_1_2&amp;link=/checklists/achievements.html%23item_1_2&amp;title=Shardbearer Radahn"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -351,9 +333,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="achievements_1_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=achievements_1_3&amp;id=achievements_1_3&amp;link=/checklists/achievements.html%23item_1_3&amp;title=Shardbearer Morgott">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=achievements_1_3&amp;id=achievements_1_3&amp;link=/checklists/achievements.html%23item_1_3&amp;title=Shardbearer Morgott"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -386,9 +366,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="achievements_1_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=achievements_1_4&amp;id=achievements_1_4&amp;link=/checklists/achievements.html%23item_1_4&amp;title=Shardbearer Rykard">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=achievements_1_4&amp;id=achievements_1_4&amp;link=/checklists/achievements.html%23item_1_4&amp;title=Shardbearer Rykard"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -421,9 +399,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="achievements_1_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=achievements_1_5&amp;id=achievements_1_5&amp;link=/checklists/achievements.html%23item_1_5&amp;title=Shardbearer Mohg">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=achievements_1_5&amp;id=achievements_1_5&amp;link=/checklists/achievements.html%23item_1_5&amp;title=Shardbearer Mohg"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -456,9 +432,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="achievements_1_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=achievements_1_6&amp;id=achievements_1_6&amp;link=/checklists/achievements.html%23item_1_6&amp;title=Shardbearer Malenia">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=achievements_1_6&amp;id=achievements_1_6&amp;link=/checklists/achievements.html%23item_1_6&amp;title=Shardbearer Malenia"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -492,9 +466,7 @@
         <div class="card shadow-sm mb-3" id="achievements_section_1">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#achievements_1Col" data-bs-toggle="collapse" href="#achievements_1Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#achievements_1Col" data-bs-toggle="collapse" href="#achievements_1Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Other Bosses</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="achievements_totals_1"></span>
             </h4>
@@ -506,9 +478,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -537,9 +507,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="achievements_2_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=achievements_2_1&amp;id=achievements_2_1&amp;link=/checklists/achievements.html%23item_2_1&amp;title=Margit, the Fell Omen">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=achievements_2_1&amp;id=achievements_2_1&amp;link=/checklists/achievements.html%23item_2_1&amp;title=Margit, the Fell Omen"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -572,9 +540,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="achievements_2_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=achievements_2_2&amp;id=achievements_2_2&amp;link=/checklists/achievements.html%23item_2_2&amp;title=Leonine Misbegotten">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=achievements_2_2&amp;id=achievements_2_2&amp;link=/checklists/achievements.html%23item_2_2&amp;title=Leonine Misbegotten"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -606,9 +572,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="achievements_2_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=achievements_2_3&amp;id=achievements_2_3&amp;link=/checklists/achievements.html%23item_2_3&amp;title=Red Wolf of Radagon">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=achievements_2_3&amp;id=achievements_2_3&amp;link=/checklists/achievements.html%23item_2_3&amp;title=Red Wolf of Radagon"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -641,9 +605,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="achievements_2_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=achievements_2_4&amp;id=achievements_2_4&amp;link=/checklists/achievements.html%23item_2_4&amp;title=Rennala, Queen of the Full Moon">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=achievements_2_4&amp;id=achievements_2_4&amp;link=/checklists/achievements.html%23item_2_4&amp;title=Rennala, Queen of the Full Moon"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -675,9 +637,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="achievements_2_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=achievements_2_5&amp;id=achievements_2_5&amp;link=/checklists/achievements.html%23item_2_5&amp;title=Royal Knight Loretta">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=achievements_2_5&amp;id=achievements_2_5&amp;link=/checklists/achievements.html%23item_2_5&amp;title=Royal Knight Loretta"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -710,9 +670,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="achievements_2_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=achievements_2_6&amp;id=achievements_2_6&amp;link=/checklists/achievements.html%23item_2_6&amp;title=Magma Wyrm Makar">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=achievements_2_6&amp;id=achievements_2_6&amp;link=/checklists/achievements.html%23item_2_6&amp;title=Magma Wyrm Makar"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -744,9 +702,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="achievements_2_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=achievements_2_7&amp;id=achievements_2_7&amp;link=/checklists/achievements.html%23item_2_7&amp;title=Ancestor Spirit">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=achievements_2_7&amp;id=achievements_2_7&amp;link=/checklists/achievements.html%23item_2_7&amp;title=Ancestor Spirit"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -778,9 +734,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="achievements_2_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=achievements_2_8&amp;id=achievements_2_8&amp;link=/checklists/achievements.html%23item_2_8&amp;title=Mimic Tear">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=achievements_2_8&amp;id=achievements_2_8&amp;link=/checklists/achievements.html%23item_2_8&amp;title=Mimic Tear"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -812,9 +766,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="achievements_2_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=achievements_2_9&amp;id=achievements_2_9&amp;link=/checklists/achievements.html%23item_2_9&amp;title=Godfrey, the First Lord">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=achievements_2_9&amp;id=achievements_2_9&amp;link=/checklists/achievements.html%23item_2_9&amp;title=Godfrey, the First Lord"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -847,9 +799,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="achievements_2_10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=achievements_2_10&amp;id=achievements_2_10&amp;link=/checklists/achievements.html%23item_2_10&amp;title=Dragonkin Soldier of Nokstella">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=achievements_2_10&amp;id=achievements_2_10&amp;link=/checklists/achievements.html%23item_2_10&amp;title=Dragonkin Soldier of Nokstella"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -881,9 +831,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="achievements_2_11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=achievements_2_11&amp;id=achievements_2_11&amp;link=/checklists/achievements.html%23item_2_11&amp;title=Astel, Naturalborn of the Void">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=achievements_2_11&amp;id=achievements_2_11&amp;link=/checklists/achievements.html%23item_2_11&amp;title=Astel, Naturalborn of the Void"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -916,9 +864,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="achievements_2_12" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=achievements_2_12&amp;id=achievements_2_12&amp;link=/checklists/achievements.html%23item_2_12&amp;title=Regal Ancestor Spirit">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=achievements_2_12&amp;id=achievements_2_12&amp;link=/checklists/achievements.html%23item_2_12&amp;title=Regal Ancestor Spirit"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -950,9 +896,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="achievements_2_13" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=achievements_2_13&amp;id=achievements_2_13&amp;link=/checklists/achievements.html%23item_2_13&amp;title=Valiant Gargoyle">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=achievements_2_13&amp;id=achievements_2_13&amp;link=/checklists/achievements.html%23item_2_13&amp;title=Valiant Gargoyle"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -984,9 +928,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="achievements_2_14" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=achievements_2_14&amp;id=achievements_2_14&amp;link=/checklists/achievements.html%23item_2_14&amp;title=Elemer of the Briar">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=achievements_2_14&amp;id=achievements_2_14&amp;link=/checklists/achievements.html%23item_2_14&amp;title=Elemer of the Briar"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1018,9 +960,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="achievements_2_15" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=achievements_2_15&amp;id=achievements_2_15&amp;link=/checklists/achievements.html%23item_2_15&amp;title=Godskin Noble">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=achievements_2_15&amp;id=achievements_2_15&amp;link=/checklists/achievements.html%23item_2_15&amp;title=Godskin Noble"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1052,9 +992,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="achievements_2_16" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=achievements_2_16&amp;id=achievements_2_16&amp;link=/checklists/achievements.html%23item_2_16&amp;title=Commander Niall">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=achievements_2_16&amp;id=achievements_2_16&amp;link=/checklists/achievements.html%23item_2_16&amp;title=Commander Niall"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1086,9 +1024,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="achievements_2_17" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=achievements_2_17&amp;id=achievements_2_17&amp;link=/checklists/achievements.html%23item_2_17&amp;title=Fire Giant">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=achievements_2_17&amp;id=achievements_2_17&amp;link=/checklists/achievements.html%23item_2_17&amp;title=Fire Giant"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1121,9 +1057,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="achievements_2_18" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=achievements_2_18&amp;id=achievements_2_18&amp;link=/checklists/achievements.html%23item_2_18&amp;title=Godskin Duo">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=achievements_2_18&amp;id=achievements_2_18&amp;link=/checklists/achievements.html%23item_2_18&amp;title=Godskin Duo"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1156,9 +1090,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="achievements_2_19" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=achievements_2_19&amp;id=achievements_2_19&amp;link=/checklists/achievements.html%23item_2_19&amp;title=Loretta, Knight of the Haligtree">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=achievements_2_19&amp;id=achievements_2_19&amp;link=/checklists/achievements.html%23item_2_19&amp;title=Loretta, Knight of the Haligtree"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1190,9 +1122,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="achievements_2_20" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=achievements_2_20&amp;id=achievements_2_20&amp;link=/checklists/achievements.html%23item_2_20&amp;title=Maliketh, the Black Blade">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=achievements_2_20&amp;id=achievements_2_20&amp;link=/checklists/achievements.html%23item_2_20&amp;title=Maliketh, the Black Blade"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1225,9 +1155,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="achievements_2_21" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=achievements_2_21&amp;id=achievements_2_21&amp;link=/checklists/achievements.html%23item_2_21&amp;title=Hoarah Loux, the Warrior">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=achievements_2_21&amp;id=achievements_2_21&amp;link=/checklists/achievements.html%23item_2_21&amp;title=Hoarah Loux, the Warrior"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1260,9 +1188,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="achievements_2_22" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=achievements_2_22&amp;id=achievements_2_22&amp;link=/checklists/achievements.html%23item_2_22&amp;title=Mohg, the Omen">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=achievements_2_22&amp;id=achievements_2_22&amp;link=/checklists/achievements.html%23item_2_22&amp;title=Mohg, the Omen"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1294,9 +1220,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="achievements_2_23" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=achievements_2_23&amp;id=achievements_2_23&amp;link=/checklists/achievements.html%23item_2_23&amp;title=Dragonlord Placidusax">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=achievements_2_23&amp;id=achievements_2_23&amp;link=/checklists/achievements.html%23item_2_23&amp;title=Dragonlord Placidusax"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1328,9 +1252,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="achievements_2_24" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=achievements_2_24&amp;id=achievements_2_24&amp;link=/checklists/achievements.html%23item_2_24&amp;title=Lichdragon Fortissax">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=achievements_2_24&amp;id=achievements_2_24&amp;link=/checklists/achievements.html%23item_2_24&amp;title=Lichdragon Fortissax"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1364,9 +1286,7 @@
         <div class="card shadow-sm mb-3" id="achievements_section_2">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#achievements_2Col" data-bs-toggle="collapse" href="#achievements_2Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#achievements_2Col" data-bs-toggle="collapse" href="#achievements_2Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Misc.</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="achievements_totals_2"></span>
             </h4>
@@ -1378,9 +1298,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -1409,9 +1327,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="achievements_3_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=achievements_3_1&amp;id=achievements_3_1&amp;link=/checklists/achievements.html%23item_3_1&amp;title=Roundtable Hold">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=achievements_3_1&amp;id=achievements_3_1&amp;link=/checklists/achievements.html%23item_3_1&amp;title=Roundtable Hold"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1444,9 +1360,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="achievements_3_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=achievements_3_2&amp;id=achievements_3_2&amp;link=/checklists/achievements.html%23item_3_2&amp;title=God-Slaying Armament">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=achievements_3_2&amp;id=achievements_3_2&amp;link=/checklists/achievements.html%23item_3_2&amp;title=God-Slaying Armament"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1478,9 +1392,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="achievements_3_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=achievements_3_3&amp;id=achievements_3_3&amp;link=/checklists/achievements.html%23item_3_3&amp;title=Legendary Armaments">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=achievements_3_3&amp;id=achievements_3_3&amp;link=/checklists/achievements.html%23item_3_3&amp;title=Legendary Armaments"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1512,9 +1424,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="achievements_3_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=achievements_3_4&amp;id=achievements_3_4&amp;link=/checklists/achievements.html%23item_3_4&amp;title=Legendary Ashen Remains">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=achievements_3_4&amp;id=achievements_3_4&amp;link=/checklists/achievements.html%23item_3_4&amp;title=Legendary Ashen Remains"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1546,9 +1456,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="achievements_3_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=achievements_3_5&amp;id=achievements_3_5&amp;link=/checklists/achievements.html%23item_3_5&amp;title=Legendary Sorceries and Incantations">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=achievements_3_5&amp;id=achievements_3_5&amp;link=/checklists/achievements.html%23item_3_5&amp;title=Legendary Sorceries and Incantations"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1580,9 +1488,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="achievements_3_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=achievements_3_6&amp;id=achievements_3_6&amp;link=/checklists/achievements.html%23item_3_6&amp;title=Legendary Talismans">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=achievements_3_6&amp;id=achievements_3_6&amp;link=/checklists/achievements.html%23item_3_6&amp;title=Legendary Talismans"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1614,9 +1520,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="achievements_3_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=achievements_3_7&amp;id=achievements_3_7&amp;link=/checklists/achievements.html%23item_3_7&amp;title=Great Rune">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=achievements_3_7&amp;id=achievements_3_7&amp;link=/checklists/achievements.html%23item_3_7&amp;title=Great Rune"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1649,9 +1553,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="achievements_3_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=achievements_3_8&amp;id=achievements_3_8&amp;link=/checklists/achievements.html%23item_3_8&amp;title=Erdtree Aflame">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=achievements_3_8&amp;id=achievements_3_8&amp;link=/checklists/achievements.html%23item_3_8&amp;title=Erdtree Aflame"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1684,9 +1586,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="achievements_3_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=achievements_3_9&amp;id=achievements_3_9&amp;link=/checklists/achievements.html%23item_3_9&amp;title=Elden Ring">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=achievements_3_9&amp;id=achievements_3_9&amp;link=/checklists/achievements.html%23item_3_9&amp;title=Elden Ring"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1720,9 +1620,7 @@
         <div class="card shadow-sm mb-3" id="achievements_section_3">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#achievements_3Col" data-bs-toggle="collapse" href="#achievements_3Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#achievements_3Col" data-bs-toggle="collapse" href="#achievements_3Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Endings</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="achievements_totals_3"></span>
             </h4>
@@ -1734,9 +1632,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -1765,9 +1661,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="achievements_4_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=achievements_4_1&amp;id=achievements_4_1&amp;link=/checklists/achievements.html%23item_4_1&amp;title=Elden Lord">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=achievements_4_1&amp;id=achievements_4_1&amp;link=/checklists/achievements.html%23item_4_1&amp;title=Elden Lord"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1800,9 +1694,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="achievements_4_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=achievements_4_2&amp;id=achievements_4_2&amp;link=/checklists/achievements.html%23item_4_2&amp;title=Age of the Stars">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=achievements_4_2&amp;id=achievements_4_2&amp;link=/checklists/achievements.html%23item_4_2&amp;title=Age of the Stars"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1835,9 +1727,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="achievements_4_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=achievements_4_3&amp;id=achievements_4_3&amp;link=/checklists/achievements.html%23item_4_3&amp;title=Lord of Frenzied Flame">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=achievements_4_3&amp;id=achievements_4_3&amp;link=/checklists/achievements.html%23item_4_3&amp;title=Lord of Frenzied Flame"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">

--- a/docs/checklists/ancient_dragon_smithing_stones.html
+++ b/docs/checklists/ancient_dragon_smithing_stones.html
@@ -27,14 +27,10 @@
         <a class="navbar-brand me-auto ms-2" href="/index.html">Roundtable Guides</a>
         <form class="d-none d-sm-flex order-2 order-xl-3">
           <input aria-label="search" class="form-control me-2" name="search" placeholder="Search" type="search">
-          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit">
-            <i class="bi bi-search"></i>
-          </button>
+          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit"><i class="bi bi-search"></i></button>
         </form>
         <div class="d-sm-none order-2">
-          <a class="nav-link me-0" href="/search.html">
-            <i class="bi bi-search sb-icon-search"></i>
-          </a>
+          <a class="nav-link me-0" href="/search.html"><i class="bi bi-search sb-icon-search"></i></a>
         </div>
         <div class="collapse navbar-collapse order-3 order-xl-2 ms-xl-2" id="nav-collapse">
           <ul class="nav navbar-nav navbar-nav-scroll mr-auto">
@@ -179,14 +175,10 @@
               </ul>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/map.html">
-                <i class="bi bi-map"></i> Map
-              </a>
+              <a class="nav-link hide-buttons" href="/map.html"><i class="bi bi-map"></i> Map</a>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/options.html">
-                <i class="bi bi-gear-fill"></i> Options
-              </a>
+              <a class="nav-link hide-buttons" href="/options.html"><i class="bi bi-gear-fill"></i> Options</a>
             </li>
           </ul>
         </div>
@@ -206,9 +198,7 @@
       </div>
       <nav class="text-muted toc d-print-none">
         <strong class="d-block h5">
-          <a class="toc-button" data-bs-toggle="collapse" href="#toc_ancient_dragon_smithing_stones" role="button">
-            <i class="bi bi-plus-lg"></i>Table Of Contents
-          </a>
+          <a class="toc-button" data-bs-toggle="collapse" href="#toc_ancient_dragon_smithing_stones" role="button"><i class="bi bi-plus-lg"></i>Table Of Contents</a>
         </strong>
         <ul class="toc_page collapse" id="toc_ancient_dragon_smithing_stones">
           <li>
@@ -228,9 +218,7 @@
         <div class="card shadow-sm mb-3" id="ancient_dragon_smithing_stones_section_0">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#ancient_dragon_smithing_stones_0Col" data-bs-toggle="collapse" href="#ancient_dragon_smithing_stones_0Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#ancient_dragon_smithing_stones_0Col" data-bs-toggle="collapse" href="#ancient_dragon_smithing_stones_0Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <img class="me-1" data-src="/img/icons/bolstering/edited/02008.png" loading="lazy" style="height: 70px; width: 70px">
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Ancient+Dragon+Smithing+Stone">Ancient Dragon Smithing Stones</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="ancient_dragon_smithing_stones_totals_0"></span>
@@ -242,9 +230,7 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="ancient_dragon_smithing_stones_1" type="checkbox" value="">
                     <label class="form-check-label item_content" for="ancient_dragon_smithing_stones_1">Rewarded by <a href="https://eldenring.wiki.fextralife.com/Gurranq+Beast+Clergyman">Gurranq, Beast Clergyman</a>, after feeding him 9 <a href="https://eldenring.wiki.fextralife.com/Deathroot">Deathroot</a>. Alternatively, he will drop this stone when killed.</label>
-                    <a class="ms-2" href="/map.html?target=ancient_dragon_smithing_stones_1&amp;id=ancient_dragon_smithing_stones_1&amp;link=/checklists/ancient_dragon_smithing_stones.html%23item_1&amp;title=Rewarded by &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gurranq+Beast+Clergyman&quot;&gt;Gurranq, Beast Clergyman&lt;/a&gt;, after feeding him 9 &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Deathroot&quot;&gt;Deathroot&lt;/a&gt;. Alternatively, he will drop this stone when killed.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=ancient_dragon_smithing_stones_1&amp;id=ancient_dragon_smithing_stones_1&amp;link=/checklists/ancient_dragon_smithing_stones.html%23item_1&amp;title=Rewarded by &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gurranq+Beast+Clergyman&quot;&gt;Gurranq, Beast Clergyman&lt;/a&gt;, after feeding him 9 &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Deathroot&quot;&gt;Deathroot&lt;/a&gt;. Alternatively, he will drop this stone when killed."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -254,9 +240,7 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="ancient_dragon_smithing_stones_2" type="checkbox" value="">
                     <label class="form-check-label item_content" for="ancient_dragon_smithing_stones_2">Found on a corpse inside the mouth of a giant skull, just south-east of <a href="https://eldenring.wiki.fextralife.com/Church+of+Repose">Church of Repose</a>.</label>
-                    <a class="ms-2" href="/map.html?target=ancient_dragon_smithing_stones_2&amp;id=ancient_dragon_smithing_stones_2&amp;link=/checklists/ancient_dragon_smithing_stones.html%23item_2&amp;title=Found on a corpse inside the mouth of a giant skull, just south-east of &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Church+of+Repose&quot;&gt;Church of Repose&lt;/a&gt;.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=ancient_dragon_smithing_stones_2&amp;id=ancient_dragon_smithing_stones_2&amp;link=/checklists/ancient_dragon_smithing_stones.html%23item_2&amp;title=Found on a corpse inside the mouth of a giant skull, just south-east of &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Church+of+Repose&quot;&gt;Church of Repose&lt;/a&gt;."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -266,27 +250,21 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="ancient_dragon_smithing_stones_3" type="checkbox" value="">
                     <label class="form-check-label item_content" for="ancient_dragon_smithing_stones_3">Dropped from the two <a href="https://eldenring.wiki.fextralife.com/Night's+Cavalry">Night's Cavalry</a> (Only spawn at night) escorting a troll-drawn carriage just south-west of the <a href="https://eldenring.wiki.fextralife.com/Interactive+Map?id=4578&lat=-73.563&lng=141.781&zoom=8&code=mapA">Inner Consecrated Snowfield</a> grace site.</label>
-                    <a class="ms-2" href="/map.html?target=ancient_dragon_smithing_stones_3&amp;id=ancient_dragon_smithing_stones_3&amp;link=/checklists/ancient_dragon_smithing_stones.html%23item_3&amp;title=Dropped from the two &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Night's+Cavalry&quot;&gt;Night's Cavalry&lt;/a&gt; (Only spawn at night) escorting a troll-drawn carriage just south-west of the &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Interactive+Map?id=4578&amp;lat=-73.563&amp;lng=141.781&amp;zoom=8&amp;code=mapA&quot;&gt;Inner Consecrated Snowfield&lt;/a&gt; grace site.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=ancient_dragon_smithing_stones_3&amp;id=ancient_dragon_smithing_stones_3&amp;link=/checklists/ancient_dragon_smithing_stones.html%23item_3&amp;title=Dropped from the two &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Night's+Cavalry&quot;&gt;Night's Cavalry&lt;/a&gt; (Only spawn at night) escorting a troll-drawn carriage just south-west of the &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Interactive+Map?id=4578&amp;lat=-73.563&amp;lng=141.781&amp;zoom=8&amp;code=mapA&quot;&gt;Inner Consecrated Snowfield&lt;/a&gt; grace site."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="ancient_dragon_smithing_stones_4" id="item_4">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="ancient_dragon_smithing_stones_4" type="checkbox" value="">
                     <label class="form-check-label item_content" for="ancient_dragon_smithing_stones_4">Found at the east end of the frozen river on a ledge at bottom of the frozen waterfall, just past <a href="https://eldenring.wiki.fextralife.com/Interactive+Map?id=4656&lat=-69.554687&lng=150.321074&zoom=8&code=mapA">Great Wyrm Theodorix</a>.</label>
-                    <a class="ms-2" href="/map.html?target=ancient_dragon_smithing_stones_4&amp;id=ancient_dragon_smithing_stones_4&amp;link=/checklists/ancient_dragon_smithing_stones.html%23item_4&amp;title=Found at the east end of the frozen river on a ledge at bottom of the frozen waterfall, just past &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Interactive+Map?id=4656&amp;lat=-69.554687&amp;lng=150.321074&amp;zoom=8&amp;code=mapA&quot;&gt;Great Wyrm Theodorix&lt;/a&gt;.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=ancient_dragon_smithing_stones_4&amp;id=ancient_dragon_smithing_stones_4&amp;link=/checklists/ancient_dragon_smithing_stones.html%23item_4&amp;title=Found at the east end of the frozen river on a ledge at bottom of the frozen waterfall, just past &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Interactive+Map?id=4656&amp;lat=-69.554687&amp;lng=150.321074&amp;zoom=8&amp;code=mapA&quot;&gt;Great Wyrm Theodorix&lt;/a&gt;."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="ancient_dragon_smithing_stones_5" id="item_5">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="ancient_dragon_smithing_stones_5" type="checkbox" value="">
                     <label class="form-check-label item_content" for="ancient_dragon_smithing_stones_5"><a href="https://eldenring.wiki.fextralife.com/Yelough+Anix+Tunnel">Yelough Anix Tunnel</a>: While making your way through the dungeon, you will find a corpse sitting on an iceshard bridge, go down the ladder just to the right; the smithing stone can be found on a corpse just past the non-boss <a href="https://eldenring.wiki.fextralife.com/Alabaster+Lord">Alabaster Lord</a>.</label>
-                    <a class="ms-2" href="/map.html?target=ancient_dragon_smithing_stones_5&amp;id=ancient_dragon_smithing_stones_5&amp;link=/checklists/ancient_dragon_smithing_stones.html%23item_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Yelough+Anix+Tunnel&quot;&gt;Yelough Anix Tunnel&lt;/a&gt;: While making your way through the dungeon, you will find a corpse sitting on an iceshard bridge, go down the ladder just to the right; the smithing stone can be found on a corpse just past the non-boss &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Alabaster+Lord&quot;&gt;Alabaster Lord&lt;/a&gt;.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=ancient_dragon_smithing_stones_5&amp;id=ancient_dragon_smithing_stones_5&amp;link=/checklists/ancient_dragon_smithing_stones.html%23item_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Yelough+Anix+Tunnel&quot;&gt;Yelough Anix Tunnel&lt;/a&gt;: While making your way through the dungeon, you will find a corpse sitting on an iceshard bridge, go down the ladder just to the right; the smithing stone can be found on a corpse just past the non-boss &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Alabaster+Lord&quot;&gt;Alabaster Lord&lt;/a&gt;."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -296,18 +274,14 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="ancient_dragon_smithing_stones_6" type="checkbox" value="">
                     <label class="form-check-label item_content" for="ancient_dragon_smithing_stones_6">Looted from a corpse just below a hugging statue, north of the <a href="https://eldenring.wiki.fextralife.com/Interactive+Map?id=4454&lat=-42.99&lng=147.24&zoom=8&code=mapA">Haligtree Town Plaza</a> grace site. The stone is guarded by two winged and one red-maned <a href="https://eldenring.wiki.fextralife.com/Misbegotten">Misbegotten</a>.</label>
-                    <a class="ms-2" href="/map.html?target=ancient_dragon_smithing_stones_6&amp;id=ancient_dragon_smithing_stones_6&amp;link=/checklists/ancient_dragon_smithing_stones.html%23item_6&amp;title=Looted from a corpse just below a hugging statue, north of the &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Interactive+Map?id=4454&amp;lat=-42.99&amp;lng=147.24&amp;zoom=8&amp;code=mapA&quot;&gt;Haligtree Town Plaza&lt;/a&gt; grace site. The stone is guarded by two winged and one red-maned &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Misbegotten&quot;&gt;Misbegotten&lt;/a&gt;.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=ancient_dragon_smithing_stones_6&amp;id=ancient_dragon_smithing_stones_6&amp;link=/checklists/ancient_dragon_smithing_stones.html%23item_6&amp;title=Looted from a corpse just below a hugging statue, north of the &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Interactive+Map?id=4454&amp;lat=-42.99&amp;lng=147.24&amp;zoom=8&amp;code=mapA&quot;&gt;Haligtree Town Plaza&lt;/a&gt; grace site. The stone is guarded by two winged and one red-maned &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Misbegotten&quot;&gt;Misbegotten&lt;/a&gt;."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="ancient_dragon_smithing_stones_7" id="item_7">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="ancient_dragon_smithing_stones_7" type="checkbox" value="">
                     <label class="form-check-label item_content" for="ancient_dragon_smithing_stones_7">After defeating <a href="https://eldenring.wiki.fextralife.com/Loretta,+Knight+of+the+Haligtree">Loretta</a>, make your way down a long ladder and past (not down) the lift to find this stone in a chest.</label>
-                    <a class="ms-2" href="/map.html?target=ancient_dragon_smithing_stones_7&amp;id=ancient_dragon_smithing_stones_7&amp;link=/checklists/ancient_dragon_smithing_stones.html%23item_7&amp;title=After defeating &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Loretta,+Knight+of+the+Haligtree&quot;&gt;Loretta&lt;/a&gt;, make your way down a long ladder and past (not down) the lift to find this stone in a chest.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=ancient_dragon_smithing_stones_7&amp;id=ancient_dragon_smithing_stones_7&amp;link=/checklists/ancient_dragon_smithing_stones.html%23item_7&amp;title=After defeating &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Loretta,+Knight+of+the+Haligtree&quot;&gt;Loretta&lt;/a&gt;, make your way down a long ladder and past (not down) the lift to find this stone in a chest."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -317,27 +291,21 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="ancient_dragon_smithing_stones_8" type="checkbox" value="">
                     <label class="form-check-label item_content" for="ancient_dragon_smithing_stones_8">Dropped from the <a href="https://eldenring.wiki.fextralife.com/Farum+Azula+Dragon">Farum Azula Dragon</a> that swoops down as you make your way along the curved platform, near the beginning of the area between the <a href="https://eldenring.wiki.fextralife.com/Interactive+Map?id=5855&lat=-129.96875&lng=218.876914&zoom=8&code=mapA">Crumbling Beast Grave</a> and <a href="https://eldenring.wiki.fextralife.com/Interactive+Map?id=5855&lat=-129.96875&lng=218.876914&zoom=8&code=mapA">Crumbling Beast Grave Depths</a> grace sites.</label>
-                    <a class="ms-2" href="/map.html?target=ancient_dragon_smithing_stones_8&amp;id=ancient_dragon_smithing_stones_8&amp;link=/checklists/ancient_dragon_smithing_stones.html%23item_8&amp;title=Dropped from the &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Farum+Azula+Dragon&quot;&gt;Farum Azula Dragon&lt;/a&gt; that swoops down as you make your way along the curved platform, near the beginning of the area between the &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Interactive+Map?id=5855&amp;lat=-129.96875&amp;lng=218.876914&amp;zoom=8&amp;code=mapA&quot;&gt;Crumbling Beast Grave&lt;/a&gt; and &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Interactive+Map?id=5855&amp;lat=-129.96875&amp;lng=218.876914&amp;zoom=8&amp;code=mapA&quot;&gt;Crumbling Beast Grave Depths&lt;/a&gt; grace sites.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=ancient_dragon_smithing_stones_8&amp;id=ancient_dragon_smithing_stones_8&amp;link=/checklists/ancient_dragon_smithing_stones.html%23item_8&amp;title=Dropped from the &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Farum+Azula+Dragon&quot;&gt;Farum Azula Dragon&lt;/a&gt; that swoops down as you make your way along the curved platform, near the beginning of the area between the &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Interactive+Map?id=5855&amp;lat=-129.96875&amp;lng=218.876914&amp;zoom=8&amp;code=mapA&quot;&gt;Crumbling Beast Grave&lt;/a&gt; and &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Interactive+Map?id=5855&amp;lat=-129.96875&amp;lng=218.876914&amp;zoom=8&amp;code=mapA&quot;&gt;Crumbling Beast Grave Depths&lt;/a&gt; grace sites."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="ancient_dragon_smithing_stones_9" id="item_9">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="ancient_dragon_smithing_stones_9" type="checkbox" value="">
                     <label class="form-check-label item_content" for="ancient_dragon_smithing_stones_9">Starting from the <a href="https://eldenring.wiki.fextralife.com/Interactive+Map?id=4501&lat=-123.840626&lng=216.455498&zoom=8&code=mapA">Dragon Temple Altar</a> grace site, head north through the door way and make your way past the assorted <a href="https://eldenring.wiki.fextralife.com/Azula+Beastman">Azula Beastman</a> and dog enemies until you find yourself on a narrow platform lined with dragon statues. Head straight and near the end will be a spiral staircase you will climb up on your right. At the top of the staircase, turn left and jump across to the floating stone pillar. Carefully walk along the pillar and jump up to the platform. You can collect the stone near the ledge, guarded by a large beastman and dog.</label>
-                    <a class="ms-2" href="/map.html?target=ancient_dragon_smithing_stones_9&amp;id=ancient_dragon_smithing_stones_9&amp;link=/checklists/ancient_dragon_smithing_stones.html%23item_9&amp;title=Starting from the &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Interactive+Map?id=4501&amp;lat=-123.840626&amp;lng=216.455498&amp;zoom=8&amp;code=mapA&quot;&gt;Dragon Temple Altar&lt;/a&gt; grace site, head north through the door way and make your way past the assorted &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Azula+Beastman&quot;&gt;Azula Beastman&lt;/a&gt; and dog enemies until you find yourself on a narrow platform lined with dragon statues. Head straight and near the end will be a spiral staircase you will climb up on your right. At the top of the staircase, turn left and jump across to the floating stone pillar. Carefully walk along the pillar and jump up to the platform. You can collect the stone near the ledge, guarded by a large beastman and dog.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=ancient_dragon_smithing_stones_9&amp;id=ancient_dragon_smithing_stones_9&amp;link=/checklists/ancient_dragon_smithing_stones.html%23item_9&amp;title=Starting from the &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Interactive+Map?id=4501&amp;lat=-123.840626&amp;lng=216.455498&amp;zoom=8&amp;code=mapA&quot;&gt;Dragon Temple Altar&lt;/a&gt; grace site, head north through the door way and make your way past the assorted &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Azula+Beastman&quot;&gt;Azula Beastman&lt;/a&gt; and dog enemies until you find yourself on a narrow platform lined with dragon statues. Head straight and near the end will be a spiral staircase you will climb up on your right. At the top of the staircase, turn left and jump across to the floating stone pillar. Carefully walk along the pillar and jump up to the platform. You can collect the stone near the ledge, guarded by a large beastman and dog."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="ancient_dragon_smithing_stones_10" id="item_10">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="ancient_dragon_smithing_stones_10" type="checkbox" value="">
                     <label class="form-check-label item_content" for="ancient_dragon_smithing_stones_10">Dropped from the stationary <a href="https://eldenring.wiki.fextralife.com/Farum+Azula+Dragon">Farum Azula Dragon</a> sitting at the back of the plaza, south of the <a href="https://eldenring.wiki.fextralife.com/Interactive+Map?id=4355&lat=-119.546875&lng=218.221505&zoom=8&code=mapA">Dragon Temple Rooftop</a> grace site. The dragon will constantly rain down red lightning while the path is riddled with <a href="https://eldenring.wiki.fextralife.com/Warhawk">Warhawks</a>.</label>
-                    <a class="ms-2" href="/map.html?target=ancient_dragon_smithing_stones_10&amp;id=ancient_dragon_smithing_stones_10&amp;link=/checklists/ancient_dragon_smithing_stones.html%23item_10&amp;title=Dropped from the stationary &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Farum+Azula+Dragon&quot;&gt;Farum Azula Dragon&lt;/a&gt; sitting at the back of the plaza, south of the &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Interactive+Map?id=4355&amp;lat=-119.546875&amp;lng=218.221505&amp;zoom=8&amp;code=mapA&quot;&gt;Dragon Temple Rooftop&lt;/a&gt; grace site. The dragon will constantly rain down red lightning while the path is riddled with &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Warhawk&quot;&gt;Warhawks&lt;/a&gt;.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=ancient_dragon_smithing_stones_10&amp;id=ancient_dragon_smithing_stones_10&amp;link=/checklists/ancient_dragon_smithing_stones.html%23item_10&amp;title=Dropped from the stationary &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Farum+Azula+Dragon&quot;&gt;Farum Azula Dragon&lt;/a&gt; sitting at the back of the plaza, south of the &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Interactive+Map?id=4355&amp;lat=-119.546875&amp;lng=218.221505&amp;zoom=8&amp;code=mapA&quot;&gt;Dragon Temple Rooftop&lt;/a&gt; grace site. The dragon will constantly rain down red lightning while the path is riddled with &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Warhawk&quot;&gt;Warhawks&lt;/a&gt;."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -347,27 +315,21 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="ancient_dragon_smithing_stones_11" type="checkbox" value="">
                     <label class="form-check-label item_content" for="ancient_dragon_smithing_stones_11">Rewarded by <a href="https://eldenring.wiki.fextralife.com/Witch-Hunter+Jerren">Witch-Hunter Jerren</a> for siding with him at the end of <a href="https://eldenring.wiki.fextralife.com/Sorceress+Sellen">Sorceress Sellen's</a> questline just outside the <a href="https://eldenring.wiki.fextralife.com/Interactive+Map?id=5846&lat=-134&lng=55&zoom=8&code=mapA">Raya Lucaria Grand Library</a>.</label>
-                    <a class="ms-2" href="/map.html?target=ancient_dragon_smithing_stones_11&amp;id=ancient_dragon_smithing_stones_11&amp;link=/checklists/ancient_dragon_smithing_stones.html%23item_11&amp;title=Rewarded by &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Witch-Hunter+Jerren&quot;&gt;Witch-Hunter Jerren&lt;/a&gt; for siding with him at the end of &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Sorceress+Sellen&quot;&gt;Sorceress Sellen's&lt;/a&gt; questline just outside the &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Interactive+Map?id=5846&amp;lat=-134&amp;lng=55&amp;zoom=8&amp;code=mapA&quot;&gt;Raya Lucaria Grand Library&lt;/a&gt;.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=ancient_dragon_smithing_stones_11&amp;id=ancient_dragon_smithing_stones_11&amp;link=/checklists/ancient_dragon_smithing_stones.html%23item_11&amp;title=Rewarded by &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Witch-Hunter+Jerren&quot;&gt;Witch-Hunter Jerren&lt;/a&gt; for siding with him at the end of &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Sorceress+Sellen&quot;&gt;Sorceress Sellen's&lt;/a&gt; questline just outside the &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Interactive+Map?id=5846&amp;lat=-134&amp;lng=55&amp;zoom=8&amp;code=mapA&quot;&gt;Raya Lucaria Grand Library&lt;/a&gt;."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="ancient_dragon_smithing_stones_12" id="item_12">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="ancient_dragon_smithing_stones_12" type="checkbox" value="">
                     <label class="form-check-label item_content" for="ancient_dragon_smithing_stones_12">Rewarded by <a href="https://eldenring.wiki.fextralife.com/Nepheli+Loux">Nepheli Loux</a> in Godrick's Throneroom (just past the <a href="https://eldenring.wiki.fextralife.com/Interactive+Map?id=1129&lat=-173.910938&lng=85.500353&zoom=8&code=mapA">Godrick the Grafted</a> grace site) after completing <a href="https://eldenring.wiki.fextralife.com/Kenneth+Haight">Kenneth Haight's</a> Lord of Limgrave questline. Unobtainable if <a href="https://eldenring.wiki.fextralife.com/Seluvis's+Potion">Seluvis's Potion</a> was given to Nepheli.</label>
-                    <a class="ms-2" href="/map.html?target=ancient_dragon_smithing_stones_12&amp;id=ancient_dragon_smithing_stones_12&amp;link=/checklists/ancient_dragon_smithing_stones.html%23item_12&amp;title=Rewarded by &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Nepheli+Loux&quot;&gt;Nepheli Loux&lt;/a&gt; in Godrick's Throneroom (just past the &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Interactive+Map?id=1129&amp;lat=-173.910938&amp;lng=85.500353&amp;zoom=8&amp;code=mapA&quot;&gt;Godrick the Grafted&lt;/a&gt; grace site) after completing &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Kenneth+Haight&quot;&gt;Kenneth Haight's&lt;/a&gt; Lord of Limgrave questline. Unobtainable if &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Seluvis's+Potion&quot;&gt;Seluvis's Potion&lt;/a&gt; was given to Nepheli.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=ancient_dragon_smithing_stones_12&amp;id=ancient_dragon_smithing_stones_12&amp;link=/checklists/ancient_dragon_smithing_stones.html%23item_12&amp;title=Rewarded by &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Nepheli+Loux&quot;&gt;Nepheli Loux&lt;/a&gt; in Godrick's Throneroom (just past the &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Interactive+Map?id=1129&amp;lat=-173.910938&amp;lng=85.500353&amp;zoom=8&amp;code=mapA&quot;&gt;Godrick the Grafted&lt;/a&gt; grace site) after completing &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Kenneth+Haight&quot;&gt;Kenneth Haight's&lt;/a&gt; Lord of Limgrave questline. Unobtainable if &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Seluvis's+Potion&quot;&gt;Seluvis's Potion&lt;/a&gt; was given to Nepheli."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="ancient_dragon_smithing_stones_13" id="item_13">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="ancient_dragon_smithing_stones_13" type="checkbox" value="">
                     <label class="form-check-label item_content" for="ancient_dragon_smithing_stones_13">Purchased from <a href="https://eldenring.wiki.fextralife.com/Gatekeeper+Gostoc">Gatekeeper Gostoc</a> in Godrick's Throneroom (just past the <a href="https://eldenring.wiki.fextralife.com/Interactive+Map?id=1129&lat=-173.910938&lng=85.500353&zoom=8&code=mapA">Godrick the Grafted</a> grace site) after completing <a href="https://eldenring.wiki.fextralife.com/Kenneth+Haight">Kenneth Haight's</a> Lord of Limgrave questline. Unobtainable if <a href="https://eldenring.wiki.fextralife.com/Seluvis's+Potion">Seluvis's Potion</a> was given to Nepheli.</label>
-                    <a class="ms-2" href="/map.html?target=ancient_dragon_smithing_stones_13&amp;id=ancient_dragon_smithing_stones_13&amp;link=/checklists/ancient_dragon_smithing_stones.html%23item_13&amp;title=Purchased from &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gatekeeper+Gostoc&quot;&gt;Gatekeeper Gostoc&lt;/a&gt; in Godrick's Throneroom (just past the &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Interactive+Map?id=1129&amp;lat=-173.910938&amp;lng=85.500353&amp;zoom=8&amp;code=mapA&quot;&gt;Godrick the Grafted&lt;/a&gt; grace site) after completing &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Kenneth+Haight&quot;&gt;Kenneth Haight's&lt;/a&gt; Lord of Limgrave questline. Unobtainable if &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Seluvis's+Potion&quot;&gt;Seluvis's Potion&lt;/a&gt; was given to Nepheli.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=ancient_dragon_smithing_stones_13&amp;id=ancient_dragon_smithing_stones_13&amp;link=/checklists/ancient_dragon_smithing_stones.html%23item_13&amp;title=Purchased from &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gatekeeper+Gostoc&quot;&gt;Gatekeeper Gostoc&lt;/a&gt; in Godrick's Throneroom (just past the &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Interactive+Map?id=1129&amp;lat=-173.910938&amp;lng=85.500353&amp;zoom=8&amp;code=mapA&quot;&gt;Godrick the Grafted&lt;/a&gt; grace site) after completing &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Kenneth+Haight&quot;&gt;Kenneth Haight's&lt;/a&gt; Lord of Limgrave questline. Unobtainable if &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Seluvis's+Potion&quot;&gt;Seluvis's Potion&lt;/a&gt; was given to Nepheli."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -428,9 +390,7 @@
         <div class="card shadow-sm mb-3" id="ancient_dragon_smithing_stones_section_1">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#ancient_dragon_smithing_stones_1Col" data-bs-toggle="collapse" href="#ancient_dragon_smithing_stones_1Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#ancient_dragon_smithing_stones_1Col" data-bs-toggle="collapse" href="#ancient_dragon_smithing_stones_1Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <img class="me-1" data-src="/img/icons/bolstering/edited/02018.png" loading="lazy" style="height: 70px; width: 70px">
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Somber+Ancient+Dragon+Smithing+Stone">Somber Ancient Dragon Smithing Stones</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="ancient_dragon_smithing_stones_totals_1"></span>
@@ -442,9 +402,7 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="ancient_dragon_smithing_stones_14" type="checkbox" value="">
                     <label class="form-check-label item_content" for="ancient_dragon_smithing_stones_14">Found in a chest just past the <a href="https://eldenring.wiki.fextralife.com/Interactive+Map?id=4585&lat=-181.82&lng=148.195&zoom=8&code=mapB">Dynasty Mausoleum Midpoint</a> grace site. The player should be careful as the chest is surrounded by a <a href="https://eldenring.wiki.fextralife.com/Sanguine+Noble">Sanguine Noble</a> and seven 2nd generation <a href="https://eldenring.wiki.fextralife.com/Albinauric">Albinaurics</a>.</label>
-                    <a class="ms-2" href="/map.html?target=ancient_dragon_smithing_stones_14&amp;id=ancient_dragon_smithing_stones_14&amp;link=/checklists/ancient_dragon_smithing_stones.html%23item_14&amp;title=Found in a chest just past the &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Interactive+Map?id=4585&amp;lat=-181.82&amp;lng=148.195&amp;zoom=8&amp;code=mapB&quot;&gt;Dynasty Mausoleum Midpoint&lt;/a&gt; grace site. The player should be careful as the chest is surrounded by a &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Sanguine+Noble&quot;&gt;Sanguine Noble&lt;/a&gt; and seven 2nd generation &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Albinauric&quot;&gt;Albinaurics&lt;/a&gt;.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=ancient_dragon_smithing_stones_14&amp;id=ancient_dragon_smithing_stones_14&amp;link=/checklists/ancient_dragon_smithing_stones.html%23item_14&amp;title=Found in a chest just past the &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Interactive+Map?id=4585&amp;lat=-181.82&amp;lng=148.195&amp;zoom=8&amp;code=mapB&quot;&gt;Dynasty Mausoleum Midpoint&lt;/a&gt; grace site. The player should be careful as the chest is surrounded by a &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Sanguine+Noble&quot;&gt;Sanguine Noble&lt;/a&gt; and seven 2nd generation &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Albinauric&quot;&gt;Albinaurics&lt;/a&gt;."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -454,9 +412,7 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="ancient_dragon_smithing_stones_15" type="checkbox" value="">
                     <label class="form-check-label item_content" for="ancient_dragon_smithing_stones_15">Dropped from the invading phantom <a href="https://eldenring.wiki.fextralife.com/Anastasia+Tarnished-Eater">Anastasia, Tarnished-Eater</a>, on the frozen river near the scarab-chasing wolf pack, south of <a href="https://eldenring.wiki.fextralife.com/Ordina+Liturgical+Town">Ordina, Liturgical Town</a>.</label>
-                    <a class="ms-2" href="/map.html?target=ancient_dragon_smithing_stones_15&amp;id=ancient_dragon_smithing_stones_15&amp;link=/checklists/ancient_dragon_smithing_stones.html%23item_15&amp;title=Dropped from the invading phantom &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Anastasia+Tarnished-Eater&quot;&gt;Anastasia, Tarnished-Eater&lt;/a&gt;, on the frozen river near the scarab-chasing wolf pack, south of &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ordina+Liturgical+Town&quot;&gt;Ordina, Liturgical Town&lt;/a&gt;.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=ancient_dragon_smithing_stones_15&amp;id=ancient_dragon_smithing_stones_15&amp;link=/checklists/ancient_dragon_smithing_stones.html%23item_15&amp;title=Dropped from the invading phantom &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Anastasia+Tarnished-Eater&quot;&gt;Anastasia, Tarnished-Eater&lt;/a&gt;, on the frozen river near the scarab-chasing wolf pack, south of &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ordina+Liturgical+Town&quot;&gt;Ordina, Liturgical Town&lt;/a&gt;."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -466,18 +422,14 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="ancient_dragon_smithing_stones_16" type="checkbox" value="">
                     <label class="form-check-label item_content" for="ancient_dragon_smithing_stones_16">Start from the <a href="https://eldenring.wiki.fextralife.com/Interactive+Map?id=4456&lat=-39.76&lng=148.97&zoom=8&code=mapA">Prayer Room</a> grace site and head north along the walkway. Cross the second stone pillar on your right, falling down to the lower ledge of the tower and finally jumping down to the long walkway with the <a href="https://eldenring.wiki.fextralife.com/Erdtree+Avatar">Erdtree Avatar</a>. At the southern end of the path will be a corpse with the stone on it.</label>
-                    <a class="ms-2" href="/map.html?target=ancient_dragon_smithing_stones_16&amp;id=ancient_dragon_smithing_stones_16&amp;link=/checklists/ancient_dragon_smithing_stones.html%23item_16&amp;title=Start from the &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Interactive+Map?id=4456&amp;lat=-39.76&amp;lng=148.97&amp;zoom=8&amp;code=mapA&quot;&gt;Prayer Room&lt;/a&gt; grace site and head north along the walkway. Cross the second stone pillar on your right, falling down to the lower ledge of the tower and finally jumping down to the long walkway with the &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Erdtree+Avatar&quot;&gt;Erdtree Avatar&lt;/a&gt;. At the southern end of the path will be a corpse with the stone on it.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=ancient_dragon_smithing_stones_16&amp;id=ancient_dragon_smithing_stones_16&amp;link=/checklists/ancient_dragon_smithing_stones.html%23item_16&amp;title=Start from the &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Interactive+Map?id=4456&amp;lat=-39.76&amp;lng=148.97&amp;zoom=8&amp;code=mapA&quot;&gt;Prayer Room&lt;/a&gt; grace site and head north along the walkway. Cross the second stone pillar on your right, falling down to the lower ledge of the tower and finally jumping down to the long walkway with the &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Erdtree+Avatar&quot;&gt;Erdtree Avatar&lt;/a&gt;. At the southern end of the path will be a corpse with the stone on it."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="ancient_dragon_smithing_stones_17" id="item_17">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="ancient_dragon_smithing_stones_17" type="checkbox" value="">
                     <label class="form-check-label item_content" for="ancient_dragon_smithing_stones_17">Start from the <a href="https://eldenring.wiki.fextralife.com/Interactive+Map?id=4456&lat=-39.76&lng=148.97&zoom=8&code=mapA">Prayer Room</a> grace site and head north to the end of the walkway. Jump off the edge to your right, down to a stone beam that is adjacent to a platform with a gazebo and health scarab. Run past and go up another stone beam and at the top, there will be an opening with a chest; the stone can be found inside.</label>
-                    <a class="ms-2" href="/map.html?target=ancient_dragon_smithing_stones_17&amp;id=ancient_dragon_smithing_stones_17&amp;link=/checklists/ancient_dragon_smithing_stones.html%23item_17&amp;title=Start from the &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Interactive+Map?id=4456&amp;lat=-39.76&amp;lng=148.97&amp;zoom=8&amp;code=mapA&quot;&gt;Prayer Room&lt;/a&gt; grace site and head north to the end of the walkway. Jump off the edge to your right, down to a stone beam that is adjacent to a platform with a gazebo and health scarab. Run past and go up another stone beam and at the top, there will be an opening with a chest; the stone can be found inside.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=ancient_dragon_smithing_stones_17&amp;id=ancient_dragon_smithing_stones_17&amp;link=/checklists/ancient_dragon_smithing_stones.html%23item_17&amp;title=Start from the &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Interactive+Map?id=4456&amp;lat=-39.76&amp;lng=148.97&amp;zoom=8&amp;code=mapA&quot;&gt;Prayer Room&lt;/a&gt; grace site and head north to the end of the walkway. Jump off the edge to your right, down to a stone beam that is adjacent to a platform with a gazebo and health scarab. Run past and go up another stone beam and at the top, there will be an opening with a chest; the stone can be found inside."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -487,9 +439,7 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="ancient_dragon_smithing_stones_18" type="checkbox" value="">
                     <label class="form-check-label item_content" for="ancient_dragon_smithing_stones_18">Found in a gazebo behind the stationary <a href="https://eldenring.wiki.fextralife.com/Farum+Azula+Dragon">Farum Azula Dragon</a> sitting at the back of the plaza, south of the <a href="https://eldenring.wiki.fextralife.com/Interactive+Map?id=4355&lat=-119.546875&lng=218.221505&zoom=8&code=mapA">Dragon Temple Rooftop</a> grace site. The dragon will constantly rain down red lightning while the path is riddled with <a href="https://eldenring.wiki.fextralife.com/Warhawk">Warhawks</a>.</label>
-                    <a class="ms-2" href="/map.html?target=ancient_dragon_smithing_stones_18&amp;id=ancient_dragon_smithing_stones_18&amp;link=/checklists/ancient_dragon_smithing_stones.html%23item_18&amp;title=Found in a gazebo behind the stationary &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Farum+Azula+Dragon&quot;&gt;Farum Azula Dragon&lt;/a&gt; sitting at the back of the plaza, south of the &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Interactive+Map?id=4355&amp;lat=-119.546875&amp;lng=218.221505&amp;zoom=8&amp;code=mapA&quot;&gt;Dragon Temple Rooftop&lt;/a&gt; grace site. The dragon will constantly rain down red lightning while the path is riddled with &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Warhawk&quot;&gt;Warhawks&lt;/a&gt;.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=ancient_dragon_smithing_stones_18&amp;id=ancient_dragon_smithing_stones_18&amp;link=/checklists/ancient_dragon_smithing_stones.html%23item_18&amp;title=Found in a gazebo behind the stationary &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Farum+Azula+Dragon&quot;&gt;Farum Azula Dragon&lt;/a&gt; sitting at the back of the plaza, south of the &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Interactive+Map?id=4355&amp;lat=-119.546875&amp;lng=218.221505&amp;zoom=8&amp;code=mapA&quot;&gt;Dragon Temple Rooftop&lt;/a&gt; grace site. The dragon will constantly rain down red lightning while the path is riddled with &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Warhawk&quot;&gt;Warhawks&lt;/a&gt;."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -499,9 +449,7 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="ancient_dragon_smithing_stones_19" type="checkbox" value="">
                     <label class="form-check-label item_content" for="ancient_dragon_smithing_stones_19">From the main <a href="https://eldenring.wiki.fextralife.com/Interactive+Map?id=7251&lat=-100.476562&lng=116.70626&zoom=8&code=mapC">Leyndell, Capital of Ash</a> grace site, head west and then up a sunken dragon wing. Jump to the crumbling wall where you will find a ladder to climb and then continue up the staircases. At the top of the rampart you will see a wandering gargoyle to your right, jump over the railing onto the soft sand below and you will find a corpse with the stone sitting in front of an eerily familiar building.</label>
-                    <a class="ms-2" href="/map.html?target=ancient_dragon_smithing_stones_19&amp;id=ancient_dragon_smithing_stones_19&amp;link=/checklists/ancient_dragon_smithing_stones.html%23item_19&amp;title=From the main &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Interactive+Map?id=7251&amp;lat=-100.476562&amp;lng=116.70626&amp;zoom=8&amp;code=mapC&quot;&gt;Leyndell, Capital of Ash&lt;/a&gt; grace site, head west and then up a sunken dragon wing. Jump to the crumbling wall where you will find a ladder to climb and then continue up the staircases. At the top of the rampart you will see a wandering gargoyle to your right, jump over the railing onto the soft sand below and you will find a corpse with the stone sitting in front of an eerily familiar building.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=ancient_dragon_smithing_stones_19&amp;id=ancient_dragon_smithing_stones_19&amp;link=/checklists/ancient_dragon_smithing_stones.html%23item_19&amp;title=From the main &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Interactive+Map?id=7251&amp;lat=-100.476562&amp;lng=116.70626&amp;zoom=8&amp;code=mapC&quot;&gt;Leyndell, Capital of Ash&lt;/a&gt; grace site, head west and then up a sunken dragon wing. Jump to the crumbling wall where you will find a ladder to climb and then continue up the staircases. At the top of the rampart you will see a wandering gargoyle to your right, jump over the railing onto the soft sand below and you will find a corpse with the stone sitting in front of an eerily familiar building."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -511,18 +459,14 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="ancient_dragon_smithing_stones_20" type="checkbox" value="">
                     <label class="form-check-label item_content" for="ancient_dragon_smithing_stones_20">Rewarded by <a href="https://eldenring.wiki.fextralife.com/Latenna">Latenna</a> after completing her questline at the <a href="https://eldenring.wiki.fextralife.com/Apostate+Derelict">Apostate Derelict</a> in the <a href="https://eldenring.wiki.fextralife.com/Consecrated+Snowfield">Consecrated Snowfield</a>.</label>
-                    <a class="ms-2" href="/map.html?target=ancient_dragon_smithing_stones_20&amp;id=ancient_dragon_smithing_stones_20&amp;link=/checklists/ancient_dragon_smithing_stones.html%23item_20&amp;title=Rewarded by &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Latenna&quot;&gt;Latenna&lt;/a&gt; after completing her questline at the &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Apostate+Derelict&quot;&gt;Apostate Derelict&lt;/a&gt; in the &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Consecrated+Snowfield&quot;&gt;Consecrated Snowfield&lt;/a&gt;.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=ancient_dragon_smithing_stones_20&amp;id=ancient_dragon_smithing_stones_20&amp;link=/checklists/ancient_dragon_smithing_stones.html%23item_20&amp;title=Rewarded by &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Latenna&quot;&gt;Latenna&lt;/a&gt; after completing her questline at the &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Apostate+Derelict&quot;&gt;Apostate Derelict&lt;/a&gt; in the &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Consecrated+Snowfield&quot;&gt;Consecrated Snowfield&lt;/a&gt;."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="ancient_dragon_smithing_stones_21" id="item_21">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="ancient_dragon_smithing_stones_21" type="checkbox" value="">
                     <label class="form-check-label item_content" for="ancient_dragon_smithing_stones_21"><a href="https://eldenring.wiki.fextralife.com/Elphael+Brace+of+the+Haligtree">Elphael, Brace of the Haligtree</a>: After completing <a href="https://eldenring.wiki.fextralife.com/Millicent">Millicent's</a> questline and defeating <a href="https://eldenring.wiki.fextralife.com/Malenia+Blade+of+Miquella">Malenia, Blade of Miquella</a>, insert the gold needle into Malenia's scarlet flower to receive the stone as well as <a href="https://eldenring.wiki.fextralife.com/Miquella's+Needle">Miquella's Needle</a>.</label>
-                    <a class="ms-2" href="/map.html?target=ancient_dragon_smithing_stones_21&amp;id=ancient_dragon_smithing_stones_21&amp;link=/checklists/ancient_dragon_smithing_stones.html%23item_21&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Elphael+Brace+of+the+Haligtree&quot;&gt;Elphael, Brace of the Haligtree&lt;/a&gt;: After completing &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Millicent&quot;&gt;Millicent's&lt;/a&gt; questline and defeating &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Malenia+Blade+of+Miquella&quot;&gt;Malenia, Blade of Miquella&lt;/a&gt;, insert the gold needle into Malenia's scarlet flower to receive the stone as well as &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Miquella's+Needle&quot;&gt;Miquella's Needle&lt;/a&gt;.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=ancient_dragon_smithing_stones_21&amp;id=ancient_dragon_smithing_stones_21&amp;link=/checklists/ancient_dragon_smithing_stones.html%23item_21&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Elphael+Brace+of+the+Haligtree&quot;&gt;Elphael, Brace of the Haligtree&lt;/a&gt;: After completing &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Millicent&quot;&gt;Millicent's&lt;/a&gt; questline and defeating &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Malenia+Blade+of+Miquella&quot;&gt;Malenia, Blade of Miquella&lt;/a&gt;, insert the gold needle into Malenia's scarlet flower to receive the stone as well as &lt;a href=&quot;https://eldenring.wiki.fextralife.com/Miquella's+Needle&quot;&gt;Miquella's Needle&lt;/a&gt;."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>

--- a/docs/checklists/armor.html
+++ b/docs/checklists/armor.html
@@ -27,14 +27,10 @@
         <a class="navbar-brand me-auto ms-2" href="/index.html">Roundtable Guides</a>
         <form class="d-none d-sm-flex order-2 order-xl-3">
           <input aria-label="search" class="form-control me-2" name="search" placeholder="Search" type="search">
-          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit">
-            <i class="bi bi-search"></i>
-          </button>
+          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit"><i class="bi bi-search"></i></button>
         </form>
         <div class="d-sm-none order-2">
-          <a class="nav-link me-0" href="/search.html">
-            <i class="bi bi-search sb-icon-search"></i>
-          </a>
+          <a class="nav-link me-0" href="/search.html"><i class="bi bi-search sb-icon-search"></i></a>
         </div>
         <div class="collapse navbar-collapse order-3 order-xl-2 ms-xl-2" id="nav-collapse">
           <ul class="nav navbar-nav navbar-nav-scroll mr-auto">
@@ -179,14 +175,10 @@
               </ul>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/map.html">
-                <i class="bi bi-map"></i> Map
-              </a>
+              <a class="nav-link hide-buttons" href="/map.html"><i class="bi bi-map"></i> Map</a>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/options.html">
-                <i class="bi bi-gear-fill"></i> Options
-              </a>
+              <a class="nav-link hide-buttons" href="/options.html"><i class="bi bi-gear-fill"></i> Options</a>
             </li>
           </ul>
         </div>
@@ -206,9 +198,7 @@
       </div>
       <nav class="text-muted toc d-print-none">
         <strong class="d-block h5">
-          <a class="toc-button" data-bs-toggle="collapse" href="#toc_armor" role="button">
-            <i class="bi bi-plus-lg"></i>Table Of Contents
-          </a>
+          <a class="toc-button" data-bs-toggle="collapse" href="#toc_armor" role="button"><i class="bi bi-plus-lg"></i>Table Of Contents</a>
         </strong>
         <ul class="toc_page collapse" id="toc_armor">
           <li>
@@ -970,9 +960,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_0">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_0Col" data-bs-toggle="collapse" href="#armor_0Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_0Col" data-bs-toggle="collapse" href="#armor_0Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Dane's+Set">Dane's Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_0"></span>
             </h4>
@@ -984,9 +972,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -1010,9 +996,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="armor_800" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_800&amp;id=armor_800&amp;link=/checklists/armor.html%23item_800&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dane's+Hat&quot;&gt;Dane's Hat&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_800&amp;id=armor_800&amp;link=/checklists/armor.html%23item_800&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dane's+Hat&quot;&gt;Dane's Hat&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1041,9 +1025,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="armor_801" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_801&amp;id=armor_801&amp;link=/checklists/armor.html%23item_801&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dryleaf+Robe&quot;&gt;Dryleaf Robe&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_801&amp;id=armor_801&amp;link=/checklists/armor.html%23item_801&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dryleaf+Robe&quot;&gt;Dryleaf Robe&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1071,9 +1053,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="armor_802" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_802&amp;id=armor_802&amp;link=/checklists/armor.html%23item_802&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dryleaf+Arm+Wraps&quot;&gt;Dryleaf Arm Wraps&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_802&amp;id=armor_802&amp;link=/checklists/armor.html%23item_802&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dryleaf+Arm+Wraps&quot;&gt;Dryleaf Arm Wraps&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1101,9 +1081,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="armor_803" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_803&amp;id=armor_803&amp;link=/checklists/armor.html%23item_803&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dryleaf+Cuissardes&quot;&gt;Dryleaf Cuissardes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_803&amp;id=armor_803&amp;link=/checklists/armor.html%23item_803&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dryleaf+Cuissardes&quot;&gt;Dryleaf Cuissardes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1131,9 +1109,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="armor_804" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_804&amp;id=armor_804&amp;link=/checklists/armor.html%23item_804&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dryleaf+Robe+(Altered)&quot;&gt;Dryleaf Robe (Altered)&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_804&amp;id=armor_804&amp;link=/checklists/armor.html%23item_804&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dryleaf+Robe+(Altered)&quot;&gt;Dryleaf Robe (Altered)&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1162,9 +1138,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_1">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_1Col" data-bs-toggle="collapse" href="#armor_1Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_1Col" data-bs-toggle="collapse" href="#armor_1Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Gaius's+Set">Gaius's Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_1"></span>
             </h4>
@@ -1176,9 +1150,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -1202,9 +1174,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="armor_805" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_805&amp;id=armor_805&amp;link=/checklists/armor.html%23item_805&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gaius's+Helm&quot;&gt;Gaius's Helm&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_805&amp;id=armor_805&amp;link=/checklists/armor.html%23item_805&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gaius's+Helm&quot;&gt;Gaius's Helm&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1233,9 +1203,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="armor_806" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_806&amp;id=armor_806&amp;link=/checklists/armor.html%23item_806&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gaius's+Armor&quot;&gt;Gaius's Armor&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_806&amp;id=armor_806&amp;link=/checklists/armor.html%23item_806&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gaius's+Armor&quot;&gt;Gaius's Armor&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1263,9 +1231,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="armor_807" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_807&amp;id=armor_807&amp;link=/checklists/armor.html%23item_807&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gaius's+Gauntlets&quot;&gt;Gaius's Gauntlets&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_807&amp;id=armor_807&amp;link=/checklists/armor.html%23item_807&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gaius's+Gauntlets&quot;&gt;Gaius's Gauntlets&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1293,9 +1259,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="armor_808" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_808&amp;id=armor_808&amp;link=/checklists/armor.html%23item_808&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gaius's+Greaves&quot;&gt;Gaius's Greaves&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_808&amp;id=armor_808&amp;link=/checklists/armor.html%23item_808&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gaius's+Greaves&quot;&gt;Gaius's Greaves&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1324,9 +1288,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_2">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_2Col" data-bs-toggle="collapse" href="#armor_2Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_2Col" data-bs-toggle="collapse" href="#armor_2Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Oathseeker+Knight+Set">Oathseeker Knight Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_2"></span>
             </h4>
@@ -1338,9 +1300,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -1364,9 +1324,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="armor_809" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_809&amp;id=armor_809&amp;link=/checklists/armor.html%23item_809&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Oathseeker+Knight+Helm&quot;&gt;Oathseeker Knight Helm&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_809&amp;id=armor_809&amp;link=/checklists/armor.html%23item_809&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Oathseeker+Knight+Helm&quot;&gt;Oathseeker Knight Helm&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1395,9 +1353,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="armor_811" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_811&amp;id=armor_811&amp;link=/checklists/armor.html%23item_811&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Oathseeker+Knight+Gauntlets&quot;&gt;Oathseeker Knight Gauntlets&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_811&amp;id=armor_811&amp;link=/checklists/armor.html%23item_811&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Oathseeker+Knight+Gauntlets&quot;&gt;Oathseeker Knight Gauntlets&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1425,9 +1381,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="armor_812" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_812&amp;id=armor_812&amp;link=/checklists/armor.html%23item_812&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Oathseeker+Knight+Greaves&quot;&gt;Oathseeker Knight Greaves&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_812&amp;id=armor_812&amp;link=/checklists/armor.html%23item_812&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Oathseeker+Knight+Greaves&quot;&gt;Oathseeker Knight Greaves&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1455,9 +1409,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="armor_813" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_813&amp;id=armor_813&amp;link=/checklists/armor.html%23item_813&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Oathseeker+Knight+Armor&quot;&gt;Oathseeker Knight Armor&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_813&amp;id=armor_813&amp;link=/checklists/armor.html%23item_813&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Oathseeker+Knight+Armor&quot;&gt;Oathseeker Knight Armor&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1486,9 +1438,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_3">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_3Col" data-bs-toggle="collapse" href="#armor_3Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_3Col" data-bs-toggle="collapse" href="#armor_3Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Leda's Armor</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_3"></span>
             </h4>
@@ -1500,9 +1450,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -1526,9 +1474,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="armor_810" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_810&amp;id=armor_810&amp;link=/checklists/armor.html%23item_810&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Leda's+Armor&quot;&gt;Leda's Armor&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_810&amp;id=armor_810&amp;link=/checklists/armor.html%23item_810&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Leda's+Armor&quot;&gt;Leda's Armor&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1557,9 +1503,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_4">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_4Col" data-bs-toggle="collapse" href="#armor_4Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_4Col" data-bs-toggle="collapse" href="#armor_4Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Verdigris+Set">Verdigris Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_4"></span>
             </h4>
@@ -1571,9 +1515,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -1597,9 +1539,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="armor_814" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_814&amp;id=armor_814&amp;link=/checklists/armor.html%23item_814&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Verdigris+Helm&quot;&gt;Verdigris Helm&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_814&amp;id=armor_814&amp;link=/checklists/armor.html%23item_814&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Verdigris+Helm&quot;&gt;Verdigris Helm&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1628,9 +1568,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="armor_815" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_815&amp;id=armor_815&amp;link=/checklists/armor.html%23item_815&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Verdigris+Armor&quot;&gt;Verdigris Armor&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_815&amp;id=armor_815&amp;link=/checklists/armor.html%23item_815&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Verdigris+Armor&quot;&gt;Verdigris Armor&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1658,9 +1596,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="armor_816" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_816&amp;id=armor_816&amp;link=/checklists/armor.html%23item_816&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Verdigris+Gauntlets&quot;&gt;Verdigris Gauntlets&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_816&amp;id=armor_816&amp;link=/checklists/armor.html%23item_816&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Verdigris+Gauntlets&quot;&gt;Verdigris Gauntlets&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1688,9 +1624,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="armor_817" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_817&amp;id=armor_817&amp;link=/checklists/armor.html%23item_817&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Verdigris+Greaves&quot;&gt;Verdigris Greaves&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_817&amp;id=armor_817&amp;link=/checklists/armor.html%23item_817&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Verdigris+Greaves&quot;&gt;Verdigris Greaves&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1719,9 +1653,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_5">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_5Col" data-bs-toggle="collapse" href="#armor_5Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_5Col" data-bs-toggle="collapse" href="#armor_5Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Iron+Rivet+Set">Iron Rivet Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_5"></span>
             </h4>
@@ -1733,9 +1665,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -1759,9 +1689,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="armor_818" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_818&amp;id=armor_818&amp;link=/checklists/armor.html%23item_818&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Pelt+of+Ralva&quot;&gt;Pelt of Ralva&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_818&amp;id=armor_818&amp;link=/checklists/armor.html%23item_818&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Pelt+of+Ralva&quot;&gt;Pelt of Ralva&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1790,9 +1718,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="armor_819" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_819&amp;id=armor_819&amp;link=/checklists/armor.html%23item_819&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Iron+Rivet+Armor&quot;&gt;Iron Rivet Armor&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_819&amp;id=armor_819&amp;link=/checklists/armor.html%23item_819&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Iron+Rivet+Armor&quot;&gt;Iron Rivet Armor&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1820,9 +1746,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="armor_820" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_820&amp;id=armor_820&amp;link=/checklists/armor.html%23item_820&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Iron+Rivet+Gauntlets&quot;&gt;Iron Rivet Gauntlets&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_820&amp;id=armor_820&amp;link=/checklists/armor.html%23item_820&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Iron+Rivet+Gauntlets&quot;&gt;Iron Rivet Gauntlets&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1850,9 +1774,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="armor_821" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_821&amp;id=armor_821&amp;link=/checklists/armor.html%23item_821&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Iron+Rivet+Greaves&quot;&gt;Iron Rivet Greaves&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_821&amp;id=armor_821&amp;link=/checklists/armor.html%23item_821&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Iron+Rivet+Greaves&quot;&gt;Iron Rivet Greaves&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1880,9 +1802,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="armor_822" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_822&amp;id=armor_822&amp;link=/checklists/armor.html%23item_822&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Fang+Helm&quot;&gt;Fang Helm&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_822&amp;id=armor_822&amp;link=/checklists/armor.html%23item_822&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Fang+Helm&quot;&gt;Fang Helm&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1911,9 +1831,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_6">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_6Col" data-bs-toggle="collapse" href="#armor_6Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_6Col" data-bs-toggle="collapse" href="#armor_6Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Thiollier's+Set">Thiollier's Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_6"></span>
             </h4>
@@ -1925,9 +1843,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -1951,9 +1867,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="armor_823" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_823&amp;id=armor_823&amp;link=/checklists/armor.html%23item_823&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Thiollier's+Mask&quot;&gt;Thiollier's Mask&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_823&amp;id=armor_823&amp;link=/checklists/armor.html%23item_823&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Thiollier's+Mask&quot;&gt;Thiollier's Mask&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1982,9 +1896,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="armor_824" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_824&amp;id=armor_824&amp;link=/checklists/armor.html%23item_824&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Thiollier's+Garb&quot;&gt;Thiollier's Garb&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_824&amp;id=armor_824&amp;link=/checklists/armor.html%23item_824&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Thiollier's+Garb&quot;&gt;Thiollier's Garb&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2012,9 +1924,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="armor_825" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_825&amp;id=armor_825&amp;link=/checklists/armor.html%23item_825&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Thiollier's+Gloves&quot;&gt;Thiollier's Gloves&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_825&amp;id=armor_825&amp;link=/checklists/armor.html%23item_825&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Thiollier's+Gloves&quot;&gt;Thiollier's Gloves&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2042,9 +1952,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="armor_826" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_826&amp;id=armor_826&amp;link=/checklists/armor.html%23item_826&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Thiollier's+Trousers&quot;&gt;Thiollier's Trousers&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_826&amp;id=armor_826&amp;link=/checklists/armor.html%23item_826&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Thiollier's+Trousers&quot;&gt;Thiollier's Trousers&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2072,9 +1980,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="armor_827" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_827&amp;id=armor_827&amp;link=/checklists/armor.html%23item_827&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Thiollier's+Garb+(Altered)&quot;&gt;Thiollier's Garb (Altered)&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_827&amp;id=armor_827&amp;link=/checklists/armor.html%23item_827&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Thiollier's+Garb+(Altered)&quot;&gt;Thiollier's Garb (Altered)&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2103,9 +2009,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_7">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_7Col" data-bs-toggle="collapse" href="#armor_7Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_7Col" data-bs-toggle="collapse" href="#armor_7Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/High+Priest+Set">High Priest Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_7"></span>
             </h4>
@@ -2117,9 +2021,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -2143,9 +2045,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="armor_828" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_828&amp;id=armor_828&amp;link=/checklists/armor.html%23item_828&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/High+Priest+Hat&quot;&gt;High Priest Hat&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_828&amp;id=armor_828&amp;link=/checklists/armor.html%23item_828&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/High+Priest+Hat&quot;&gt;High Priest Hat&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2174,9 +2074,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="armor_829" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_829&amp;id=armor_829&amp;link=/checklists/armor.html%23item_829&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/High+Priest+Robe&quot;&gt;High Priest Robe&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_829&amp;id=armor_829&amp;link=/checklists/armor.html%23item_829&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/High+Priest+Robe&quot;&gt;High Priest Robe&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2204,9 +2102,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="armor_830" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_830&amp;id=armor_830&amp;link=/checklists/armor.html%23item_830&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/High+Priest+Gloves&quot;&gt;High Priest Gloves&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_830&amp;id=armor_830&amp;link=/checklists/armor.html%23item_830&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/High+Priest+Gloves&quot;&gt;High Priest Gloves&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2234,9 +2130,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="armor_831" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_831&amp;id=armor_831&amp;link=/checklists/armor.html%23item_831&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/High+Priest+Undergarments&quot;&gt;High Priest Undergarments&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_831&amp;id=armor_831&amp;link=/checklists/armor.html%23item_831&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/High+Priest+Undergarments&quot;&gt;High Priest Undergarments&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2264,9 +2158,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="armor_832" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_832&amp;id=armor_832&amp;link=/checklists/armor.html%23item_832&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Finger+Robe&quot;&gt;Finger Robe&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_832&amp;id=armor_832&amp;link=/checklists/armor.html%23item_832&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Finger+Robe&quot;&gt;Finger Robe&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2295,9 +2187,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_8">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_8Col" data-bs-toggle="collapse" href="#armor_8Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_8Col" data-bs-toggle="collapse" href="#armor_8Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Hornsent+Set">Hornsent Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_8"></span>
             </h4>
@@ -2309,9 +2199,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -2335,9 +2223,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="armor_833" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_833&amp;id=armor_833&amp;link=/checklists/armor.html%23item_833&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Caterpillar+Mask&quot;&gt;Caterpillar Mask&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_833&amp;id=armor_833&amp;link=/checklists/armor.html%23item_833&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Caterpillar+Mask&quot;&gt;Caterpillar Mask&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2366,9 +2252,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="armor_834" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_834&amp;id=armor_834&amp;link=/checklists/armor.html%23item_834&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Braided+Cord+Robe&quot;&gt;Braided Cord Robe&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_834&amp;id=armor_834&amp;link=/checklists/armor.html%23item_834&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Braided+Cord+Robe&quot;&gt;Braided Cord Robe&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2396,9 +2280,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="armor_835" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_835&amp;id=armor_835&amp;link=/checklists/armor.html%23item_835&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Braided+Arm+Wraps&quot;&gt;Braided Arm Wraps&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_835&amp;id=armor_835&amp;link=/checklists/armor.html%23item_835&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Braided+Arm+Wraps&quot;&gt;Braided Arm Wraps&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2426,9 +2308,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="armor_836" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_836&amp;id=armor_836&amp;link=/checklists/armor.html%23item_836&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Soiled+Loincloth&quot;&gt;Soiled Loincloth&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_836&amp;id=armor_836&amp;link=/checklists/armor.html%23item_836&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Soiled+Loincloth&quot;&gt;Soiled Loincloth&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2457,9 +2337,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_9">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_9Col" data-bs-toggle="collapse" href="#armor_9Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_9Col" data-bs-toggle="collapse" href="#armor_9Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Dancer's+Set">Dancer's Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_9"></span>
             </h4>
@@ -2471,9 +2349,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -2497,9 +2373,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="armor_837" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_837&amp;id=armor_837&amp;link=/checklists/armor.html%23item_837&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dancer's+Hood&quot;&gt;Dancer's Hood&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_837&amp;id=armor_837&amp;link=/checklists/armor.html%23item_837&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dancer's+Hood&quot;&gt;Dancer's Hood&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2528,9 +2402,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="armor_838" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_838&amp;id=armor_838&amp;link=/checklists/armor.html%23item_838&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dancer's+Dress&quot;&gt;Dancer's Dress&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_838&amp;id=armor_838&amp;link=/checklists/armor.html%23item_838&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dancer's+Dress&quot;&gt;Dancer's Dress&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2558,9 +2430,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="armor_839" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_839&amp;id=armor_839&amp;link=/checklists/armor.html%23item_839&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dancer's+Bracer&quot;&gt;Dancer's Bracer&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_839&amp;id=armor_839&amp;link=/checklists/armor.html%23item_839&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dancer's+Bracer&quot;&gt;Dancer's Bracer&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2588,9 +2458,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="armor_840" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_840&amp;id=armor_840&amp;link=/checklists/armor.html%23item_840&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dancer's+Trousers&quot;&gt;Dancer's Trousers&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_840&amp;id=armor_840&amp;link=/checklists/armor.html%23item_840&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dancer's+Trousers&quot;&gt;Dancer's Trousers&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2618,9 +2486,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="armor_841" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_841&amp;id=armor_841&amp;link=/checklists/armor.html%23item_841&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dancer's+Dress+(Altered)&quot;&gt;Dancer's Dress (Altered)&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_841&amp;id=armor_841&amp;link=/checklists/armor.html%23item_841&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dancer's+Dress+(Altered)&quot;&gt;Dancer's Dress (Altered)&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2649,9 +2515,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_10">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_10Col" data-bs-toggle="collapse" href="#armor_10Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_10Col" data-bs-toggle="collapse" href="#armor_10Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Night+Set">Night Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_10"></span>
             </h4>
@@ -2663,9 +2527,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -2689,9 +2551,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="10" id="armor_842" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_842&amp;id=armor_842&amp;link=/checklists/armor.html%23item_842&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Helm+of+Night&quot;&gt;Helm of Night&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_842&amp;id=armor_842&amp;link=/checklists/armor.html%23item_842&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Helm+of+Night&quot;&gt;Helm of Night&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2720,9 +2580,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="10" id="armor_843" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_843&amp;id=armor_843&amp;link=/checklists/armor.html%23item_843&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Armor+of+Night&quot;&gt;Armor of Night&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_843&amp;id=armor_843&amp;link=/checklists/armor.html%23item_843&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Armor+of+Night&quot;&gt;Armor of Night&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2750,9 +2608,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="10" id="armor_844" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_844&amp;id=armor_844&amp;link=/checklists/armor.html%23item_844&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gauntlets+of+Night&quot;&gt;Gauntlets of Night&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_844&amp;id=armor_844&amp;link=/checklists/armor.html%23item_844&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gauntlets+of+Night&quot;&gt;Gauntlets of Night&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2780,9 +2636,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="10" id="armor_845" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_845&amp;id=armor_845&amp;link=/checklists/armor.html%23item_845&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Greaves+of+Night&quot;&gt;Greaves of Night&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_845&amp;id=armor_845&amp;link=/checklists/armor.html%23item_845&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Greaves+of+Night&quot;&gt;Greaves of Night&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2811,9 +2665,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_11">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_11Col" data-bs-toggle="collapse" href="#armor_11Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_11Col" data-bs-toggle="collapse" href="#armor_11Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Igon's+Set">Igon's Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_11"></span>
             </h4>
@@ -2825,9 +2677,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -2851,9 +2701,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="11" id="armor_846" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_846&amp;id=armor_846&amp;link=/checklists/armor.html%23item_846&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Igon's+Helm&quot;&gt;Igon's Helm&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_846&amp;id=armor_846&amp;link=/checklists/armor.html%23item_846&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Igon's+Helm&quot;&gt;Igon's Helm&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2882,9 +2730,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="11" id="armor_847" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_847&amp;id=armor_847&amp;link=/checklists/armor.html%23item_847&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Igon's+Armor&quot;&gt;Igon's Armor&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_847&amp;id=armor_847&amp;link=/checklists/armor.html%23item_847&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Igon's+Armor&quot;&gt;Igon's Armor&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2912,9 +2758,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="11" id="armor_848" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_848&amp;id=armor_848&amp;link=/checklists/armor.html%23item_848&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Igon's+Gauntlets&quot;&gt;Igon's Gauntlets&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_848&amp;id=armor_848&amp;link=/checklists/armor.html%23item_848&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Igon's+Gauntlets&quot;&gt;Igon's Gauntlets&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2942,9 +2786,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="11" id="armor_849" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_849&amp;id=armor_849&amp;link=/checklists/armor.html%23item_849&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Igon's+Loincloth&quot;&gt;Igon's Loincloth&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_849&amp;id=armor_849&amp;link=/checklists/armor.html%23item_849&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Igon's+Loincloth&quot;&gt;Igon's Loincloth&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2972,9 +2814,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="11" id="armor_850" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_850&amp;id=armor_850&amp;link=/checklists/armor.html%23item_850&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Igon's+Helm+(Altered)&quot;&gt;Igon's Helm (Altered)&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_850&amp;id=armor_850&amp;link=/checklists/armor.html%23item_850&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Igon's+Helm+(Altered)&quot;&gt;Igon's Helm (Altered)&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3002,9 +2842,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="11" id="armor_851" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_851&amp;id=armor_851&amp;link=/checklists/armor.html%23item_851&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Igon's+Armor+(Altered)&quot;&gt;Igon's Armor (Altered)&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_851&amp;id=armor_851&amp;link=/checklists/armor.html%23item_851&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Igon's+Armor+(Altered)&quot;&gt;Igon's Armor (Altered)&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3033,9 +2871,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_12">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_12Col" data-bs-toggle="collapse" href="#armor_12Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_12Col" data-bs-toggle="collapse" href="#armor_12Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Ansbach's+Set">Ansbach's Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_12"></span>
             </h4>
@@ -3047,9 +2883,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -3073,9 +2907,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="armor_852" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_852&amp;id=armor_852&amp;link=/checklists/armor.html%23item_852&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Wise+Man's+Mask&quot;&gt;Wise Man's Mask&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_852&amp;id=armor_852&amp;link=/checklists/armor.html%23item_852&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Wise+Man's+Mask&quot;&gt;Wise Man's Mask&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3104,9 +2936,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="armor_853" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_853&amp;id=armor_853&amp;link=/checklists/armor.html%23item_853&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ansbach's+Attire&quot;&gt;Ansbach's Attire&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_853&amp;id=armor_853&amp;link=/checklists/armor.html%23item_853&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ansbach's+Attire&quot;&gt;Ansbach's Attire&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3134,9 +2964,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="armor_854" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_854&amp;id=armor_854&amp;link=/checklists/armor.html%23item_854&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ansbach's+Manchettes&quot;&gt;Ansbach's Manchettes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_854&amp;id=armor_854&amp;link=/checklists/armor.html%23item_854&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ansbach's+Manchettes&quot;&gt;Ansbach's Manchettes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3164,9 +2992,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="armor_855" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_855&amp;id=armor_855&amp;link=/checklists/armor.html%23item_855&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ansbach's+Boots&quot;&gt;Ansbach's Boots&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_855&amp;id=armor_855&amp;link=/checklists/armor.html%23item_855&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ansbach's+Boots&quot;&gt;Ansbach's Boots&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3194,9 +3020,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="armor_856" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_856&amp;id=armor_856&amp;link=/checklists/armor.html%23item_856&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ansbach's+Attire+(Altered)&quot;&gt;Ansbach's Attire (Altered)&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_856&amp;id=armor_856&amp;link=/checklists/armor.html%23item_856&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ansbach's+Attire+(Altered)&quot;&gt;Ansbach's Attire (Altered)&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3225,9 +3049,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_13">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_13Col" data-bs-toggle="collapse" href="#armor_13Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_13Col" data-bs-toggle="collapse" href="#armor_13Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Freyja's+Set">Freyja's Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_13"></span>
             </h4>
@@ -3239,9 +3061,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -3265,9 +3085,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="13" id="armor_857" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_857&amp;id=armor_857&amp;link=/checklists/armor.html%23item_857&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Freyja's+Helm&quot;&gt;Freyja's Helm&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_857&amp;id=armor_857&amp;link=/checklists/armor.html%23item_857&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Freyja's+Helm&quot;&gt;Freyja's Helm&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3296,9 +3114,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="13" id="armor_858" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_858&amp;id=armor_858&amp;link=/checklists/armor.html%23item_858&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Freyja's+Armor&quot;&gt;Freyja's Armor&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_858&amp;id=armor_858&amp;link=/checklists/armor.html%23item_858&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Freyja's+Armor&quot;&gt;Freyja's Armor&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3326,9 +3142,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="13" id="armor_859" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_859&amp;id=armor_859&amp;link=/checklists/armor.html%23item_859&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Freyja's+Gauntlets&quot;&gt;Freyja's Gauntlets&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_859&amp;id=armor_859&amp;link=/checklists/armor.html%23item_859&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Freyja's+Gauntlets&quot;&gt;Freyja's Gauntlets&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3356,9 +3170,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="13" id="armor_860" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_860&amp;id=armor_860&amp;link=/checklists/armor.html%23item_860&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Freyja's+Greaves&quot;&gt;Freyja's Greaves&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_860&amp;id=armor_860&amp;link=/checklists/armor.html%23item_860&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Freyja's+Greaves&quot;&gt;Freyja's Greaves&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3386,9 +3198,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="13" id="armor_861" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_861&amp;id=armor_861&amp;link=/checklists/armor.html%23item_861&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Freyja's+Armor+(Altered)&quot;&gt;Freyja's Armor (Altered)&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_861&amp;id=armor_861&amp;link=/checklists/armor.html%23item_861&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Freyja's+Armor+(Altered)&quot;&gt;Freyja's Armor (Altered)&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3417,9 +3227,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_14">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_14Col" data-bs-toggle="collapse" href="#armor_14Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_14Col" data-bs-toggle="collapse" href="#armor_14Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Solitude+Set">Solitude Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_14"></span>
             </h4>
@@ -3431,9 +3239,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -3457,9 +3263,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="14" id="armor_862" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_862&amp;id=armor_862&amp;link=/checklists/armor.html%23item_862&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Helm+of+Solitude&quot;&gt;Helm of Solitude&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_862&amp;id=armor_862&amp;link=/checklists/armor.html%23item_862&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Helm+of+Solitude&quot;&gt;Helm of Solitude&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3488,9 +3292,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="14" id="armor_863" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_863&amp;id=armor_863&amp;link=/checklists/armor.html%23item_863&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Armor+of+Solitude&quot;&gt;Armor of Solitude&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_863&amp;id=armor_863&amp;link=/checklists/armor.html%23item_863&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Armor+of+Solitude&quot;&gt;Armor of Solitude&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3518,9 +3320,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="14" id="armor_864" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_864&amp;id=armor_864&amp;link=/checklists/armor.html%23item_864&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gauntlets+of+Solitude&quot;&gt;Gauntlets of Solitude&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_864&amp;id=armor_864&amp;link=/checklists/armor.html%23item_864&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gauntlets+of+Solitude&quot;&gt;Gauntlets of Solitude&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3548,9 +3348,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="14" id="armor_865" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_865&amp;id=armor_865&amp;link=/checklists/armor.html%23item_865&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Greaves+of+Solitude&quot;&gt;Greaves of Solitude&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_865&amp;id=armor_865&amp;link=/checklists/armor.html%23item_865&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Greaves+of+Solitude&quot;&gt;Greaves of Solitude&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3578,9 +3376,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="14" id="armor_866" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_866&amp;id=armor_866&amp;link=/checklists/armor.html%23item_866&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Armor+of+Solitude+(Altered)&quot;&gt;Armor of Solitude (Altered)&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_866&amp;id=armor_866&amp;link=/checklists/armor.html%23item_866&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Armor+of+Solitude+(Altered)&quot;&gt;Armor of Solitude (Altered)&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3609,9 +3405,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_15">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_15Col" data-bs-toggle="collapse" href="#armor_15Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_15Col" data-bs-toggle="collapse" href="#armor_15Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Messmer+Soldier+Set">Messmer Soldier Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_15"></span>
             </h4>
@@ -3623,9 +3417,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -3649,9 +3441,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="15" id="armor_867" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_867&amp;id=armor_867&amp;link=/checklists/armor.html%23item_867&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Messmer+Soldier+Helm&quot;&gt;Messmer Soldier Helm&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_867&amp;id=armor_867&amp;link=/checklists/armor.html%23item_867&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Messmer+Soldier+Helm&quot;&gt;Messmer Soldier Helm&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3680,9 +3470,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="15" id="armor_868" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_868&amp;id=armor_868&amp;link=/checklists/armor.html%23item_868&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Messmer+Soldier+Armor&quot;&gt;Messmer Soldier Armor&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_868&amp;id=armor_868&amp;link=/checklists/armor.html%23item_868&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Messmer+Soldier+Armor&quot;&gt;Messmer Soldier Armor&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3710,9 +3498,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="15" id="armor_869" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_869&amp;id=armor_869&amp;link=/checklists/armor.html%23item_869&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Messmer+Soldier+Gauntlets&quot;&gt;Messmer Soldier Gauntlets&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_869&amp;id=armor_869&amp;link=/checklists/armor.html%23item_869&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Messmer+Soldier+Gauntlets&quot;&gt;Messmer Soldier Gauntlets&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3740,9 +3526,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="15" id="armor_870" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_870&amp;id=armor_870&amp;link=/checklists/armor.html%23item_870&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Messmer+Soldier+Greaves&quot;&gt;Messmer Soldier Greaves&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_870&amp;id=armor_870&amp;link=/checklists/armor.html%23item_870&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Messmer+Soldier+Greaves&quot;&gt;Messmer Soldier Greaves&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3770,9 +3554,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="15" id="armor_871" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_871&amp;id=armor_871&amp;link=/checklists/armor.html%23item_871&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Messmer+Soldier+Armor+(Altered)&quot;&gt;Messmer Soldier Armor (Altered)&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_871&amp;id=armor_871&amp;link=/checklists/armor.html%23item_871&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Messmer+Soldier+Armor+(Altered)&quot;&gt;Messmer Soldier Armor (Altered)&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3801,9 +3583,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_16">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_16Col" data-bs-toggle="collapse" href="#armor_16Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_16Col" data-bs-toggle="collapse" href="#armor_16Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Black+Knight+Set">Black Knight Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_16"></span>
             </h4>
@@ -3815,9 +3595,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -3841,9 +3619,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="16" id="armor_872" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_872&amp;id=armor_872&amp;link=/checklists/armor.html%23item_872&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Black+Knight+Helm&quot;&gt;Black Knight Helm&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_872&amp;id=armor_872&amp;link=/checklists/armor.html%23item_872&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Black+Knight+Helm&quot;&gt;Black Knight Helm&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3872,9 +3648,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="16" id="armor_873" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_873&amp;id=armor_873&amp;link=/checklists/armor.html%23item_873&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Black+Knight+Armor&quot;&gt;Black Knight Armor&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_873&amp;id=armor_873&amp;link=/checklists/armor.html%23item_873&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Black+Knight+Armor&quot;&gt;Black Knight Armor&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3902,9 +3676,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="16" id="armor_874" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_874&amp;id=armor_874&amp;link=/checklists/armor.html%23item_874&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Black+Knight+Gauntlets&quot;&gt;Black Knight Gauntlets&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_874&amp;id=armor_874&amp;link=/checklists/armor.html%23item_874&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Black+Knight+Gauntlets&quot;&gt;Black Knight Gauntlets&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3932,9 +3704,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="16" id="armor_875" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_875&amp;id=armor_875&amp;link=/checklists/armor.html%23item_875&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Black+Knight+Greaves&quot;&gt;Black Knight Greaves&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_875&amp;id=armor_875&amp;link=/checklists/armor.html%23item_875&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Black+Knight+Greaves&quot;&gt;Black Knight Greaves&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3963,9 +3733,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_17">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_17Col" data-bs-toggle="collapse" href="#armor_17Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_17Col" data-bs-toggle="collapse" href="#armor_17Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Rakshasa+Set">Rakshasa Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_17"></span>
             </h4>
@@ -3977,9 +3745,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -4003,9 +3769,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="17" id="armor_876" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_876&amp;id=armor_876&amp;link=/checklists/armor.html%23item_876&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Rakshasa+Helm&quot;&gt;Rakshasa Helm&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_876&amp;id=armor_876&amp;link=/checklists/armor.html%23item_876&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Rakshasa+Helm&quot;&gt;Rakshasa Helm&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4034,9 +3798,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="17" id="armor_877" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_877&amp;id=armor_877&amp;link=/checklists/armor.html%23item_877&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Rakshasa+Armor&quot;&gt;Rakshasa Armor&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_877&amp;id=armor_877&amp;link=/checklists/armor.html%23item_877&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Rakshasa+Armor&quot;&gt;Rakshasa Armor&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4064,9 +3826,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="17" id="armor_878" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_878&amp;id=armor_878&amp;link=/checklists/armor.html%23item_878&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Rakshasa+Gauntlets&quot;&gt;Rakshasa Gauntlets&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_878&amp;id=armor_878&amp;link=/checklists/armor.html%23item_878&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Rakshasa+Gauntlets&quot;&gt;Rakshasa Gauntlets&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4094,9 +3854,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="17" id="armor_879" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_879&amp;id=armor_879&amp;link=/checklists/armor.html%23item_879&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Rakshasa+Greaves&quot;&gt;Rakshasa Greaves&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_879&amp;id=armor_879&amp;link=/checklists/armor.html%23item_879&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Rakshasa+Greaves&quot;&gt;Rakshasa Greaves&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4125,9 +3883,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_18">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_18Col" data-bs-toggle="collapse" href="#armor_18Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_18Col" data-bs-toggle="collapse" href="#armor_18Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Fire+Knight+Set">Fire Knight Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_18"></span>
             </h4>
@@ -4139,9 +3895,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -4165,9 +3919,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="18" id="armor_880" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_880&amp;id=armor_880&amp;link=/checklists/armor.html%23item_880&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Fire+Knight+Helm&quot;&gt;Fire Knight Helm&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_880&amp;id=armor_880&amp;link=/checklists/armor.html%23item_880&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Fire+Knight+Helm&quot;&gt;Fire Knight Helm&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4196,9 +3948,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="18" id="armor_881" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_881&amp;id=armor_881&amp;link=/checklists/armor.html%23item_881&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Fire+Knight+Armor&quot;&gt;Fire Knight Armor&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_881&amp;id=armor_881&amp;link=/checklists/armor.html%23item_881&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Fire+Knight+Armor&quot;&gt;Fire Knight Armor&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4226,9 +3976,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="18" id="armor_882" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_882&amp;id=armor_882&amp;link=/checklists/armor.html%23item_882&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Fire+Knight+Gauntlets&quot;&gt;Fire Knight Gauntlets&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_882&amp;id=armor_882&amp;link=/checklists/armor.html%23item_882&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Fire+Knight+Gauntlets&quot;&gt;Fire Knight Gauntlets&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4256,9 +4004,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="18" id="armor_883" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_883&amp;id=armor_883&amp;link=/checklists/armor.html%23item_883&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Fire+Knight+Greaves&quot;&gt;Fire Knight Greaves&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_883&amp;id=armor_883&amp;link=/checklists/armor.html%23item_883&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Fire+Knight+Greaves&quot;&gt;Fire Knight Greaves&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4286,9 +4032,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="18" id="armor_884" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_884&amp;id=armor_884&amp;link=/checklists/armor.html%23item_884&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Fire+Knight+Armor+(Altered)&quot;&gt;Fire Knight Armor (Altered)&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_884&amp;id=armor_884&amp;link=/checklists/armor.html%23item_884&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Fire+Knight+Armor+(Altered)&quot;&gt;Fire Knight Armor (Altered)&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4317,9 +4061,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_19">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_19Col" data-bs-toggle="collapse" href="#armor_19Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_19Col" data-bs-toggle="collapse" href="#armor_19Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Death Mask Helm</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_19"></span>
             </h4>
@@ -4331,9 +4073,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -4357,9 +4097,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="19" id="armor_885" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_885&amp;id=armor_885&amp;link=/checklists/armor.html%23item_885&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Death+Mask+Helm&quot;&gt;Death Mask Helm&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_885&amp;id=armor_885&amp;link=/checklists/armor.html%23item_885&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Death+Mask+Helm&quot;&gt;Death Mask Helm&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4389,9 +4127,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_20">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_20Col" data-bs-toggle="collapse" href="#armor_20Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_20Col" data-bs-toggle="collapse" href="#armor_20Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Winged Serpent Helm</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_20"></span>
             </h4>
@@ -4403,9 +4139,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -4429,9 +4163,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="20" id="armor_886" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_886&amp;id=armor_886&amp;link=/checklists/armor.html%23item_886&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Winged+Serpent+Helm&quot;&gt;Winged Serpent Helm&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_886&amp;id=armor_886&amp;link=/checklists/armor.html%23item_886&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Winged+Serpent+Helm&quot;&gt;Winged Serpent Helm&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4461,9 +4193,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_21">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_21Col" data-bs-toggle="collapse" href="#armor_21Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_21Col" data-bs-toggle="collapse" href="#armor_21Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Salza's Hood</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_21"></span>
             </h4>
@@ -4475,9 +4205,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -4501,9 +4229,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="21" id="armor_887" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_887&amp;id=armor_887&amp;link=/checklists/armor.html%23item_887&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Salza's+Hood&quot;&gt;Salza's Hood&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_887&amp;id=armor_887&amp;link=/checklists/armor.html%23item_887&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Salza's+Hood&quot;&gt;Salza's Hood&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4533,9 +4259,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_22">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_22Col" data-bs-toggle="collapse" href="#armor_22Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_22Col" data-bs-toggle="collapse" href="#armor_22Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Highland+Warrior+Set">Highland Warrior Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_22"></span>
             </h4>
@@ -4547,9 +4271,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -4573,9 +4295,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="22" id="armor_888" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_888&amp;id=armor_888&amp;link=/checklists/armor.html%23item_888&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Leather+Headband&quot;&gt;Leather Headband&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_888&amp;id=armor_888&amp;link=/checklists/armor.html%23item_888&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Leather+Headband&quot;&gt;Leather Headband&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4604,9 +4324,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="22" id="armor_889" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_889&amp;id=armor_889&amp;link=/checklists/armor.html%23item_889&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gloried+Attire&quot;&gt;Gloried Attire&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_889&amp;id=armor_889&amp;link=/checklists/armor.html%23item_889&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gloried+Attire&quot;&gt;Gloried Attire&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4634,9 +4352,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="22" id="armor_890" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_890&amp;id=armor_890&amp;link=/checklists/armor.html%23item_890&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Leather+Arm+Wraps&quot;&gt;Leather Arm Wraps&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_890&amp;id=armor_890&amp;link=/checklists/armor.html%23item_890&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Leather+Arm+Wraps&quot;&gt;Leather Arm Wraps&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4664,9 +4380,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="22" id="armor_891" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_891&amp;id=armor_891&amp;link=/checklists/armor.html%23item_891&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Leather+Leg+Wraps&quot;&gt;Leather Leg Wraps&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_891&amp;id=armor_891&amp;link=/checklists/armor.html%23item_891&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Leather+Leg+Wraps&quot;&gt;Leather Leg Wraps&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4694,9 +4408,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="22" id="armor_892" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_892&amp;id=armor_892&amp;link=/checklists/armor.html%23item_892&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Leather+Crown&quot;&gt;Leather Crown&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_892&amp;id=armor_892&amp;link=/checklists/armor.html%23item_892&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Leather+Crown&quot;&gt;Leather Crown&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4725,9 +4437,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="22" id="armor_893" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_893&amp;id=armor_893&amp;link=/checklists/armor.html%23item_893&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Highland+Attire&quot;&gt;Highland Attire&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_893&amp;id=armor_893&amp;link=/checklists/armor.html%23item_893&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Highland+Attire&quot;&gt;Highland Attire&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4756,9 +4466,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_23">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_23Col" data-bs-toggle="collapse" href="#armor_23Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_23Col" data-bs-toggle="collapse" href="#armor_23Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Death+Knight+Set">Death Knight Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_23"></span>
             </h4>
@@ -4770,9 +4478,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -4796,9 +4502,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="23" id="armor_894" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_894&amp;id=armor_894&amp;link=/checklists/armor.html%23item_894&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Death+Knight+Helm&quot;&gt;Death Knight Helm&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_894&amp;id=armor_894&amp;link=/checklists/armor.html%23item_894&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Death+Knight+Helm&quot;&gt;Death Knight Helm&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4827,9 +4531,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="23" id="armor_895" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_895&amp;id=armor_895&amp;link=/checklists/armor.html%23item_895&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Death+Knight+Armor&quot;&gt;Death Knight Armor&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_895&amp;id=armor_895&amp;link=/checklists/armor.html%23item_895&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Death+Knight+Armor&quot;&gt;Death Knight Armor&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4857,9 +4559,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="23" id="armor_896" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_896&amp;id=armor_896&amp;link=/checklists/armor.html%23item_896&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Death+Knight+Gauntlets&quot;&gt;Death Knight Gauntlets&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_896&amp;id=armor_896&amp;link=/checklists/armor.html%23item_896&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Death+Knight+Gauntlets&quot;&gt;Death Knight Gauntlets&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4887,9 +4587,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="23" id="armor_897" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_897&amp;id=armor_897&amp;link=/checklists/armor.html%23item_897&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Death+Knight+Greaves&quot;&gt;Death Knight Greaves&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_897&amp;id=armor_897&amp;link=/checklists/armor.html%23item_897&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Death+Knight+Greaves&quot;&gt;Death Knight Greaves&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4918,9 +4616,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_24">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_24Col" data-bs-toggle="collapse" href="#armor_24Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_24Col" data-bs-toggle="collapse" href="#armor_24Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Ascetic's+Set">Ascetic's Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_24"></span>
             </h4>
@@ -4932,9 +4628,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -4958,9 +4652,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="24" id="armor_898" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_898&amp;id=armor_898&amp;link=/checklists/armor.html%23item_898&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Curseblade+Mask&quot;&gt;Curseblade Mask&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_898&amp;id=armor_898&amp;link=/checklists/armor.html%23item_898&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Curseblade+Mask&quot;&gt;Curseblade Mask&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4989,9 +4681,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="24" id="armor_899" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_899&amp;id=armor_899&amp;link=/checklists/armor.html%23item_899&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ascetic's+Loincloth&quot;&gt;Ascetic's Loincloth&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_899&amp;id=armor_899&amp;link=/checklists/armor.html%23item_899&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ascetic's+Loincloth&quot;&gt;Ascetic's Loincloth&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5019,9 +4709,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="24" id="armor_900" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_900&amp;id=armor_900&amp;link=/checklists/armor.html%23item_900&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ascetic's+Wrist+Guards&quot;&gt;Ascetic's Wrist Guards&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_900&amp;id=armor_900&amp;link=/checklists/armor.html%23item_900&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ascetic's+Wrist+Guards&quot;&gt;Ascetic's Wrist Guards&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5049,9 +4737,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="24" id="armor_901" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_901&amp;id=armor_901&amp;link=/checklists/armor.html%23item_901&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ascetic's+Ankle+Guards&quot;&gt;Ascetic's Ankle Guards&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_901&amp;id=armor_901&amp;link=/checklists/armor.html%23item_901&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ascetic's+Ankle+Guards&quot;&gt;Ascetic's Ankle Guards&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5080,9 +4766,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_25">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_25Col" data-bs-toggle="collapse" href="#armor_25Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_25Col" data-bs-toggle="collapse" href="#armor_25Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Messmer's+Set">Messmer's Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_25"></span>
             </h4>
@@ -5094,9 +4778,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -5120,9 +4802,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="25" id="armor_902" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_902&amp;id=armor_902&amp;link=/checklists/armor.html%23item_902&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Messmer's+Helm&quot;&gt;Messmer's Helm&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_902&amp;id=armor_902&amp;link=/checklists/armor.html%23item_902&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Messmer's+Helm&quot;&gt;Messmer's Helm&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5151,9 +4831,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="25" id="armor_903" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_903&amp;id=armor_903&amp;link=/checklists/armor.html%23item_903&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Messmer's+Armor&quot;&gt;Messmer's Armor&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_903&amp;id=armor_903&amp;link=/checklists/armor.html%23item_903&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Messmer's+Armor&quot;&gt;Messmer's Armor&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5181,9 +4859,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="25" id="armor_904" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_904&amp;id=armor_904&amp;link=/checklists/armor.html%23item_904&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Messmer's+Gauntlets&quot;&gt;Messmer's Gauntlets&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_904&amp;id=armor_904&amp;link=/checklists/armor.html%23item_904&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Messmer's+Gauntlets&quot;&gt;Messmer's Gauntlets&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5211,9 +4887,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="25" id="armor_905" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_905&amp;id=armor_905&amp;link=/checklists/armor.html%23item_905&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Messmer's+Greaves&quot;&gt;Messmer's Greaves&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_905&amp;id=armor_905&amp;link=/checklists/armor.html%23item_905&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Messmer's+Greaves&quot;&gt;Messmer's Greaves&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5241,9 +4915,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="25" id="armor_906" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_906&amp;id=armor_906&amp;link=/checklists/armor.html%23item_906&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Messmer's+Helm+(Altered)&quot;&gt;Messmer's Helm (Altered)&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_906&amp;id=armor_906&amp;link=/checklists/armor.html%23item_906&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Messmer's+Helm+(Altered)&quot;&gt;Messmer's Helm (Altered)&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5272,9 +4944,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_26">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_26Col" data-bs-toggle="collapse" href="#armor_26Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_26Col" data-bs-toggle="collapse" href="#armor_26Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Gravebird+Set">Gravebird Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_26"></span>
             </h4>
@@ -5286,9 +4956,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -5312,9 +4980,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="26" id="armor_907" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_907&amp;id=armor_907&amp;link=/checklists/armor.html%23item_907&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gravebird+Helm&quot;&gt;Gravebird Helm&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_907&amp;id=armor_907&amp;link=/checklists/armor.html%23item_907&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gravebird+Helm&quot;&gt;Gravebird Helm&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5343,9 +5009,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="26" id="armor_908" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_908&amp;id=armor_908&amp;link=/checklists/armor.html%23item_908&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gravebird's+Blackquill+Armor&quot;&gt;Gravebird's Blackquill Armor&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_908&amp;id=armor_908&amp;link=/checklists/armor.html%23item_908&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gravebird's+Blackquill+Armor&quot;&gt;Gravebird's Blackquill Armor&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5374,9 +5038,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="26" id="armor_909" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_909&amp;id=armor_909&amp;link=/checklists/armor.html%23item_909&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gravebird+Bracelets&quot;&gt;Gravebird Bracelets&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_909&amp;id=armor_909&amp;link=/checklists/armor.html%23item_909&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gravebird+Bracelets&quot;&gt;Gravebird Bracelets&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5405,9 +5067,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="26" id="armor_910" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_910&amp;id=armor_910&amp;link=/checklists/armor.html%23item_910&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gravebird+Anklets&quot;&gt;Gravebird Anklets&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_910&amp;id=armor_910&amp;link=/checklists/armor.html%23item_910&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gravebird+Anklets&quot;&gt;Gravebird Anklets&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5436,9 +5096,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="26" id="armor_911" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_911&amp;id=armor_911&amp;link=/checklists/armor.html%23item_911&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gravebird+Armor&quot;&gt;Gravebird Armor&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_911&amp;id=armor_911&amp;link=/checklists/armor.html%23item_911&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gravebird+Armor&quot;&gt;Gravebird Armor&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5468,9 +5126,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_27">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_27Col" data-bs-toggle="collapse" href="#armor_27Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_27Col" data-bs-toggle="collapse" href="#armor_27Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Common+Soldier+Set">Common Soldier Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_27"></span>
             </h4>
@@ -5482,9 +5138,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -5508,9 +5162,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="27" id="armor_912" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_912&amp;id=armor_912&amp;link=/checklists/armor.html%23item_912&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Common+Soldier+Helm&quot;&gt;Common Soldier Helm&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_912&amp;id=armor_912&amp;link=/checklists/armor.html%23item_912&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Common+Soldier+Helm&quot;&gt;Common Soldier Helm&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5539,9 +5191,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="27" id="armor_913" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_913&amp;id=armor_913&amp;link=/checklists/armor.html%23item_913&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Common+Soldier+Cloth+Armor&quot;&gt;Common Soldier Cloth Armor&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_913&amp;id=armor_913&amp;link=/checklists/armor.html%23item_913&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Common+Soldier+Cloth+Armor&quot;&gt;Common Soldier Cloth Armor&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5569,9 +5219,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="27" id="armor_914" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_914&amp;id=armor_914&amp;link=/checklists/armor.html%23item_914&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Common+Soldier+Gauntlets&quot;&gt;Common Soldier Gauntlets&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_914&amp;id=armor_914&amp;link=/checklists/armor.html%23item_914&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Common+Soldier+Gauntlets&quot;&gt;Common Soldier Gauntlets&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5599,9 +5247,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="27" id="armor_915" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_915&amp;id=armor_915&amp;link=/checklists/armor.html%23item_915&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Common+Soldier+Greaves&quot;&gt;Common Soldier Greaves&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_915&amp;id=armor_915&amp;link=/checklists/armor.html%23item_915&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Common+Soldier+Greaves&quot;&gt;Common Soldier Greaves&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5630,9 +5276,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_28">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_28Col" data-bs-toggle="collapse" href="#armor_28Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_28Col" data-bs-toggle="collapse" href="#armor_28Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Horned+Warrior+Set">Horned Warrior Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_28"></span>
             </h4>
@@ -5644,9 +5288,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -5670,9 +5312,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="28" id="armor_916" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_916&amp;id=armor_916&amp;link=/checklists/armor.html%23item_916&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Horned+Warrior+Helm&quot;&gt;Horned Warrior Helm&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_916&amp;id=armor_916&amp;link=/checklists/armor.html%23item_916&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Horned+Warrior+Helm&quot;&gt;Horned Warrior Helm&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5701,9 +5341,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="28" id="armor_917" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_917&amp;id=armor_917&amp;link=/checklists/armor.html%23item_917&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Horned+Warrior+Armor&quot;&gt;Horned Warrior Armor&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_917&amp;id=armor_917&amp;link=/checklists/armor.html%23item_917&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Horned+Warrior+Armor&quot;&gt;Horned Warrior Armor&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5731,9 +5369,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="28" id="armor_918" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_918&amp;id=armor_918&amp;link=/checklists/armor.html%23item_918&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Horned+Warrior+Gauntlets&quot;&gt;Horned Warrior Gauntlets&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_918&amp;id=armor_918&amp;link=/checklists/armor.html%23item_918&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Horned+Warrior+Gauntlets&quot;&gt;Horned Warrior Gauntlets&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5761,9 +5397,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="28" id="armor_919" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_919&amp;id=armor_919&amp;link=/checklists/armor.html%23item_919&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Horned+Warrior+Greaves&quot;&gt;Horned Warrior Greaves&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_919&amp;id=armor_919&amp;link=/checklists/armor.html%23item_919&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Horned+Warrior+Greaves&quot;&gt;Horned Warrior Greaves&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5792,9 +5426,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_29">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_29Col" data-bs-toggle="collapse" href="#armor_29Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_29Col" data-bs-toggle="collapse" href="#armor_29Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Divine+Beast+Set">Divine Beast Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_29"></span>
             </h4>
@@ -5806,9 +5438,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -5832,9 +5462,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="29" id="armor_920" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_920&amp;id=armor_920&amp;link=/checklists/armor.html%23item_920&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Divine+Beast+Helm&quot;&gt;Divine Beast Helm&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_920&amp;id=armor_920&amp;link=/checklists/armor.html%23item_920&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Divine+Beast+Helm&quot;&gt;Divine Beast Helm&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5863,9 +5491,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="29" id="armor_921" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_921&amp;id=armor_921&amp;link=/checklists/armor.html%23item_921&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Divine+Beast+Warrior+Armor&quot;&gt;Divine Beast Warrior Armor&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_921&amp;id=armor_921&amp;link=/checklists/armor.html%23item_921&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Divine+Beast+Warrior+Armor&quot;&gt;Divine Beast Warrior Armor&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5894,9 +5520,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_30">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_30Col" data-bs-toggle="collapse" href="#armor_30Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_30Col" data-bs-toggle="collapse" href="#armor_30Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Divine+Bird+Set">Divine Bird Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_30"></span>
             </h4>
@@ -5908,9 +5532,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -5934,9 +5556,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="30" id="armor_922" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_922&amp;id=armor_922&amp;link=/checklists/armor.html%23item_922&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Divine+Bird+Helm&quot;&gt;Divine Bird Helm&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_922&amp;id=armor_922&amp;link=/checklists/armor.html%23item_922&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Divine+Bird+Helm&quot;&gt;Divine Bird Helm&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5965,9 +5585,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="30" id="armor_923" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_923&amp;id=armor_923&amp;link=/checklists/armor.html%23item_923&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Divine+Bird+Warrior+Armor&quot;&gt;Divine Bird Warrior Armor&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_923&amp;id=armor_923&amp;link=/checklists/armor.html%23item_923&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Divine+Bird+Warrior+Armor&quot;&gt;Divine Bird Warrior Armor&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5995,9 +5613,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="30" id="armor_924" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_924&amp;id=armor_924&amp;link=/checklists/armor.html%23item_924&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Divine+Bird+Warrior+Gauntlets&quot;&gt;Divine Bird Warrior Gauntlets&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_924&amp;id=armor_924&amp;link=/checklists/armor.html%23item_924&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Divine+Bird+Warrior+Gauntlets&quot;&gt;Divine Bird Warrior Gauntlets&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6025,9 +5641,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="30" id="armor_925" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_925&amp;id=armor_925&amp;link=/checklists/armor.html%23item_925&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Divine+Bird+Warrior+Greaves&quot;&gt;Divine Bird Warrior Greaves&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_925&amp;id=armor_925&amp;link=/checklists/armor.html%23item_925&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Divine+Bird+Warrior+Greaves&quot;&gt;Divine Bird Warrior Greaves&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6056,9 +5670,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_31">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_31Col" data-bs-toggle="collapse" href="#armor_31Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_31Col" data-bs-toggle="collapse" href="#armor_31Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Rellana's+Set">Rellana's Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_31"></span>
             </h4>
@@ -6070,9 +5682,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -6096,9 +5706,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="31" id="armor_926" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_926&amp;id=armor_926&amp;link=/checklists/armor.html%23item_926&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Rellana's+Helm&quot;&gt;Rellana's Helm&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_926&amp;id=armor_926&amp;link=/checklists/armor.html%23item_926&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Rellana's+Helm&quot;&gt;Rellana's Helm&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6127,9 +5735,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="31" id="armor_927" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_927&amp;id=armor_927&amp;link=/checklists/armor.html%23item_927&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Rellana's+Armor&quot;&gt;Rellana's Armor&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_927&amp;id=armor_927&amp;link=/checklists/armor.html%23item_927&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Rellana's+Armor&quot;&gt;Rellana's Armor&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6157,9 +5763,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="31" id="armor_928" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_928&amp;id=armor_928&amp;link=/checklists/armor.html%23item_928&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Rellana's+Gloves&quot;&gt;Rellana's Gloves&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_928&amp;id=armor_928&amp;link=/checklists/armor.html%23item_928&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Rellana's+Gloves&quot;&gt;Rellana's Gloves&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6187,9 +5791,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="31" id="armor_929" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_929&amp;id=armor_929&amp;link=/checklists/armor.html%23item_929&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Rellana's+Greaves&quot;&gt;Rellana's Greaves&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_929&amp;id=armor_929&amp;link=/checklists/armor.html%23item_929&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Rellana's+Greaves&quot;&gt;Rellana's Greaves&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6218,9 +5820,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_32">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_32Col" data-bs-toggle="collapse" href="#armor_32Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_32Col" data-bs-toggle="collapse" href="#armor_32Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Young+Lion's+Set">Young Lion's Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_32"></span>
             </h4>
@@ -6232,9 +5832,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -6258,9 +5856,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="32" id="armor_930" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_930&amp;id=armor_930&amp;link=/checklists/armor.html%23item_930&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Young+Lion's+Helm&quot;&gt;Young Lion's Helm&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_930&amp;id=armor_930&amp;link=/checklists/armor.html%23item_930&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Young+Lion's+Helm&quot;&gt;Young Lion's Helm&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6289,9 +5885,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="32" id="armor_931" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_931&amp;id=armor_931&amp;link=/checklists/armor.html%23item_931&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Young+Lion's+Armor&quot;&gt;Young Lion's Armor&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_931&amp;id=armor_931&amp;link=/checklists/armor.html%23item_931&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Young+Lion's+Armor&quot;&gt;Young Lion's Armor&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6319,9 +5913,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="32" id="armor_932" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_932&amp;id=armor_932&amp;link=/checklists/armor.html%23item_932&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Young+Lion's+Gauntlets&quot;&gt;Young Lion's Gauntlets&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_932&amp;id=armor_932&amp;link=/checklists/armor.html%23item_932&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Young+Lion's+Gauntlets&quot;&gt;Young Lion's Gauntlets&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6349,9 +5941,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="32" id="armor_933" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_933&amp;id=armor_933&amp;link=/checklists/armor.html%23item_933&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Young+Lion's+Greaves&quot;&gt;Young Lion's Greaves&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_933&amp;id=armor_933&amp;link=/checklists/armor.html%23item_933&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Young+Lion's+Greaves&quot;&gt;Young Lion's Greaves&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6379,9 +5969,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="32" id="armor_934" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_934&amp;id=armor_934&amp;link=/checklists/armor.html%23item_934&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Young+Lion's+Armor+(Altered)&quot;&gt;Young Lion's Armor (Altered)&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_934&amp;id=armor_934&amp;link=/checklists/armor.html%23item_934&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Young+Lion's+Armor+(Altered)&quot;&gt;Young Lion's Armor (Altered)&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6410,9 +5998,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_33">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_33Col" data-bs-toggle="collapse" href="#armor_33Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_33Col" data-bs-toggle="collapse" href="#armor_33Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Circlet of Light</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_33"></span>
             </h4>
@@ -6424,9 +6010,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -6450,9 +6034,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="33" id="armor_935" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_935&amp;id=armor_935&amp;link=/checklists/armor.html%23item_935&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Circlet+of+Light&quot;&gt;Circlet of Light&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_935&amp;id=armor_935&amp;link=/checklists/armor.html%23item_935&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Circlet+of+Light&quot;&gt;Circlet of Light&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6482,9 +6064,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_34">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_34Col" data-bs-toggle="collapse" href="#armor_34Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_34Col" data-bs-toggle="collapse" href="#armor_34Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Shadow+Militiaman+Set">Shadow Militiaman Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_34"></span>
             </h4>
@@ -6496,9 +6076,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -6522,9 +6100,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="34" id="armor_936" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_936&amp;id=armor_936&amp;link=/checklists/armor.html%23item_936&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Shadow+Militiaman+Helm&quot;&gt;Shadow Militiaman Helm&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_936&amp;id=armor_936&amp;link=/checklists/armor.html%23item_936&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Shadow+Militiaman+Helm&quot;&gt;Shadow Militiaman Helm&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6553,9 +6129,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="34" id="armor_937" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_937&amp;id=armor_937&amp;link=/checklists/armor.html%23item_937&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Shadow+Militiaman+Armor&quot;&gt;Shadow Militiaman Armor&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_937&amp;id=armor_937&amp;link=/checklists/armor.html%23item_937&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Shadow+Militiaman+Armor&quot;&gt;Shadow Militiaman Armor&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6583,9 +6157,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="34" id="armor_938" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_938&amp;id=armor_938&amp;link=/checklists/armor.html%23item_938&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Shadow+Militiaman+Gauntlets&quot;&gt;Shadow Militiaman Gauntlets&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_938&amp;id=armor_938&amp;link=/checklists/armor.html%23item_938&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Shadow+Militiaman+Gauntlets&quot;&gt;Shadow Militiaman Gauntlets&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6613,9 +6185,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="34" id="armor_939" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_939&amp;id=armor_939&amp;link=/checklists/armor.html%23item_939&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Shadow+Militiaman+Greaves&quot;&gt;Shadow Militiaman Greaves&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_939&amp;id=armor_939&amp;link=/checklists/armor.html%23item_939&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Shadow+Militiaman+Greaves&quot;&gt;Shadow Militiaman Greaves&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6644,9 +6214,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_35">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_35Col" data-bs-toggle="collapse" href="#armor_35Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_35Col" data-bs-toggle="collapse" href="#armor_35Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Divine Beast Head</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_35"></span>
             </h4>
@@ -6658,9 +6226,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -6684,9 +6250,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="35" id="armor_940" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_940&amp;id=armor_940&amp;link=/checklists/armor.html%23item_940&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Divine+Beast+Head&quot;&gt;Divine Beast Head&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_940&amp;id=armor_940&amp;link=/checklists/armor.html%23item_940&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Divine+Beast+Head&quot;&gt;Divine Beast Head&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6716,9 +6280,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_36">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_36Col" data-bs-toggle="collapse" href="#armor_36Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_36Col" data-bs-toggle="collapse" href="#armor_36Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">St. Trina's Blossom</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_36"></span>
             </h4>
@@ -6730,9 +6292,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -6756,9 +6316,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="36" id="armor_941" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_941&amp;id=armor_941&amp;link=/checklists/armor.html%23item_941&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/St.+Trina's+Blossom&quot;&gt;St. Trina's Blossom&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_941&amp;id=armor_941&amp;link=/checklists/armor.html%23item_941&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/St.+Trina's+Blossom&quot;&gt;St. Trina's Blossom&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6788,9 +6346,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_37">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_37Col" data-bs-toggle="collapse" href="#armor_37Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_37Col" data-bs-toggle="collapse" href="#armor_37Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Crucible Hammer-Helm</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_37"></span>
             </h4>
@@ -6802,9 +6358,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -6828,9 +6382,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="37" id="armor_942" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_942&amp;id=armor_942&amp;link=/checklists/armor.html%23item_942&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Crucible+Hammer-Helm&quot;&gt;Crucible Hammer-Helm&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_942&amp;id=armor_942&amp;link=/checklists/armor.html%23item_942&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Crucible+Hammer-Helm&quot;&gt;Crucible Hammer-Helm&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6860,9 +6412,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_38">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_38Col" data-bs-toggle="collapse" href="#armor_38Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_38Col" data-bs-toggle="collapse" href="#armor_38Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Greatjar</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_38"></span>
             </h4>
@@ -6874,9 +6424,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -6900,9 +6448,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="38" id="armor_943" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_943&amp;id=armor_943&amp;link=/checklists/armor.html%23item_943&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Greatjar&quot;&gt;Greatjar&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_943&amp;id=armor_943&amp;link=/checklists/armor.html%23item_943&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Greatjar&quot;&gt;Greatjar&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6932,9 +6478,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_39">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_39Col" data-bs-toggle="collapse" href="#armor_39Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_39Col" data-bs-toggle="collapse" href="#armor_39Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Imp Head (Lion)</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_39"></span>
             </h4>
@@ -6946,9 +6490,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -6972,9 +6514,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="39" id="armor_944" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_944&amp;id=armor_944&amp;link=/checklists/armor.html%23item_944&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Imp+Head+(Lion)&quot;&gt;Imp Head (Lion)&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_944&amp;id=armor_944&amp;link=/checklists/armor.html%23item_944&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Imp+Head+(Lion)&quot;&gt;Imp Head (Lion)&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7004,9 +6544,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_40">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_40Col" data-bs-toggle="collapse" href="#armor_40Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_40Col" data-bs-toggle="collapse" href="#armor_40Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Traveler's+Set">Traveler's Set (No Helmet)</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_40"></span>
             </h4>
@@ -7018,9 +6556,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -7044,9 +6580,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="40" id="armor_0" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_0&amp;id=armor_0&amp;link=/checklists/armor.html%23item_0&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Traveler's+Clothes&quot;&gt;Traveler's Clothes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_0&amp;id=armor_0&amp;link=/checklists/armor.html%23item_0&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Traveler's+Clothes&quot;&gt;Traveler's Clothes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7075,9 +6609,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="40" id="armor_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_1&amp;id=armor_1&amp;link=/checklists/armor.html%23item_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Traveler's+Manchettes&quot;&gt;Traveler's Manchettes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_1&amp;id=armor_1&amp;link=/checklists/armor.html%23item_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Traveler's+Manchettes&quot;&gt;Traveler's Manchettes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7105,9 +6637,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="40" id="armor_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=armor_2&amp;id=armor_2&amp;link=/checklists/armor.html%23item_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Traveler's+Boots&quot;&gt;Traveler's Boots&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=armor_2&amp;id=armor_2&amp;link=/checklists/armor.html%23item_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Traveler's+Boots&quot;&gt;Traveler's Boots&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7136,9 +6666,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_41">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_41Col" data-bs-toggle="collapse" href="#armor_41Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_41Col" data-bs-toggle="collapse" href="#armor_41Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Commoner's+Set">Commoner's Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_41"></span>
             </h4>
@@ -7191,9 +6719,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_42">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_42Col" data-bs-toggle="collapse" href="#armor_42Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_42Col" data-bs-toggle="collapse" href="#armor_42Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Aristocrat+Set">Aristocrat Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_42"></span>
             </h4>
@@ -7254,9 +6780,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_43">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_43Col" data-bs-toggle="collapse" href="#armor_43Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_43Col" data-bs-toggle="collapse" href="#armor_43Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Old+Aristocrat+Set">Old Aristocrat Set (No Gloves)</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_43"></span>
             </h4>
@@ -7293,9 +6817,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_44">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_44Col" data-bs-toggle="collapse" href="#armor_44Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_44Col" data-bs-toggle="collapse" href="#armor_44Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Page+Set">Page Set (No Gloves)</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_44"></span>
             </h4>
@@ -7332,9 +6854,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_45">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_45Col" data-bs-toggle="collapse" href="#armor_45Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_45Col" data-bs-toggle="collapse" href="#armor_45Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/High+Page+Set">High Page Set (No Gloves)</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_45"></span>
             </h4>
@@ -7371,9 +6891,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_46">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_46Col" data-bs-toggle="collapse" href="#armor_46Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_46Col" data-bs-toggle="collapse" href="#armor_46Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Guardian+Set">Guardian Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_46"></span>
             </h4>
@@ -7426,9 +6944,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_47">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_47Col" data-bs-toggle="collapse" href="#armor_47Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_47Col" data-bs-toggle="collapse" href="#armor_47Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Festive+Set">Festive Set (No Gloves or Legs)</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_47"></span>
             </h4>
@@ -7465,9 +6981,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_48">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_48Col" data-bs-toggle="collapse" href="#armor_48Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_48Col" data-bs-toggle="collapse" href="#armor_48Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Blue+Festive+Set">Blue Festive Set (No Gloves or Legs)</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_48"></span>
             </h4>
@@ -7496,9 +7010,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_49">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_49Col" data-bs-toggle="collapse" href="#armor_49Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_49Col" data-bs-toggle="collapse" href="#armor_49Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Guilty+Set">Guilty Set (No Gloves)</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_49"></span>
             </h4>
@@ -7535,9 +7047,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_50">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_50Col" data-bs-toggle="collapse" href="#armor_50Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_50Col" data-bs-toggle="collapse" href="#armor_50Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Prisoner+Set">Prisoner Set (No Gloves)</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_50"></span>
             </h4>
@@ -7574,9 +7084,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_51">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_51Col" data-bs-toggle="collapse" href="#armor_51Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_51Col" data-bs-toggle="collapse" href="#armor_51Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Blackguard's Iron Mask (Helmet Only)</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_51"></span>
             </h4>
@@ -7597,9 +7105,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_52">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_52Col" data-bs-toggle="collapse" href="#armor_52Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_52Col" data-bs-toggle="collapse" href="#armor_52Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Bloodsoaked+Set">Bloodsoaked Set (No Legs)</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_52"></span>
             </h4>
@@ -7636,9 +7142,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_53">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_53Col" data-bs-toggle="collapse" href="#armor_53Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_53Col" data-bs-toggle="collapse" href="#armor_53Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Black Dumpling (Helmet Only)</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_53"></span>
             </h4>
@@ -7659,9 +7163,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_54">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_54Col" data-bs-toggle="collapse" href="#armor_54Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_54Col" data-bs-toggle="collapse" href="#armor_54Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Mushroom+Set">Mushroom Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_54"></span>
             </h4>
@@ -7714,9 +7216,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_55">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_55Col" data-bs-toggle="collapse" href="#armor_55Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_55Col" data-bs-toggle="collapse" href="#armor_55Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Astrologer+Set">Astrologer Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_55"></span>
             </h4>
@@ -7761,9 +7261,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_56">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_56Col" data-bs-toggle="collapse" href="#armor_56Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_56Col" data-bs-toggle="collapse" href="#armor_56Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Juvenile+Scholar+Set">Juvenile Scholar Set (No Gloves or Legs)</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_56"></span>
             </h4>
@@ -7792,9 +7290,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_57">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_57Col" data-bs-toggle="collapse" href="#armor_57Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_57Col" data-bs-toggle="collapse" href="#armor_57Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Raya+Lucarian+Sorcerer+Set">Raya Lucarian Sorcerer Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_57"></span>
             </h4>
@@ -7863,9 +7359,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_58">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_58Col" data-bs-toggle="collapse" href="#armor_58Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_58Col" data-bs-toggle="collapse" href="#armor_58Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Lazuli+Sorcerer+Set">Lazuli Sorcerer Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_58"></span>
             </h4>
@@ -7910,9 +7404,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_59">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_59Col" data-bs-toggle="collapse" href="#armor_59Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_59Col" data-bs-toggle="collapse" href="#armor_59Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Battlemage+Set">Battlemage Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_59"></span>
             </h4>
@@ -7957,9 +7449,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_60">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_60Col" data-bs-toggle="collapse" href="#armor_60Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_60Col" data-bs-toggle="collapse" href="#armor_60Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Errant+Sorcerer+Set">Errant Sorcerer Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_60"></span>
             </h4>
@@ -8004,9 +7494,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_61">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_61Col" data-bs-toggle="collapse" href="#armor_61Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_61Col" data-bs-toggle="collapse" href="#armor_61Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Spellblade+Set">Spellblade Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_61"></span>
             </h4>
@@ -8051,9 +7539,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_62">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_62Col" data-bs-toggle="collapse" href="#armor_62Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_62Col" data-bs-toggle="collapse" href="#armor_62Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Alberich's+Set">Alberich's Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_62"></span>
             </h4>
@@ -8098,9 +7584,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_63">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_63Col" data-bs-toggle="collapse" href="#armor_63Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_63Col" data-bs-toggle="collapse" href="#armor_63Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Preceptor's+Set">Preceptor's Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_63"></span>
             </h4>
@@ -8145,9 +7629,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_64">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_64Col" data-bs-toggle="collapse" href="#armor_64Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_64Col" data-bs-toggle="collapse" href="#armor_64Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Mask of Confidence (Helmet Only)</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_64"></span>
             </h4>
@@ -8168,9 +7650,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_65">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_65Col" data-bs-toggle="collapse" href="#armor_65Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_65Col" data-bs-toggle="collapse" href="#armor_65Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Azur's+Glintstone+Set">Azur's Glintstone Set (No Legs)</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_65"></span>
             </h4>
@@ -8207,9 +7687,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_66">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_66Col" data-bs-toggle="collapse" href="#armor_66Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_66Col" data-bs-toggle="collapse" href="#armor_66Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Lusat's+Set">Lusat's Glintstone Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_66"></span>
             </h4>
@@ -8254,9 +7732,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_67">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_67Col" data-bs-toggle="collapse" href="#armor_67Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_67Col" data-bs-toggle="collapse" href="#armor_67Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Queen+of+the+Full+Moon+Set">Queen of the Full Moon Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_67"></span>
             </h4>
@@ -8301,9 +7777,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_68">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_68Col" data-bs-toggle="collapse" href="#armor_68Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_68Col" data-bs-toggle="collapse" href="#armor_68Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Snow+Witch+Set">Snow Witch Set (No Gloves)</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_68"></span>
             </h4>
@@ -8340,9 +7814,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_69">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_69Col" data-bs-toggle="collapse" href="#armor_69Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_69Col" data-bs-toggle="collapse" href="#armor_69Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Fia's+Set">Fia's Set (No Gloves or Legs)</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_69"></span>
             </h4>
@@ -8371,9 +7843,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_70">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_70Col" data-bs-toggle="collapse" href="#armor_70Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_70Col" data-bs-toggle="collapse" href="#armor_70Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Deathbed Dress (Chest Only)</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_70"></span>
             </h4>
@@ -8394,9 +7864,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_71">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_71Col" data-bs-toggle="collapse" href="#armor_71Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_71Col" data-bs-toggle="collapse" href="#armor_71Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Prophet+Set">Prophet Set (No Gloves)</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_71"></span>
             </h4>
@@ -8433,9 +7901,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_72">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_72Col" data-bs-toggle="collapse" href="#armor_72Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_72Col" data-bs-toggle="collapse" href="#armor_72Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Corhyn's Robe (Chest Only)</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_72"></span>
             </h4>
@@ -8456,9 +7922,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_73">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_73Col" data-bs-toggle="collapse" href="#armor_73Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_73Col" data-bs-toggle="collapse" href="#armor_73Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Traveling+Maiden+Set">Traveling Maiden Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_73"></span>
             </h4>
@@ -8503,9 +7967,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_74">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_74Col" data-bs-toggle="collapse" href="#armor_74Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_74Col" data-bs-toggle="collapse" href="#armor_74Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Finger+Maiden+Set">Finger Maiden Set (No Gloves)</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_74"></span>
             </h4>
@@ -8542,9 +8004,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_75">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_75Col" data-bs-toggle="collapse" href="#armor_75Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_75Col" data-bs-toggle="collapse" href="#armor_75Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Sage+Set">Sage Set (No Gloves)</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_75"></span>
             </h4>
@@ -8581,9 +8041,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_76">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_76Col" data-bs-toggle="collapse" href="#armor_76Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_76Col" data-bs-toggle="collapse" href="#armor_76Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Greathood (Helmet Only)</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_76"></span>
             </h4>
@@ -8604,9 +8062,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_77">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_77Col" data-bs-toggle="collapse" href="#armor_77Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_77Col" data-bs-toggle="collapse" href="#armor_77Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Goldmask's+Set">Goldmask's Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_77"></span>
             </h4>
@@ -8651,9 +8107,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_78">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_78Col" data-bs-toggle="collapse" href="#armor_78Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_78Col" data-bs-toggle="collapse" href="#armor_78Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Perfumer+Set">Perfumer Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_78"></span>
             </h4>
@@ -8698,9 +8152,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_79">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_79Col" data-bs-toggle="collapse" href="#armor_79Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_79Col" data-bs-toggle="collapse" href="#armor_79Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Perfumer+Traveler%27s+Set">Perfumer Traveler's Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_79"></span>
             </h4>
@@ -8745,9 +8197,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_80">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_80Col" data-bs-toggle="collapse" href="#armor_80Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_80Col" data-bs-toggle="collapse" href="#armor_80Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Depraved+Perfumer+Set">Depraved Perfumer Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_80"></span>
             </h4>
@@ -8792,9 +8242,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_81">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_81Col" data-bs-toggle="collapse" href="#armor_81Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_81Col" data-bs-toggle="collapse" href="#armor_81Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Upper-Class Robe (Chest Only)</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_81"></span>
             </h4>
@@ -8815,9 +8263,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_82">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_82Col" data-bs-toggle="collapse" href="#armor_82Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_82Col" data-bs-toggle="collapse" href="#armor_82Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Ruler's+Set">Ruler's Set (No Gloves or Legs)</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_82"></span>
             </h4>
@@ -8846,9 +8292,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_83">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_83Col" data-bs-toggle="collapse" href="#armor_83Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_83Col" data-bs-toggle="collapse" href="#armor_83Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Consort's+Set">Consort's Set (No Gloves)</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_83"></span>
             </h4>
@@ -8885,9 +8329,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_84">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_84Col" data-bs-toggle="collapse" href="#armor_84Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_84Col" data-bs-toggle="collapse" href="#armor_84Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/House+Marais+Set">House Marais Set (No Gloves or Legs)</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_84"></span>
             </h4>
@@ -8916,9 +8358,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_85">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_85Col" data-bs-toggle="collapse" href="#armor_85Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_85Col" data-bs-toggle="collapse" href="#armor_85Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Fur+Set">Fur Set (No Gloves)</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_85"></span>
             </h4>
@@ -8955,9 +8395,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_86">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_86Col" data-bs-toggle="collapse" href="#armor_86Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_86Col" data-bs-toggle="collapse" href="#armor_86Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Shaman+Set">Shaman Set (No Gloves)</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_86"></span>
             </h4>
@@ -8994,9 +8432,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_87">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_87Col" data-bs-toggle="collapse" href="#armor_87Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_87Col" data-bs-toggle="collapse" href="#armor_87Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Godskin+Apostle+Set">Godskin Apostle Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_87"></span>
             </h4>
@@ -9041,9 +8477,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_88">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_88Col" data-bs-toggle="collapse" href="#armor_88Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_88Col" data-bs-toggle="collapse" href="#armor_88Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Godskin+Noble+Set">Godskin Noble Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_88"></span>
             </h4>
@@ -9088,9 +8522,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_89">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_89Col" data-bs-toggle="collapse" href="#armor_89Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_89Col" data-bs-toggle="collapse" href="#armor_89Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Fell Omen Cloak (Chest Only)</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_89"></span>
             </h4>
@@ -9111,9 +8543,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_90">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_90Col" data-bs-toggle="collapse" href="#armor_90Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_90Col" data-bs-toggle="collapse" href="#armor_90Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Sanguine+Noble+Set">Sanguine Noble Set (No Gloves)</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_90"></span>
             </h4>
@@ -9150,9 +8580,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_91">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_91Col" data-bs-toggle="collapse" href="#armor_91Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_91Col" data-bs-toggle="collapse" href="#armor_91Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Lord of Blood's Robes (Chest Only)</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_91"></span>
             </h4>
@@ -9173,9 +8601,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_92">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_92Col" data-bs-toggle="collapse" href="#armor_92Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_92Col" data-bs-toggle="collapse" href="#armor_92Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Scarab Masks</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_92"></span>
             </h4>
@@ -9228,9 +8654,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_93">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_93Col" data-bs-toggle="collapse" href="#armor_93Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_93Col" data-bs-toggle="collapse" href="#armor_93Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Imp Heads</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_93"></span>
             </h4>
@@ -9291,9 +8715,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_94">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_94Col" data-bs-toggle="collapse" href="#armor_94Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_94Col" data-bs-toggle="collapse" href="#armor_94Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Nox Mirrorhelm (Helmet Only)</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_94"></span>
             </h4>
@@ -9314,9 +8736,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_95">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_95Col" data-bs-toggle="collapse" href="#armor_95Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_95Col" data-bs-toggle="collapse" href="#armor_95Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Iji's Mirrorhelm (Helmet Only)</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_95"></span>
             </h4>
@@ -9337,9 +8757,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_96">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_96Col" data-bs-toggle="collapse" href="#armor_96Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_96Col" data-bs-toggle="collapse" href="#armor_96Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Silver Tear Mask (Helmet Only)</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_96"></span>
             </h4>
@@ -9360,9 +8778,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_97">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_97Col" data-bs-toggle="collapse" href="#armor_97Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_97Col" data-bs-toggle="collapse" href="#armor_97Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Envoy Crown (Helmet Only)</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_97"></span>
             </h4>
@@ -9383,9 +8799,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_98">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_98Col" data-bs-toggle="collapse" href="#armor_98Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_98Col" data-bs-toggle="collapse" href="#armor_98Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Octopus Head (Helmet Only)</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_98"></span>
             </h4>
@@ -9406,9 +8820,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_99">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_99Col" data-bs-toggle="collapse" href="#armor_99Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_99Col" data-bs-toggle="collapse" href="#armor_99Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Jar (Helmet Only)</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_99"></span>
             </h4>
@@ -9429,9 +8841,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_100">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_100Col" data-bs-toggle="collapse" href="#armor_100Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_100Col" data-bs-toggle="collapse" href="#armor_100Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Albinauric+Set">Albinauric Set (No Gloves or Legs)</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_100"></span>
             </h4>
@@ -9460,9 +8870,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_101">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_101Col" data-bs-toggle="collapse" href="#armor_101Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_101Col" data-bs-toggle="collapse" href="#armor_101Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Leather+Set">Leather Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_101"></span>
             </h4>
@@ -9507,9 +8915,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_102">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_102Col" data-bs-toggle="collapse" href="#armor_102Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_102Col" data-bs-toggle="collapse" href="#armor_102Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Blue+Cloth+Set">Blue Cloth Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_102"></span>
             </h4>
@@ -9554,9 +8960,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_103">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_103Col" data-bs-toggle="collapse" href="#armor_103Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_103Col" data-bs-toggle="collapse" href="#armor_103Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Noble's+Set">Noble's Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_103"></span>
             </h4>
@@ -9609,9 +9013,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_104">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_104Col" data-bs-toggle="collapse" href="#armor_104Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_104Col" data-bs-toggle="collapse" href="#armor_104Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="">War Surgeon Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_104"></span>
             </h4>
@@ -9656,9 +9058,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_105">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_105Col" data-bs-toggle="collapse" href="#armor_105Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_105Col" data-bs-toggle="collapse" href="#armor_105Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Nomadic+Merchant's+Set">Nomadic Merchant's Set (No Gloves)</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_105"></span>
             </h4>
@@ -9695,9 +9095,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_106">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_106Col" data-bs-toggle="collapse" href="#armor_106Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_106Col" data-bs-toggle="collapse" href="#armor_106Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Bandit+Set">Bandit Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_106"></span>
             </h4>
@@ -9742,9 +9140,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_107">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_107Col" data-bs-toggle="collapse" href="#armor_107Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_107Col" data-bs-toggle="collapse" href="#armor_107Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Confessor+Set">Confessor Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_107"></span>
             </h4>
@@ -9789,9 +9185,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_108">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_108Col" data-bs-toggle="collapse" href="#armor_108Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_108Col" data-bs-toggle="collapse" href="#armor_108Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Omenkiller+Set">Omenkiller Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_108"></span>
             </h4>
@@ -9836,9 +9230,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_109">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_109Col" data-bs-toggle="collapse" href="#armor_109Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_109Col" data-bs-toggle="collapse" href="#armor_109Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Raptor's+Set">Raptor's Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_109"></span>
             </h4>
@@ -9883,9 +9275,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_110">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_110Col" data-bs-toggle="collapse" href="#armor_110Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_110Col" data-bs-toggle="collapse" href="#armor_110Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Godrick+Foot+Soldier+Set">Godrick Foot Soldier Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_110"></span>
             </h4>
@@ -9930,9 +9320,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_111">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_111Col" data-bs-toggle="collapse" href="#armor_111Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_111Col" data-bs-toggle="collapse" href="#armor_111Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Raya+Lucarian+Foot+Soldier+Set">Raya Lucarian Foot Soldier Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_111"></span>
             </h4>
@@ -9977,9 +9365,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_112">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_112Col" data-bs-toggle="collapse" href="#armor_112Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_112Col" data-bs-toggle="collapse" href="#armor_112Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Radahn+Foot+Soldier+Set">Radahn Foot Soldier Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_112"></span>
             </h4>
@@ -10024,9 +9410,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_113">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_113Col" data-bs-toggle="collapse" href="#armor_113Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_113Col" data-bs-toggle="collapse" href="#armor_113Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Leyndell+Foot+Soldier+Set">Leyndell Foot Soldier Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_113"></span>
             </h4>
@@ -10071,9 +9455,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_114">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_114Col" data-bs-toggle="collapse" href="#armor_114Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_114Col" data-bs-toggle="collapse" href="#armor_114Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Haligtree+Foot+Soldier+Set">Haligtree Foot Soldier Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_114"></span>
             </h4>
@@ -10118,9 +9500,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_115">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_115Col" data-bs-toggle="collapse" href="#armor_115Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_115Col" data-bs-toggle="collapse" href="#armor_115Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Mausoleum+Foot+Soldier+Set">Mausoleum Foot Soldier Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_115"></span>
             </h4>
@@ -10157,9 +9537,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_116">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_116Col" data-bs-toggle="collapse" href="#armor_116Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_116Col" data-bs-toggle="collapse" href="#armor_116Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Highwayman+Set">Highwayman Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_116"></span>
             </h4>
@@ -10204,9 +9582,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_117">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_117Col" data-bs-toggle="collapse" href="#armor_117Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_117Col" data-bs-toggle="collapse" href="#armor_117Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Vulgar+Militia+Set">Vulgar Militia Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_117"></span>
             </h4>
@@ -10251,9 +9627,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_118">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_118Col" data-bs-toggle="collapse" href="#armor_118Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_118Col" data-bs-toggle="collapse" href="#armor_118Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Duelist+Set">Duelist Set (No Gloves)</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_118"></span>
             </h4>
@@ -10290,9 +9664,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_119">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_119Col" data-bs-toggle="collapse" href="#armor_119Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_119Col" data-bs-toggle="collapse" href="#armor_119Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Rotten+Duelist+Set">Rotten Duelist Set (No Gloves)</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_119"></span>
             </h4>
@@ -10329,9 +9701,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_120">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_120Col" data-bs-toggle="collapse" href="#armor_120Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_120Col" data-bs-toggle="collapse" href="#armor_120Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Nox+Monk+Set">Nox Monk Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_120"></span>
             </h4>
@@ -10376,9 +9746,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_121">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_121Col" data-bs-toggle="collapse" href="#armor_121Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_121Col" data-bs-toggle="collapse" href="#armor_121Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Nox+Swordstress+Set">Nox Swordstress Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_121"></span>
             </h4>
@@ -10423,9 +9791,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_122">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_122Col" data-bs-toggle="collapse" href="#armor_122Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_122Col" data-bs-toggle="collapse" href="#armor_122Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Night+Maiden+Set">Night Maiden Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_122"></span>
             </h4>
@@ -10470,9 +9836,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_123">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_123Col" data-bs-toggle="collapse" href="#armor_123Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_123Col" data-bs-toggle="collapse" href="#armor_123Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Champion+Set">Champion Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_123"></span>
             </h4>
@@ -10517,9 +9881,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_124">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_124Col" data-bs-toggle="collapse" href="#armor_124Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_124Col" data-bs-toggle="collapse" href="#armor_124Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Chain+Set">Chain Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_124"></span>
             </h4>
@@ -10580,9 +9942,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_125">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_125Col" data-bs-toggle="collapse" href="#armor_125Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_125Col" data-bs-toggle="collapse" href="#armor_125Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Iron+Set">Iron Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_125"></span>
             </h4>
@@ -10627,9 +9987,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_126">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_126Col" data-bs-toggle="collapse" href="#armor_126Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_126Col" data-bs-toggle="collapse" href="#armor_126Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Godrick+Soldier+Set">Godrick Soldier Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_126"></span>
             </h4>
@@ -10674,9 +10032,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_127">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_127Col" data-bs-toggle="collapse" href="#armor_127Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_127Col" data-bs-toggle="collapse" href="#armor_127Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Raya+Lucarian+Soldier+Set">Raya Lucarian Soldier Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_127"></span>
             </h4>
@@ -10721,9 +10077,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_128">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_128Col" data-bs-toggle="collapse" href="#armor_128Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_128Col" data-bs-toggle="collapse" href="#armor_128Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Radahn+Soldier+Set">Radahn Soldier Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_128"></span>
             </h4>
@@ -10768,9 +10122,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_129">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_129Col" data-bs-toggle="collapse" href="#armor_129Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_129Col" data-bs-toggle="collapse" href="#armor_129Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Leyndell+Soldier+Set">Leyndell Soldier Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_129"></span>
             </h4>
@@ -10815,9 +10167,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_130">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_130Col" data-bs-toggle="collapse" href="#armor_130Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_130Col" data-bs-toggle="collapse" href="#armor_130Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Haligtree+Soldier+Set">Haligtree Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_130"></span>
             </h4>
@@ -10862,9 +10212,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_131">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_131Col" data-bs-toggle="collapse" href="#armor_131Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_131Col" data-bs-toggle="collapse" href="#armor_131Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Mausoleum+Soldier+Set">Mausoleum Soldier Set (No Helmet)</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_131"></span>
             </h4>
@@ -10901,9 +10249,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_132">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_132Col" data-bs-toggle="collapse" href="#armor_132Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_132Col" data-bs-toggle="collapse" href="#armor_132Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Exile+Set">Exile Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_132"></span>
             </h4>
@@ -10948,9 +10294,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_133">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_133Col" data-bs-toggle="collapse" href="#armor_133Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_133Col" data-bs-toggle="collapse" href="#armor_133Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Kaiden+Set">Kaiden Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_133"></span>
             </h4>
@@ -10995,9 +10339,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_134">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_134Col" data-bs-toggle="collapse" href="#armor_134Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_134Col" data-bs-toggle="collapse" href="#armor_134Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Land+of+Reeds+Set">Land of Reeds Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_134"></span>
             </h4>
@@ -11042,9 +10384,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_135">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_135Col" data-bs-toggle="collapse" href="#armor_135Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_135Col" data-bs-toggle="collapse" href="#armor_135Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/White+Reed+Set">White Reed Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_135"></span>
             </h4>
@@ -11089,9 +10429,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_136">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_136Col" data-bs-toggle="collapse" href="#armor_136Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_136Col" data-bs-toggle="collapse" href="#armor_136Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Ronin's+Set">Ronin's Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_136"></span>
             </h4>
@@ -11136,9 +10474,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_137">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_137Col" data-bs-toggle="collapse" href="#armor_137Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_137Col" data-bs-toggle="collapse" href="#armor_137Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Eccentric+Set">Eccentric Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_137"></span>
             </h4>
@@ -11183,9 +10519,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_138">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_138Col" data-bs-toggle="collapse" href="#armor_138Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_138Col" data-bs-toggle="collapse" href="#armor_138Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Marionette+Soldier+Set">Marionette Soldier Set (No Gloves or Legs)</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_138"></span>
             </h4>
@@ -11222,9 +10556,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_139">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_139Col" data-bs-toggle="collapse" href="#armor_139Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_139Col" data-bs-toggle="collapse" href="#armor_139Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Blue+Silver+Set">Blue Silver Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_139"></span>
             </h4>
@@ -11269,9 +10601,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_140">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_140Col" data-bs-toggle="collapse" href="#armor_140Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_140Col" data-bs-toggle="collapse" href="#armor_140Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Fire+Monk+Set">Fire Monk Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_140"></span>
             </h4>
@@ -11316,9 +10646,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_141">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_141Col" data-bs-toggle="collapse" href="#armor_141Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_141Col" data-bs-toggle="collapse" href="#armor_141Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Blackflame+Monk+Set">Blackflame Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_141"></span>
             </h4>
@@ -11363,9 +10691,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_142">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_142Col" data-bs-toggle="collapse" href="#armor_142Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_142Col" data-bs-toggle="collapse" href="#armor_142Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Zamor+Set">Zamor Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_142"></span>
             </h4>
@@ -11410,9 +10736,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_143">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_143Col" data-bs-toggle="collapse" href="#armor_143Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_143Col" data-bs-toggle="collapse" href="#armor_143Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Black+Knife+Set">Black Knife Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_143"></span>
             </h4>
@@ -11457,9 +10781,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_144">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_144Col" data-bs-toggle="collapse" href="#armor_144Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_144Col" data-bs-toggle="collapse" href="#armor_144Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Malenia's+Set">Malenia's Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_144"></span>
             </h4>
@@ -11504,9 +10826,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_145">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_145Col" data-bs-toggle="collapse" href="#armor_145Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_145Col" data-bs-toggle="collapse" href="#armor_145Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Elden+Lord+Set">Elden Lord Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_145"></span>
             </h4>
@@ -11551,9 +10871,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_146">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_146Col" data-bs-toggle="collapse" href="#armor_146Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_146Col" data-bs-toggle="collapse" href="#armor_146Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Knight+Set">Knight Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_146"></span>
             </h4>
@@ -11598,9 +10916,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_147">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_147Col" data-bs-toggle="collapse" href="#armor_147Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_147Col" data-bs-toggle="collapse" href="#armor_147Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Vagabond+Knight+Set">Vagabond Knight Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_147"></span>
             </h4>
@@ -11645,9 +10961,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_148">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_148Col" data-bs-toggle="collapse" href="#armor_148Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_148Col" data-bs-toggle="collapse" href="#armor_148Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Greathelm (Helmet Only)</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_148"></span>
             </h4>
@@ -11668,9 +10982,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_149">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_149Col" data-bs-toggle="collapse" href="#armor_149Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_149Col" data-bs-toggle="collapse" href="#armor_149Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Carian+Knight+Set">Carian Knight Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_149"></span>
             </h4>
@@ -11715,9 +11027,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_150">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_150Col" data-bs-toggle="collapse" href="#armor_150Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_150Col" data-bs-toggle="collapse" href="#armor_150Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Godrick+Knight+Set">Godrick Knight Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_150"></span>
             </h4>
@@ -11762,9 +11072,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_151">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_151Col" data-bs-toggle="collapse" href="#armor_151Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_151Col" data-bs-toggle="collapse" href="#armor_151Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Cuckoo+Knight+Set">Cuckoo Knight Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_151"></span>
             </h4>
@@ -11809,9 +11117,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_152">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_152Col" data-bs-toggle="collapse" href="#armor_152Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_152Col" data-bs-toggle="collapse" href="#armor_152Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Redmane+Knight+Set">Redmane Knight Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_152"></span>
             </h4>
@@ -11856,9 +11162,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_153">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_153Col" data-bs-toggle="collapse" href="#armor_153Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_153Col" data-bs-toggle="collapse" href="#armor_153Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Gelmir+Knight+Set">Gelmir Knight Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_153"></span>
             </h4>
@@ -11903,9 +11207,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_154">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_154Col" data-bs-toggle="collapse" href="#armor_154Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_154Col" data-bs-toggle="collapse" href="#armor_154Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Leyndell+Knight+Set">Leyndell Knight Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_154"></span>
             </h4>
@@ -11950,9 +11252,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_155">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_155Col" data-bs-toggle="collapse" href="#armor_155Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_155Col" data-bs-toggle="collapse" href="#armor_155Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Haligtree+Knight+Set">Haligtree Knight Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_155"></span>
             </h4>
@@ -11997,9 +11297,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_156">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_156Col" data-bs-toggle="collapse" href="#armor_156Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_156Col" data-bs-toggle="collapse" href="#armor_156Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Mausoleum+Knight+Set">Mausoleum Knight Set (No Helmet)</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_156"></span>
             </h4>
@@ -12036,9 +11334,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_157">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_157Col" data-bs-toggle="collapse" href="#armor_157Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_157Col" data-bs-toggle="collapse" href="#armor_157Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Bloodhound+Knight+Set">Bloodhound Knight Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_157"></span>
             </h4>
@@ -12083,9 +11379,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_158">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_158Col" data-bs-toggle="collapse" href="#armor_158Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_158Col" data-bs-toggle="collapse" href="#armor_158Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Cleanrot+Set">Cleanrot Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_158"></span>
             </h4>
@@ -12130,9 +11424,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_159">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_159Col" data-bs-toggle="collapse" href="#armor_159Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_159Col" data-bs-toggle="collapse" href="#armor_159Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Raging+Wolf+Set">Raging Wolf Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_159"></span>
             </h4>
@@ -12177,9 +11469,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_160">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_160Col" data-bs-toggle="collapse" href="#armor_160Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_160Col" data-bs-toggle="collapse" href="#armor_160Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Hoslow's+Set">Hoslow's Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_160"></span>
             </h4>
@@ -12232,9 +11522,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_161">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_161Col" data-bs-toggle="collapse" href="#armor_161Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_161Col" data-bs-toggle="collapse" href="#armor_161Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Twinned+Set">Twinned Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_161"></span>
             </h4>
@@ -12279,9 +11567,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_162">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_162Col" data-bs-toggle="collapse" href="#armor_162Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_162Col" data-bs-toggle="collapse" href="#armor_162Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Drake+Knight+Set">Drake Knight Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_162"></span>
             </h4>
@@ -12326,9 +11612,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_163">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_163Col" data-bs-toggle="collapse" href="#armor_163Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_163Col" data-bs-toggle="collapse" href="#armor_163Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="">Blaidd's Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_163"></span>
             </h4>
@@ -12373,9 +11657,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_164">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_164Col" data-bs-toggle="collapse" href="#armor_164Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_164Col" data-bs-toggle="collapse" href="#armor_164Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Briar+Set">Briar Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_164"></span>
             </h4>
@@ -12420,9 +11702,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_165">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_165Col" data-bs-toggle="collapse" href="#armor_165Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_165Col" data-bs-toggle="collapse" href="#armor_165Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Fingerprint+Set">Fingerprint Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_165"></span>
             </h4>
@@ -12467,9 +11747,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_166">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_166Col" data-bs-toggle="collapse" href="#armor_166Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_166Col" data-bs-toggle="collapse" href="#armor_166Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Royal+Remains+Set">Royal Remains Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_166"></span>
             </h4>
@@ -12514,9 +11792,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_167">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_167Col" data-bs-toggle="collapse" href="#armor_167Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_167Col" data-bs-toggle="collapse" href="#armor_167Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/All-Knowing+Set">All-Knowing Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_167"></span>
             </h4>
@@ -12561,9 +11837,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_168">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_168Col" data-bs-toggle="collapse" href="#armor_168Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_168Col" data-bs-toggle="collapse" href="#armor_168Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Royal+Knight+Set">Royal Knight Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_168"></span>
             </h4>
@@ -12608,9 +11882,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_169">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_169Col" data-bs-toggle="collapse" href="#armor_169Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_169Col" data-bs-toggle="collapse" href="#armor_169Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Maliketh's+Set">Maliketh's Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_169"></span>
             </h4>
@@ -12655,9 +11927,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_170">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_170Col" data-bs-toggle="collapse" href="#armor_170Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_170Col" data-bs-toggle="collapse" href="#armor_170Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Banished+Knight+Set">Banished Knight Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_170"></span>
             </h4>
@@ -12718,9 +11988,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_171">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_171Col" data-bs-toggle="collapse" href="#armor_171Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_171Col" data-bs-toggle="collapse" href="#armor_171Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Night's+Cavalry+Set">Night's Cavalry Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_171"></span>
             </h4>
@@ -12765,9 +12033,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_172">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_172Col" data-bs-toggle="collapse" href="#armor_172Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_172Col" data-bs-toggle="collapse" href="#armor_172Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Veteran's+Set">Veteran's Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_172"></span>
             </h4>
@@ -12812,9 +12078,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_173">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_173Col" data-bs-toggle="collapse" href="#armor_173Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_173Col" data-bs-toggle="collapse" href="#armor_173Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Scaled+Set">Scaled Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_173"></span>
             </h4>
@@ -12859,9 +12123,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_174">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_174Col" data-bs-toggle="collapse" href="#armor_174Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_174Col" data-bs-toggle="collapse" href="#armor_174Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Beast+Champion+Set">Beast Champion Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_174"></span>
             </h4>
@@ -12914,9 +12176,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_175">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_175Col" data-bs-toggle="collapse" href="#armor_175Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_175Col" data-bs-toggle="collapse" href="#armor_175Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Tree+Sentinel+Set">Tree Sentinel Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_175"></span>
             </h4>
@@ -12961,9 +12221,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_176">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_176Col" data-bs-toggle="collapse" href="#armor_176Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_176Col" data-bs-toggle="collapse" href="#armor_176Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Malformed+Dragon+Set">Malformed Dragon Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_176"></span>
             </h4>
@@ -13008,9 +12266,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_177">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_177Col" data-bs-toggle="collapse" href="#armor_177Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_177Col" data-bs-toggle="collapse" href="#armor_177Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Crucible+Axe+Set">Crucible Axe Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_177"></span>
             </h4>
@@ -13055,9 +12311,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_178">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_178Col" data-bs-toggle="collapse" href="#armor_178Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_178Col" data-bs-toggle="collapse" href="#armor_178Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Crucible+Tree+Set">Crucible Tree Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_178"></span>
             </h4>
@@ -13102,9 +12356,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_179">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_179Col" data-bs-toggle="collapse" href="#armor_179Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_179Col" data-bs-toggle="collapse" href="#armor_179Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/General+Radahn+Set">General Radahn's Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_179"></span>
             </h4>
@@ -13149,9 +12401,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_180">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_180Col" data-bs-toggle="collapse" href="#armor_180Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_180Col" data-bs-toggle="collapse" href="#armor_180Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Lionel's+Set">Lionel's Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_180"></span>
             </h4>
@@ -13196,9 +12446,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_181">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_181Col" data-bs-toggle="collapse" href="#armor_181Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_181Col" data-bs-toggle="collapse" href="#armor_181Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Bull-Goat+Set">Bull-Goat Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_181"></span>
             </h4>
@@ -13243,9 +12491,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_182">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_182Col" data-bs-toggle="collapse" href="#armor_182Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_182Col" data-bs-toggle="collapse" href="#armor_182Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Omen+Set">Omen Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_182"></span>
             </h4>
@@ -13290,9 +12536,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_183">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_183Col" data-bs-toggle="collapse" href="#armor_183Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_183Col" data-bs-toggle="collapse" href="#armor_183Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Fire+Prelate+Set">Fire Prelate's Set</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_183"></span>
             </h4>
@@ -13345,9 +12589,7 @@
         <div class="card shadow-sm mb-3" id="armor_section_184">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_184Col" data-bs-toggle="collapse" href="#armor_184Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#armor_184Col" data-bs-toggle="collapse" href="#armor_184Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Pumpkin Helm (Helmet Only)</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="armor_totals_184"></span>
             </h4>

--- a/docs/checklists/ashesof_war.html
+++ b/docs/checklists/ashesof_war.html
@@ -27,14 +27,10 @@
         <a class="navbar-brand me-auto ms-2" href="/index.html">Roundtable Guides</a>
         <form class="d-none d-sm-flex order-2 order-xl-3">
           <input aria-label="search" class="form-control me-2" name="search" placeholder="Search" type="search">
-          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit">
-            <i class="bi bi-search"></i>
-          </button>
+          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit"><i class="bi bi-search"></i></button>
         </form>
         <div class="d-sm-none order-2">
-          <a class="nav-link me-0" href="/search.html">
-            <i class="bi bi-search sb-icon-search"></i>
-          </a>
+          <a class="nav-link me-0" href="/search.html"><i class="bi bi-search sb-icon-search"></i></a>
         </div>
         <div class="collapse navbar-collapse order-3 order-xl-2 ms-xl-2" id="nav-collapse">
           <ul class="nav navbar-nav navbar-nav-scroll mr-auto">
@@ -179,14 +175,10 @@
               </ul>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/map.html">
-                <i class="bi bi-map"></i> Map
-              </a>
+              <a class="nav-link hide-buttons" href="/map.html"><i class="bi bi-map"></i> Map</a>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/options.html">
-                <i class="bi bi-gear-fill"></i> Options
-              </a>
+              <a class="nav-link hide-buttons" href="/options.html"><i class="bi bi-gear-fill"></i> Options</a>
             </li>
           </ul>
         </div>
@@ -206,9 +198,7 @@
       </div>
       <nav class="text-muted toc d-print-none">
         <strong class="d-block h5">
-          <a class="toc-button" data-bs-toggle="collapse" href="#toc_ashesofwar" role="button">
-            <i class="bi bi-plus-lg"></i>Table Of Contents
-          </a>
+          <a class="toc-button" data-bs-toggle="collapse" href="#toc_ashesofwar" role="button"><i class="bi bi-plus-lg"></i>Table Of Contents</a>
         </strong>
         <ul class="toc_page collapse" id="toc_ashesofwar">
           <li>
@@ -286,9 +276,7 @@
         <div class="card shadow-sm mb-3" id="ashesofwar_section_0">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#ashesofwar_0Col" data-bs-toggle="collapse" href="#ashesofwar_0Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#ashesofwar_0Col" data-bs-toggle="collapse" href="#ashesofwar_0Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Heavy</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="ashesofwar_totals_0"></span>
             </h4>
@@ -300,9 +288,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -331,9 +317,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="ashesofwar_5_11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_5_11&amp;id=ashesofwar_5_11&amp;link=/checklists/ashesof_war.html%23item_5_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Stamp+(Upward+Cut)&quot;&gt;Stamp (Upward Cut)&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_5_11&amp;id=ashesofwar_5_11&amp;link=/checklists/ashesof_war.html%23item_5_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Stamp+(Upward+Cut)&quot;&gt;Stamp (Upward Cut)&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -366,9 +350,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="ashesofwar_5_10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_5_10&amp;id=ashesofwar_5_10&amp;link=/checklists/ashesof_war.html%23item_5_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Stamp+(Sweep)&quot;&gt;Stamp (Sweep)&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_5_10&amp;id=ashesofwar_5_10&amp;link=/checklists/ashesof_war.html%23item_5_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Stamp+(Sweep)&quot;&gt;Stamp (Sweep)&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -401,9 +383,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="ashesofwar_5_14" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_5_14&amp;id=ashesofwar_5_14&amp;link=/checklists/ashesof_war.html%23item_5_14&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Wild+Strikes&quot;&gt;Wild Strikes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_5_14&amp;id=ashesofwar_5_14&amp;link=/checklists/ashesof_war.html%23item_5_14&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Wild+Strikes&quot;&gt;Wild Strikes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -436,9 +416,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="ashesofwar_5_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_5_9&amp;id=ashesofwar_5_9&amp;link=/checklists/ashesof_war.html%23item_5_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Lion's+Claw&quot;&gt;Lion's Claw&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_5_9&amp;id=ashesofwar_5_9&amp;link=/checklists/ashesof_war.html%23item_5_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Lion's+Claw&quot;&gt;Lion's Claw&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -471,9 +449,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="ashesofwar_5_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_5_3&amp;id=ashesofwar_5_3&amp;link=/checklists/ashesof_war.html%23item_5_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Cragblade&quot;&gt;Cragblade&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_5_3&amp;id=ashesofwar_5_3&amp;link=/checklists/ashesof_war.html%23item_5_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Cragblade&quot;&gt;Cragblade&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -506,9 +482,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="ashesofwar_5_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_5_8&amp;id=ashesofwar_5_8&amp;link=/checklists/ashesof_war.html%23item_5_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Kick&quot;&gt;Kick&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_5_8&amp;id=ashesofwar_5_8&amp;link=/checklists/ashesof_war.html%23item_5_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Kick&quot;&gt;Kick&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -541,9 +515,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="ashesofwar_5_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_5_5&amp;id=ashesofwar_5_5&amp;link=/checklists/ashesof_war.html%23item_5_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Endure&quot;&gt;Endure&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_5_5&amp;id=ashesofwar_5_5&amp;link=/checklists/ashesof_war.html%23item_5_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Endure&quot;&gt;Endure&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -576,9 +548,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="ashesofwar_5_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_5_6&amp;id=ashesofwar_5_6&amp;link=/checklists/ashesof_war.html%23item_5_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Ground+Slam&quot;&gt;Ground Slam&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_5_6&amp;id=ashesofwar_5_6&amp;link=/checklists/ashesof_war.html%23item_5_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Ground+Slam&quot;&gt;Ground Slam&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -611,9 +581,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="ashesofwar_5_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_5_4&amp;id=ashesofwar_5_4&amp;link=/checklists/ashesof_war.html%23item_5_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Earthshaker&quot;&gt;Earthshaker&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_5_4&amp;id=ashesofwar_5_4&amp;link=/checklists/ashesof_war.html%23item_5_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Earthshaker&quot;&gt;Earthshaker&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -646,9 +614,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="ashesofwar_5_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_5_7&amp;id=ashesofwar_5_7&amp;link=/checklists/ashesof_war.html%23item_5_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Hoarah+Loux's+Earthshaker&quot;&gt;Hoarah Loux's Earthshaker&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_5_7&amp;id=ashesofwar_5_7&amp;link=/checklists/ashesof_war.html%23item_5_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Hoarah+Loux's+Earthshaker&quot;&gt;Hoarah Loux's Earthshaker&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -681,9 +647,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="ashesofwar_5_13" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_5_13&amp;id=ashesofwar_5_13&amp;link=/checklists/ashesof_war.html%23item_5_13&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+War+Cry&quot;&gt;War Cry&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_5_13&amp;id=ashesofwar_5_13&amp;link=/checklists/ashesof_war.html%23item_5_13&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+War+Cry&quot;&gt;War Cry&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -716,9 +680,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="ashesofwar_5_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_5_1&amp;id=ashesofwar_5_1&amp;link=/checklists/ashesof_war.html%23item_5_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Barbaric+Roar&quot;&gt;Barbaric Roar&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_5_1&amp;id=ashesofwar_5_1&amp;link=/checklists/ashesof_war.html%23item_5_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Barbaric+Roar&quot;&gt;Barbaric Roar&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -751,9 +713,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="ashesofwar_5_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_5_2&amp;id=ashesofwar_5_2&amp;link=/checklists/ashesof_war.html%23item_5_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Braggart's+Roar&quot;&gt;Braggart's Roar&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_5_2&amp;id=ashesofwar_5_2&amp;link=/checklists/ashesof_war.html%23item_5_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Braggart's+Roar&quot;&gt;Braggart's Roar&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -786,9 +746,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="ashesofwar_5_12" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_5_12&amp;id=ashesofwar_5_12&amp;link=/checklists/ashesof_war.html%23item_5_12&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Troll's+Roar&quot;&gt;Troll's Roar&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_5_12&amp;id=ashesofwar_5_12&amp;link=/checklists/ashesof_war.html%23item_5_12&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Troll's+Roar&quot;&gt;Troll's Roar&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -821,9 +779,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="ashesofwar_20_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_20_3&amp;id=ashesofwar_20_3&amp;link=/checklists/ashesof_war.html%23item_20_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War+Spinning+Gravity+Thrust&quot;&gt;Spinning Gravity Thrust&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_20_3&amp;id=ashesofwar_20_3&amp;link=/checklists/ashesof_war.html%23item_20_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War+Spinning+Gravity+Thrust&quot;&gt;Spinning Gravity Thrust&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -856,9 +812,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="ashesofwar_20_17" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_20_17&amp;id=ashesofwar_20_17&amp;link=/checklists/ashesof_war.html%23item_20_17&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War+Savage+Lion's+Claw&quot;&gt;Savage Lion's Claw&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_20_17&amp;id=ashesofwar_20_17&amp;link=/checklists/ashesof_war.html%23item_20_17&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War+Savage+Lion's+Claw&quot;&gt;Savage Lion's Claw&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -892,9 +846,7 @@
         <div class="card shadow-sm mb-3" id="ashesofwar_section_1">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#ashesofwar_1Col" data-bs-toggle="collapse" href="#ashesofwar_1Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#ashesofwar_1Col" data-bs-toggle="collapse" href="#ashesofwar_1Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Keen</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="ashesofwar_totals_1"></span>
             </h4>
@@ -906,9 +858,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -937,9 +887,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="ashesofwar_6_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_6_9&amp;id=ashesofwar_6_9&amp;link=/checklists/ashesof_war.html%23item_6_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Spinning+Slash&quot;&gt;Spinning Slash&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_6_9&amp;id=ashesofwar_6_9&amp;link=/checklists/ashesof_war.html%23item_6_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Spinning+Slash&quot;&gt;Spinning Slash&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -972,9 +920,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="ashesofwar_6_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_6_4&amp;id=ashesofwar_6_4&amp;link=/checklists/ashesof_war.html%23item_6_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Impaling+Thrust&quot;&gt;Impaling Thrust&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_6_4&amp;id=ashesofwar_6_4&amp;link=/checklists/ashesof_war.html%23item_6_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Impaling+Thrust&quot;&gt;Impaling Thrust&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1007,9 +953,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="ashesofwar_6_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_6_5&amp;id=ashesofwar_6_5&amp;link=/checklists/ashesof_war.html%23item_6_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Piercing+Fang&quot;&gt;Piercing Fang&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_6_5&amp;id=ashesofwar_6_5&amp;link=/checklists/ashesof_war.html%23item_6_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Piercing+Fang&quot;&gt;Piercing Fang&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1042,9 +986,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="ashesofwar_6_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_6_8&amp;id=ashesofwar_6_8&amp;link=/checklists/ashesof_war.html%23item_6_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Repeating+Thrust&quot;&gt;Repeating Thrust&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_6_8&amp;id=ashesofwar_6_8&amp;link=/checklists/ashesof_war.html%23item_6_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Repeating+Thrust&quot;&gt;Repeating Thrust&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1077,9 +1019,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="ashesofwar_6_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_6_3&amp;id=ashesofwar_6_3&amp;link=/checklists/ashesof_war.html%23item_6_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Double+Slash&quot;&gt;Double Slash&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_6_3&amp;id=ashesofwar_6_3&amp;link=/checklists/ashesof_war.html%23item_6_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Double+Slash&quot;&gt;Double Slash&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1112,9 +1052,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="ashesofwar_6_10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_6_10&amp;id=ashesofwar_6_10&amp;link=/checklists/ashesof_war.html%23item_6_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Sword+Dance&quot;&gt;Sword Dance&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_6_10&amp;id=ashesofwar_6_10&amp;link=/checklists/ashesof_war.html%23item_6_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Sword+Dance&quot;&gt;Sword Dance&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1147,9 +1085,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="ashesofwar_6_11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_6_11&amp;id=ashesofwar_6_11&amp;link=/checklists/ashesof_war.html%23item_6_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Unsheathe&quot;&gt;Unsheathe&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_6_11&amp;id=ashesofwar_6_11&amp;link=/checklists/ashesof_war.html%23item_6_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Unsheathe&quot;&gt;Unsheathe&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1182,9 +1118,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="ashesofwar_6_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_6_6&amp;id=ashesofwar_6_6&amp;link=/checklists/ashesof_war.html%23item_6_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Quickstep&quot;&gt;Quickstep&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_6_6&amp;id=ashesofwar_6_6&amp;link=/checklists/ashesof_war.html%23item_6_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Quickstep&quot;&gt;Quickstep&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1217,9 +1151,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="ashesofwar_6_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_6_2&amp;id=ashesofwar_6_2&amp;link=/checklists/ashesof_war.html%23item_6_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Bloodhound's+Step&quot;&gt;Bloodhound's Step&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_6_2&amp;id=ashesofwar_6_2&amp;link=/checklists/ashesof_war.html%23item_6_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Bloodhound's+Step&quot;&gt;Bloodhound's Step&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1252,9 +1184,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="ashesofwar_6_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_6_7&amp;id=ashesofwar_6_7&amp;link=/checklists/ashesof_war.html%23item_6_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Raptor+of+the+Mists&quot;&gt;Raptor of the Mist&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_6_7&amp;id=ashesofwar_6_7&amp;link=/checklists/ashesof_war.html%23item_6_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Raptor+of+the+Mists&quot;&gt;Raptor of the Mist&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1287,9 +1217,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="ashesofwar_6_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_6_1&amp;id=ashesofwar_6_1&amp;link=/checklists/ashesof_war.html%23item_6_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Beast's+Roar&quot;&gt;Beast's Roar&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_6_1&amp;id=ashesofwar_6_1&amp;link=/checklists/ashesof_war.html%23item_6_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Beast's+Roar&quot;&gt;Beast's Roar&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1322,9 +1250,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="ashesofwar_20_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_20_5&amp;id=ashesofwar_20_5&amp;link=/checklists/ashesof_war.html%23item_20_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War+Piercing+Throw&quot;&gt;Piercing Throw&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_20_5&amp;id=ashesofwar_20_5&amp;link=/checklists/ashesof_war.html%23item_20_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War+Piercing+Throw&quot;&gt;Piercing Throw&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1357,9 +1283,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="ashesofwar_20_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_20_6&amp;id=ashesofwar_20_6&amp;link=/checklists/ashesof_war.html%23item_20_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War+Scattershot+Throw&quot;&gt;Scattershot Throw&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_20_6&amp;id=ashesofwar_20_6&amp;link=/checklists/ashesof_war.html%23item_20_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War+Scattershot+Throw&quot;&gt;Scattershot Throw&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1392,9 +1316,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="ashesofwar_20_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_20_9&amp;id=ashesofwar_20_9&amp;link=/checklists/ashesof_war.html%23item_20_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War+Raging+Beast&quot;&gt;Raging Beast&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_20_9&amp;id=ashesofwar_20_9&amp;link=/checklists/ashesof_war.html%23item_20_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War+Raging+Beast&quot;&gt;Raging Beast&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1427,9 +1349,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="ashesofwar_20_10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_20_10&amp;id=ashesofwar_20_10&amp;link=/checklists/ashesof_war.html%23item_20_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War+Savage+Claws&quot;&gt;Savage Claws&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_20_10&amp;id=ashesofwar_20_10&amp;link=/checklists/ashesof_war.html%23item_20_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War+Savage+Claws&quot;&gt;Savage Claws&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1462,9 +1382,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="ashesofwar_20_11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_20_11&amp;id=ashesofwar_20_11&amp;link=/checklists/ashesof_war.html%23item_20_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War+Blind+Spot&quot;&gt;Blind Spot&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_20_11&amp;id=ashesofwar_20_11&amp;link=/checklists/ashesof_war.html%23item_20_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War+Blind+Spot&quot;&gt;Blind Spot&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1497,9 +1415,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="ashesofwar_20_12" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_20_12&amp;id=ashesofwar_20_12&amp;link=/checklists/ashesof_war.html%23item_20_12&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War+Swift+Slash&quot;&gt;Swift Slash&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_20_12&amp;id=ashesofwar_20_12&amp;link=/checklists/ashesof_war.html%23item_20_12&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War+Swift+Slash&quot;&gt;Swift Slash&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1532,9 +1448,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="ashesofwar_20_13" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_20_13&amp;id=ashesofwar_20_13&amp;link=/checklists/ashesof_war.html%23item_20_13&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War+Overhead+Stance&quot;&gt;Overhead Stance&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_20_13&amp;id=ashesofwar_20_13&amp;link=/checklists/ashesof_war.html%23item_20_13&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War+Overhead+Stance&quot;&gt;Overhead Stance&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1568,9 +1482,7 @@
         <div class="card shadow-sm mb-3" id="ashesofwar_section_2">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#ashesofwar_2Col" data-bs-toggle="collapse" href="#ashesofwar_2Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#ashesofwar_2Col" data-bs-toggle="collapse" href="#ashesofwar_2Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Quality</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="ashesofwar_totals_2"></span>
             </h4>
@@ -1582,9 +1494,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -1613,9 +1523,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="ashesofwar_11_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_11_7&amp;id=ashesofwar_11_7&amp;link=/checklists/ashesof_war.html%23item_11_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Square+Off&quot;&gt;Square Off&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_11_7&amp;id=ashesofwar_11_7&amp;link=/checklists/ashesof_war.html%23item_11_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Square+Off&quot;&gt;Square Off&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1648,9 +1556,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="ashesofwar_11_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_11_1&amp;id=ashesofwar_11_1&amp;link=/checklists/ashesof_war.html%23item_11_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Charge+Forth&quot;&gt;Charge Forth&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_11_1&amp;id=ashesofwar_11_1&amp;link=/checklists/ashesof_war.html%23item_11_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Charge+Forth&quot;&gt;Charge Forth&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1683,9 +1589,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="ashesofwar_11_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_11_6&amp;id=ashesofwar_11_6&amp;link=/checklists/ashesof_war.html%23item_11_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Spinning+Strikes&quot;&gt;Spinning Strikes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_11_6&amp;id=ashesofwar_11_6&amp;link=/checklists/ashesof_war.html%23item_11_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Spinning+Strikes&quot;&gt;Spinning Strikes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1718,9 +1622,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="ashesofwar_11_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_11_3&amp;id=ashesofwar_11_3&amp;link=/checklists/ashesof_war.html%23item_11_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Giant+Hunt&quot;&gt;Giant Hunt&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_11_3&amp;id=ashesofwar_11_3&amp;link=/checklists/ashesof_war.html%23item_11_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Giant+Hunt&quot;&gt;Giant Hunt&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1753,9 +1655,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="ashesofwar_11_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_11_9&amp;id=ashesofwar_11_9&amp;link=/checklists/ashesof_war.html%23item_11_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Storm+Blade&quot;&gt;Storm Blade&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_11_9&amp;id=ashesofwar_11_9&amp;link=/checklists/ashesof_war.html%23item_11_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Storm+Blade&quot;&gt;Storm Blade&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1788,9 +1688,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="ashesofwar_11_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_11_8&amp;id=ashesofwar_11_8&amp;link=/checklists/ashesof_war.html%23item_11_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Storm+Assault&quot;&gt;Storm Assault&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_11_8&amp;id=ashesofwar_11_8&amp;link=/checklists/ashesof_war.html%23item_11_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Storm+Assault&quot;&gt;Storm Assault&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1823,9 +1721,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="ashesofwar_11_11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_11_11&amp;id=ashesofwar_11_11&amp;link=/checklists/ashesof_war.html%23item_11_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Stormcaller&quot;&gt;Stormcaller&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_11_11&amp;id=ashesofwar_11_11&amp;link=/checklists/ashesof_war.html%23item_11_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Stormcaller&quot;&gt;Stormcaller&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1858,9 +1754,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="ashesofwar_11_10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_11_10&amp;id=ashesofwar_11_10&amp;link=/checklists/ashesof_war.html%23item_11_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Storm+Stomp&quot;&gt;Storm Stomp&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_11_10&amp;id=ashesofwar_11_10&amp;link=/checklists/ashesof_war.html%23item_11_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Storm+Stomp&quot;&gt;Storm Stomp&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1893,9 +1787,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="ashesofwar_11_12" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_11_12&amp;id=ashesofwar_11_12&amp;link=/checklists/ashesof_war.html%23item_11_12&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Vacuum+Slice&quot;&gt;Vacuum Slice&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_11_12&amp;id=ashesofwar_11_12&amp;link=/checklists/ashesof_war.html%23item_11_12&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Vacuum+Slice&quot;&gt;Vacuum Slice&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1928,9 +1820,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="ashesofwar_11_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_11_4&amp;id=ashesofwar_11_4&amp;link=/checklists/ashesof_war.html%23item_11_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Phantom+Slash&quot;&gt;Phantom Slash&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_11_4&amp;id=ashesofwar_11_4&amp;link=/checklists/ashesof_war.html%23item_11_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Phantom+Slash&quot;&gt;Phantom Slash&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1963,9 +1853,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="ashesofwar_11_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_11_2&amp;id=ashesofwar_11_2&amp;link=/checklists/ashesof_war.html%23item_11_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Determination&quot;&gt;Determination&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_11_2&amp;id=ashesofwar_11_2&amp;link=/checklists/ashesof_war.html%23item_11_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Determination&quot;&gt;Determination&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1998,9 +1886,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="ashesofwar_11_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_11_5&amp;id=ashesofwar_11_5&amp;link=/checklists/ashesof_war.html%23item_11_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Royal+Knight's+Resolve&quot;&gt;Royal Knight's Resolve&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_11_5&amp;id=ashesofwar_11_5&amp;link=/checklists/ashesof_war.html%23item_11_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Royal+Knight's+Resolve&quot;&gt;Royal Knight's Resolve&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2033,9 +1919,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="ashesofwar_20_14" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_20_14&amp;id=ashesofwar_20_14&amp;link=/checklists/ashesof_war.html%23item_20_14&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War+Wing+Stance&quot;&gt;Wing Stance&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_20_14&amp;id=ashesofwar_20_14&amp;link=/checklists/ashesof_war.html%23item_20_14&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War+Wing+Stance&quot;&gt;Wing Stance&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2069,9 +1953,7 @@
         <div class="card shadow-sm mb-3" id="ashesofwar_section_3">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#ashesofwar_3Col" data-bs-toggle="collapse" href="#ashesofwar_3Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#ashesofwar_3Col" data-bs-toggle="collapse" href="#ashesofwar_3Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Magic</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="ashesofwar_totals_3"></span>
             </h4>
@@ -2083,9 +1965,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -2114,9 +1994,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="ashesofwar_8_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_8_5&amp;id=ashesofwar_8_5&amp;link=/checklists/ashesof_war.html%23item_8_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Glintstone+Pebble&quot;&gt;Glintstone Pebble&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_8_5&amp;id=ashesofwar_8_5&amp;link=/checklists/ashesof_war.html%23item_8_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Glintstone+Pebble&quot;&gt;Glintstone Pebble&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2149,9 +2027,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="ashesofwar_8_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_8_4&amp;id=ashesofwar_8_4&amp;link=/checklists/ashesof_war.html%23item_8_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Glintblade+Phalanx&quot;&gt;Glintblade Phalanx&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_8_4&amp;id=ashesofwar_8_4&amp;link=/checklists/ashesof_war.html%23item_8_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Glintblade+Phalanx&quot;&gt;Glintblade Phalanx&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2184,9 +2060,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="ashesofwar_8_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_8_2&amp;id=ashesofwar_8_2&amp;link=/checklists/ashesof_war.html%23item_8_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Carian+Greatsword&quot;&gt;Carian Greatsword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_8_2&amp;id=ashesofwar_8_2&amp;link=/checklists/ashesof_war.html%23item_8_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Carian+Greatsword&quot;&gt;Carian Greatsword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2219,9 +2093,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="ashesofwar_8_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_8_1&amp;id=ashesofwar_8_1&amp;link=/checklists/ashesof_war.html%23item_8_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Carian+Grandeur&quot;&gt;Carian Grandeur&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_8_1&amp;id=ashesofwar_8_1&amp;link=/checklists/ashesof_war.html%23item_8_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Carian+Grandeur&quot;&gt;Carian Grandeur&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2254,9 +2126,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="ashesofwar_8_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_8_8&amp;id=ashesofwar_8_8&amp;link=/checklists/ashesof_war.html%23item_8_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Spinning+Weapon&quot;&gt;Spinning Weapon&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_8_8&amp;id=ashesofwar_8_8&amp;link=/checklists/ashesof_war.html%23item_8_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Spinning+Weapon&quot;&gt;Spinning Weapon&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2289,9 +2159,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="ashesofwar_8_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_8_7&amp;id=ashesofwar_8_7&amp;link=/checklists/ashesof_war.html%23item_8_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Loretta's+Slash&quot;&gt;Loretta's Slash&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_8_7&amp;id=ashesofwar_8_7&amp;link=/checklists/ashesof_war.html%23item_8_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Loretta's+Slash&quot;&gt;Loretta's Slash&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2324,9 +2192,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="ashesofwar_8_10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_8_10&amp;id=ashesofwar_8_10&amp;link=/checklists/ashesof_war.html%23item_8_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Waves+of+Darkness&quot;&gt;Waves of Darkness&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_8_10&amp;id=ashesofwar_8_10&amp;link=/checklists/ashesof_war.html%23item_8_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Waves+of+Darkness&quot;&gt;Waves of Darkness&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2359,9 +2225,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="ashesofwar_8_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_8_6&amp;id=ashesofwar_8_6&amp;link=/checklists/ashesof_war.html%23item_8_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Gravitas&quot;&gt;Gravitas&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_8_6&amp;id=ashesofwar_8_6&amp;link=/checklists/ashesof_war.html%23item_8_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Gravitas&quot;&gt;Gravitas&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2394,9 +2258,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="ashesofwar_20_20" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_20_20&amp;id=ashesofwar_20_20&amp;link=/checklists/ashesof_war.html%23item_20_20&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War+Carian+Sovereignty&quot;&gt;Carian Sovereignty&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_20_20&amp;id=ashesofwar_20_20&amp;link=/checklists/ashesof_war.html%23item_20_20&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War+Carian+Sovereignty&quot;&gt;Carian Sovereignty&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2430,9 +2292,7 @@
         <div class="card shadow-sm mb-3" id="ashesofwar_section_4">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#ashesofwar_4Col" data-bs-toggle="collapse" href="#ashesofwar_4Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#ashesofwar_4Col" data-bs-toggle="collapse" href="#ashesofwar_4Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Fire</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="ashesofwar_totals_4"></span>
             </h4>
@@ -2444,9 +2304,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -2475,9 +2333,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="ashesofwar_3_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_3_3&amp;id=ashesofwar_3_3&amp;link=/checklists/ashesof_war.html%23item_3_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Flaming+Strike&quot;&gt;Flaming Strike&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_3_3&amp;id=ashesofwar_3_3&amp;link=/checklists/ashesof_war.html%23item_3_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Flaming+Strike&quot;&gt;Flaming Strike&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2510,9 +2366,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="ashesofwar_3_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_3_2&amp;id=ashesofwar_3_2&amp;link=/checklists/ashesof_war.html%23item_3_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Flame+of+the+Redmanes&quot;&gt;Flame of the Redmanes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_3_2&amp;id=ashesofwar_3_2&amp;link=/checklists/ashesof_war.html%23item_3_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Flame+of+the+Redmanes&quot;&gt;Flame of the Redmanes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2545,9 +2399,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="ashesofwar_3_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_3_1&amp;id=ashesofwar_3_1&amp;link=/checklists/ashesof_war.html%23item_3_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Eruption&quot;&gt;Eruption&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_3_1&amp;id=ashesofwar_3_1&amp;link=/checklists/ashesof_war.html%23item_3_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Eruption&quot;&gt;Eruption&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2581,9 +2433,7 @@
         <div class="card shadow-sm mb-3" id="ashesofwar_section_5">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#ashesofwar_5Col" data-bs-toggle="collapse" href="#ashesofwar_5Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#ashesofwar_5Col" data-bs-toggle="collapse" href="#ashesofwar_5Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Flame</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="ashesofwar_totals_5"></span>
             </h4>
@@ -2595,9 +2445,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -2626,9 +2474,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="ashesofwar_4_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_4_2&amp;id=ashesofwar_4_2&amp;link=/checklists/ashesof_war.html%23item_4_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Prelate's+Charge&quot;&gt;Prelate's Charge&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_4_2&amp;id=ashesofwar_4_2&amp;link=/checklists/ashesof_war.html%23item_4_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Prelate's+Charge&quot;&gt;Prelate's Charge&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2661,9 +2507,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="ashesofwar_4_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_4_1&amp;id=ashesofwar_4_1&amp;link=/checklists/ashesof_war.html%23item_4_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Black+Flame+Tornado&quot;&gt;Black Flame Tornado&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_4_1&amp;id=ashesofwar_4_1&amp;link=/checklists/ashesof_war.html%23item_4_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Black+Flame+Tornado&quot;&gt;Black Flame Tornado&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2696,9 +2540,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="ashesofwar_20_16" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_20_16&amp;id=ashesofwar_20_16&amp;link=/checklists/ashesof_war.html%23item_20_16&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War+Flame+Skewer&quot;&gt;Flame Skewer&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_20_16&amp;id=ashesofwar_20_16&amp;link=/checklists/ashesof_war.html%23item_20_16&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War+Flame+Skewer&quot;&gt;Flame Skewer&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2731,9 +2573,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="ashesofwar_20_19" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_20_19&amp;id=ashesofwar_20_19&amp;link=/checklists/ashesof_war.html%23item_20_19&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War+Flame+Spear&quot;&gt;Flame Spear&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_20_19&amp;id=ashesofwar_20_19&amp;link=/checklists/ashesof_war.html%23item_20_19&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War+Flame+Spear&quot;&gt;Flame Spear&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2767,9 +2607,7 @@
         <div class="card shadow-sm mb-3" id="ashesofwar_section_6">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#ashesofwar_6Col" data-bs-toggle="collapse" href="#ashesofwar_6Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#ashesofwar_6Col" data-bs-toggle="collapse" href="#ashesofwar_6Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Lightning</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="ashesofwar_totals_6"></span>
             </h4>
@@ -2781,9 +2619,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -2812,9 +2648,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="ashesofwar_7_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_7_3&amp;id=ashesofwar_7_3&amp;link=/checklists/ashesof_war.html%23item_7_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Thunderbolt&quot;&gt;Thunderbolt&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_7_3&amp;id=ashesofwar_7_3&amp;link=/checklists/ashesof_war.html%23item_7_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Thunderbolt&quot;&gt;Thunderbolt&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2847,9 +2681,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="ashesofwar_7_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_7_2&amp;id=ashesofwar_7_2&amp;link=/checklists/ashesof_war.html%23item_7_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Lightning+Slash&quot;&gt;Lightning Slash&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_7_2&amp;id=ashesofwar_7_2&amp;link=/checklists/ashesof_war.html%23item_7_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Lightning+Slash&quot;&gt;Lightning Slash&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2882,9 +2714,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="ashesofwar_7_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_7_1&amp;id=ashesofwar_7_1&amp;link=/checklists/ashesof_war.html%23item_7_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Lightning+Ram&quot;&gt;Lightning Ram&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_7_1&amp;id=ashesofwar_7_1&amp;link=/checklists/ashesof_war.html%23item_7_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Lightning+Ram&quot;&gt;Lightning Ram&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2917,9 +2747,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="ashesofwar_20_15" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_20_15&amp;id=ashesofwar_20_15&amp;link=/checklists/ashesof_war.html%23item_20_15&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War+Blinkbolt&quot;&gt;Blinkbolt&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_20_15&amp;id=ashesofwar_20_15&amp;link=/checklists/ashesof_war.html%23item_20_15&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War+Blinkbolt&quot;&gt;Blinkbolt&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2953,9 +2781,7 @@
         <div class="card shadow-sm mb-3" id="ashesofwar_section_7">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#ashesofwar_7Col" data-bs-toggle="collapse" href="#ashesofwar_7Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#ashesofwar_7Col" data-bs-toggle="collapse" href="#ashesofwar_7Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Sacred</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="ashesofwar_totals_7"></span>
             </h4>
@@ -2967,9 +2793,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -2998,9 +2822,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="ashesofwar_12_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_12_7&amp;id=ashesofwar_12_7&amp;link=/checklists/ashesof_war.html%23item_12_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Sacred+Blade&quot;&gt;Sacred Blade&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_12_7&amp;id=ashesofwar_12_7&amp;link=/checklists/ashesof_war.html%23item_12_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Sacred+Blade&quot;&gt;Sacred Blade&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3033,9 +2855,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="ashesofwar_12_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_12_6&amp;id=ashesofwar_12_6&amp;link=/checklists/ashesof_war.html%23item_12_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Prayerful+Strike&quot;&gt;Prayerful Strike&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_12_6&amp;id=ashesofwar_12_6&amp;link=/checklists/ashesof_war.html%23item_12_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Prayerful+Strike&quot;&gt;Prayerful Strike&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3068,9 +2888,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="ashesofwar_12_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_12_9&amp;id=ashesofwar_12_9&amp;link=/checklists/ashesof_war.html%23item_12_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Sacred+Ring+of+Light&quot;&gt;Sacred Ring of Light&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_12_9&amp;id=ashesofwar_12_9&amp;link=/checklists/ashesof_war.html%23item_12_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Sacred+Ring+of+Light&quot;&gt;Sacred Ring of Light&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3103,9 +2921,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="ashesofwar_12_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_12_8&amp;id=ashesofwar_12_8&amp;link=/checklists/ashesof_war.html%23item_12_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Sacred+Order&quot;&gt;Sacred Order&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_12_8&amp;id=ashesofwar_12_8&amp;link=/checklists/ashesof_war.html%23item_12_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Sacred+Order&quot;&gt;Sacred Order&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3138,9 +2954,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="ashesofwar_12_10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_12_10&amp;id=ashesofwar_12_10&amp;link=/checklists/ashesof_war.html%23item_12_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Shared+Order&quot;&gt;Shared Order&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_12_10&amp;id=ashesofwar_12_10&amp;link=/checklists/ashesof_war.html%23item_12_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Shared+Order&quot;&gt;Shared Order&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3173,9 +2987,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="ashesofwar_12_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_12_1&amp;id=ashesofwar_12_1&amp;link=/checklists/ashesof_war.html%23item_12_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Golden+Land&quot;&gt;Golden Land&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_12_1&amp;id=ashesofwar_12_1&amp;link=/checklists/ashesof_war.html%23item_12_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Golden+Land&quot;&gt;Golden Land&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3208,9 +3020,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="ashesofwar_12_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_12_3&amp;id=ashesofwar_12_3&amp;link=/checklists/ashesof_war.html%23item_12_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Golden+Slam&quot;&gt;Golden Slam&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_12_3&amp;id=ashesofwar_12_3&amp;link=/checklists/ashesof_war.html%23item_12_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Golden+Slam&quot;&gt;Golden Slam&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3243,9 +3053,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="ashesofwar_12_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_12_4&amp;id=ashesofwar_12_4&amp;link=/checklists/ashesof_war.html%23item_12_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Golden+Vow&quot;&gt;Golden Vow&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_12_4&amp;id=ashesofwar_12_4&amp;link=/checklists/ashesof_war.html%23item_12_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Golden+Vow&quot;&gt;Golden Vow&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3278,9 +3086,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="ashesofwar_12_11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_12_11&amp;id=ashesofwar_12_11&amp;link=/checklists/ashesof_war.html%23item_12_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Vow+of+the+Indomitable&quot;&gt;Vow of the Indomitable&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_12_11&amp;id=ashesofwar_12_11&amp;link=/checklists/ashesof_war.html%23item_12_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Vow+of+the+Indomitable&quot;&gt;Vow of the Indomitable&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3313,9 +3119,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="ashesofwar_12_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_12_5&amp;id=ashesofwar_12_5&amp;link=/checklists/ashesof_war.html%23item_12_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Holy+Ground&quot;&gt;Holy Ground&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_12_5&amp;id=ashesofwar_12_5&amp;link=/checklists/ashesof_war.html%23item_12_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Holy+Ground&quot;&gt;Holy Ground&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3348,9 +3152,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="ashesofwar_20_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_20_2&amp;id=ashesofwar_20_2&amp;link=/checklists/ashesof_war.html%23item_20_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Aspects+of+the+Crucible:+Wings&quot;&gt;Aspects of the Crucible: Wings&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_20_2&amp;id=ashesofwar_20_2&amp;link=/checklists/ashesof_war.html%23item_20_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Aspects+of+the+Crucible:+Wings&quot;&gt;Aspects of the Crucible: Wings&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3384,9 +3186,7 @@
         <div class="card shadow-sm mb-3" id="ashesofwar_section_8">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#ashesofwar_8Col" data-bs-toggle="collapse" href="#ashesofwar_8Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#ashesofwar_8Col" data-bs-toggle="collapse" href="#ashesofwar_8Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Poison</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="ashesofwar_totals_8"></span>
             </h4>
@@ -3398,9 +3198,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -3429,9 +3227,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="ashesofwar_10_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_10_2&amp;id=ashesofwar_10_2&amp;link=/checklists/ashesof_war.html%23item_10_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Poisonous+Mist&quot;&gt;Poisonous Mist&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_10_2&amp;id=ashesofwar_10_2&amp;link=/checklists/ashesof_war.html%23item_10_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Poisonous+Mist&quot;&gt;Poisonous Mist&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3464,9 +3260,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="ashesofwar_10_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_10_1&amp;id=ashesofwar_10_1&amp;link=/checklists/ashesof_war.html%23item_10_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Poison+Moth+Flight&quot;&gt;Poison Moth Flight&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_10_1&amp;id=ashesofwar_10_1&amp;link=/checklists/ashesof_war.html%23item_10_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Poison+Moth+Flight&quot;&gt;Poison Moth Flight&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3499,9 +3293,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="ashesofwar_20_23" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_20_23&amp;id=ashesofwar_20_23&amp;link=/checklists/ashesof_war.html%23item_20_23&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War+The+Poison+Flower+Blooms+Twice&quot;&gt;The Poison Flower Blooms Twice&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_20_23&amp;id=ashesofwar_20_23&amp;link=/checklists/ashesof_war.html%23item_20_23&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War+The+Poison+Flower+Blooms+Twice&quot;&gt;The Poison Flower Blooms Twice&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3535,9 +3327,7 @@
         <div class="card shadow-sm mb-3" id="ashesofwar_section_9">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#ashesofwar_9Col" data-bs-toggle="collapse" href="#ashesofwar_9Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#ashesofwar_9Col" data-bs-toggle="collapse" href="#ashesofwar_9Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Blood</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="ashesofwar_totals_9"></span>
             </h4>
@@ -3549,9 +3339,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -3580,9 +3368,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="ashesofwar_1_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_1_1&amp;id=ashesofwar_1_1&amp;link=/checklists/ashesof_war.html%23item_1_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Blood+Blade&quot;&gt;Blood Blade&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_1_1&amp;id=ashesofwar_1_1&amp;link=/checklists/ashesof_war.html%23item_1_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Blood+Blade&quot;&gt;Blood Blade&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3615,9 +3401,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="ashesofwar_1_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_1_3&amp;id=ashesofwar_1_3&amp;link=/checklists/ashesof_war.html%23item_1_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Bloody+Slash&quot;&gt;Bloody Slash&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_1_3&amp;id=ashesofwar_1_3&amp;link=/checklists/ashesof_war.html%23item_1_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Bloody+Slash&quot;&gt;Bloody Slash&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3650,9 +3434,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="ashesofwar_1_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_1_2&amp;id=ashesofwar_1_2&amp;link=/checklists/ashesof_war.html%23item_1_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Blood+Tax&quot;&gt;Blood Tax&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_1_2&amp;id=ashesofwar_1_2&amp;link=/checklists/ashesof_war.html%23item_1_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Blood+Tax&quot;&gt;Blood Tax&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3685,9 +3467,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="ashesofwar_1_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_1_4&amp;id=ashesofwar_1_4&amp;link=/checklists/ashesof_war.html%23item_1_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Seppuku&quot;&gt;Seppuku&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_1_4&amp;id=ashesofwar_1_4&amp;link=/checklists/ashesof_war.html%23item_1_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Seppuku&quot;&gt;Seppuku&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3721,9 +3501,7 @@
         <div class="card shadow-sm mb-3" id="ashesofwar_section_10">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#ashesofwar_10Col" data-bs-toggle="collapse" href="#ashesofwar_10Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#ashesofwar_10Col" data-bs-toggle="collapse" href="#ashesofwar_10Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Cold</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="ashesofwar_totals_10"></span>
             </h4>
@@ -3735,9 +3513,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -3766,9 +3542,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="10" id="ashesofwar_2_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_2_3&amp;id=ashesofwar_2_3&amp;link=/checklists/ashesof_war.html%23item_2_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Ice+Spear&quot;&gt;Ice Spear&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_2_3&amp;id=ashesofwar_2_3&amp;link=/checklists/ashesof_war.html%23item_2_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Ice+Spear&quot;&gt;Ice Spear&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3801,9 +3575,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="10" id="ashesofwar_2_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_2_1&amp;id=ashesofwar_2_1&amp;link=/checklists/ashesof_war.html%23item_2_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Chilling+Mist&quot;&gt;Chilling Mist&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_2_1&amp;id=ashesofwar_2_1&amp;link=/checklists/ashesof_war.html%23item_2_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Chilling+Mist&quot;&gt;Chilling Mist&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3836,9 +3608,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="10" id="ashesofwar_2_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_2_2&amp;id=ashesofwar_2_2&amp;link=/checklists/ashesof_war.html%23item_2_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Hoarfrost+Stomp&quot;&gt;Hoarfrost Stomp&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_2_2&amp;id=ashesofwar_2_2&amp;link=/checklists/ashesof_war.html%23item_2_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Hoarfrost+Stomp&quot;&gt;Hoarfrost Stomp&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3871,9 +3641,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="10" id="ashesofwar_20_18" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_20_18&amp;id=ashesofwar_20_18&amp;link=/checklists/ashesof_war.html%23item_20_18&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War+Divine+Beast+Frost+Stomp&quot;&gt;Divine Beast Frost Stomp&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_20_18&amp;id=ashesofwar_20_18&amp;link=/checklists/ashesof_war.html%23item_20_18&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War+Divine+Beast+Frost+Stomp&quot;&gt;Divine Beast Frost Stomp&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3906,9 +3674,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="10" id="ashesofwar_20_22" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_20_22&amp;id=ashesofwar_20_22&amp;link=/checklists/ashesof_war.html%23item_20_22&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War+Ghostflame+Call&quot;&gt;Ghostflame Call&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_20_22&amp;id=ashesofwar_20_22&amp;link=/checklists/ashesof_war.html%23item_20_22&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War+Ghostflame+Call&quot;&gt;Ghostflame Call&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3942,9 +3708,7 @@
         <div class="card shadow-sm mb-3" id="ashesofwar_section_11">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#ashesofwar_11Col" data-bs-toggle="collapse" href="#ashesofwar_11Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#ashesofwar_11Col" data-bs-toggle="collapse" href="#ashesofwar_11Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Occult</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="ashesofwar_totals_11"></span>
             </h4>
@@ -3956,9 +3720,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -3987,9 +3749,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="11" id="ashesofwar_9_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_9_3&amp;id=ashesofwar_9_3&amp;link=/checklists/ashesof_war.html%23item_9_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Spectral+Lance&quot;&gt;Spectral Lance&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_9_3&amp;id=ashesofwar_9_3&amp;link=/checklists/ashesof_war.html%23item_9_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Spectral+Lance&quot;&gt;Spectral Lance&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4022,9 +3782,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="11" id="ashesofwar_9_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_9_2&amp;id=ashesofwar_9_2&amp;link=/checklists/ashesof_war.html%23item_9_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Lifesteal+Fist&quot;&gt;Lifesteal Fist&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_9_2&amp;id=ashesofwar_9_2&amp;link=/checklists/ashesof_war.html%23item_9_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Lifesteal+Fist&quot;&gt;Lifesteal Fist&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4057,9 +3815,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="11" id="ashesofwar_9_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_9_4&amp;id=ashesofwar_9_4&amp;link=/checklists/ashesof_war.html%23item_9_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+White+Shadow's+Lure&quot;&gt;White Shadow's Lure&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_9_4&amp;id=ashesofwar_9_4&amp;link=/checklists/ashesof_war.html%23item_9_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+White+Shadow's+Lure&quot;&gt;White Shadow's Lure&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4092,9 +3848,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="11" id="ashesofwar_9_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_9_1&amp;id=ashesofwar_9_1&amp;link=/checklists/ashesof_war.html%23item_9_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Assassin's+Gambit&quot;&gt;Assassin's Gambit&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_9_1&amp;id=ashesofwar_9_1&amp;link=/checklists/ashesof_war.html%23item_9_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Assassin's+Gambit&quot;&gt;Assassin's Gambit&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4127,9 +3881,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="11" id="ashesofwar_20_21" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_20_21&amp;id=ashesofwar_20_21&amp;link=/checklists/ashesof_war.html%23item_20_21&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War+Shriek+of+Sorrow&quot;&gt;Shriek of Sorrow&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_20_21&amp;id=ashesofwar_20_21&amp;link=/checklists/ashesof_war.html%23item_20_21&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War+Shriek+of+Sorrow&quot;&gt;Shriek of Sorrow&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4163,9 +3915,7 @@
         <div class="card shadow-sm mb-3" id="ashesofwar_section_12">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#ashesofwar_12Col" data-bs-toggle="collapse" href="#ashesofwar_12Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#ashesofwar_12Col" data-bs-toggle="collapse" href="#ashesofwar_12Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Standard</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="ashesofwar_totals_12"></span>
             </h4>
@@ -4177,9 +3927,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -4208,9 +3956,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="ashesofwar_13_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_13_4&amp;id=ashesofwar_13_4&amp;link=/checklists/ashesof_war.html%23item_13_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Mighty+Shot&quot;&gt;Mighty Shot&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_13_4&amp;id=ashesofwar_13_4&amp;link=/checklists/ashesof_war.html%23item_13_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Mighty+Shot&quot;&gt;Mighty Shot&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4243,9 +3989,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="ashesofwar_13_12" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_13_12&amp;id=ashesofwar_13_12&amp;link=/checklists/ashesof_war.html%23item_13_12&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Through+and+Through&quot;&gt;Through and Through&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_13_12&amp;id=ashesofwar_13_12&amp;link=/checklists/ashesof_war.html%23item_13_12&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Through+and+Through&quot;&gt;Through and Through&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4278,9 +4022,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="ashesofwar_13_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_13_1&amp;id=ashesofwar_13_1&amp;link=/checklists/ashesof_war.html%23item_13_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Barrage&quot;&gt;Barrage&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_13_1&amp;id=ashesofwar_13_1&amp;link=/checklists/ashesof_war.html%23item_13_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Barrage&quot;&gt;Barrage&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4313,9 +4055,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="ashesofwar_13_10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_13_10&amp;id=ashesofwar_13_10&amp;link=/checklists/ashesof_war.html%23item_13_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Sky+Shot&quot;&gt;Sky Shot&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_13_10&amp;id=ashesofwar_13_10&amp;link=/checklists/ashesof_war.html%23item_13_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Sky+Shot&quot;&gt;Sky Shot&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4348,9 +4088,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="ashesofwar_13_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_13_3&amp;id=ashesofwar_13_3&amp;link=/checklists/ashesof_war.html%23item_13_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Enchanted+Shot&quot;&gt;Enchanted Shot&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_13_3&amp;id=ashesofwar_13_3&amp;link=/checklists/ashesof_war.html%23item_13_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Enchanted+Shot&quot;&gt;Enchanted Shot&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4383,9 +4121,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="ashesofwar_13_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_13_7&amp;id=ashesofwar_13_7&amp;link=/checklists/ashesof_war.html%23item_13_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Rain+of+Arrows&quot;&gt;Rain of Arrows&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_13_7&amp;id=ashesofwar_13_7&amp;link=/checklists/ashesof_war.html%23item_13_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Rain+of+Arrows&quot;&gt;Rain of Arrows&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4418,9 +4154,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="ashesofwar_13_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_13_6&amp;id=ashesofwar_13_6&amp;link=/checklists/ashesof_war.html%23item_13_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Parry&quot;&gt;Parry&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_13_6&amp;id=ashesofwar_13_6&amp;link=/checklists/ashesof_war.html%23item_13_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Parry&quot;&gt;Parry&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4453,9 +4187,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="ashesofwar_12_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_12_2&amp;id=ashesofwar_12_2&amp;link=/checklists/ashesof_war.html%23item_12_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Golden+Parry&quot;&gt;Golden Parry&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_12_2&amp;id=ashesofwar_12_2&amp;link=/checklists/ashesof_war.html%23item_12_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Golden+Parry&quot;&gt;Golden Parry&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4488,9 +4220,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="ashesofwar_13_11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_13_11&amp;id=ashesofwar_13_11&amp;link=/checklists/ashesof_war.html%23item_13_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Storm+Wall&quot;&gt;Storm Wall&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_13_11&amp;id=ashesofwar_13_11&amp;link=/checklists/ashesof_war.html%23item_13_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Storm+Wall&quot;&gt;Storm Wall&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4523,9 +4253,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="ashesofwar_13_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_13_8&amp;id=ashesofwar_13_8&amp;link=/checklists/ashesof_war.html%23item_13_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Shield+Bash&quot;&gt;Shield Bash&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_13_8&amp;id=ashesofwar_13_8&amp;link=/checklists/ashesof_war.html%23item_13_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Shield+Bash&quot;&gt;Shield Bash&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4558,9 +4286,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="ashesofwar_13_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_13_9&amp;id=ashesofwar_13_9&amp;link=/checklists/ashesof_war.html%23item_13_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Shield+Crash&quot;&gt;Shield Crash&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_13_9&amp;id=ashesofwar_13_9&amp;link=/checklists/ashesof_war.html%23item_13_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Shield+Crash&quot;&gt;Shield Crash&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4593,9 +4319,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="ashesofwar_13_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_13_2&amp;id=ashesofwar_13_2&amp;link=/checklists/ashesof_war.html%23item_13_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Barricade+Shield&quot;&gt;Barricade Shield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_13_2&amp;id=ashesofwar_13_2&amp;link=/checklists/ashesof_war.html%23item_13_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Barricade+Shield&quot;&gt;Barricade Shield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4628,9 +4352,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="ashesofwar_8_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_8_9&amp;id=ashesofwar_8_9&amp;link=/checklists/ashesof_war.html%23item_8_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Thops's+Barrier&quot;&gt;Thops's Barrier&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_8_9&amp;id=ashesofwar_8_9&amp;link=/checklists/ashesof_war.html%23item_8_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Thops's+Barrier&quot;&gt;Thops's Barrier&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4663,9 +4385,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="ashesofwar_8_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_8_3&amp;id=ashesofwar_8_3&amp;link=/checklists/ashesof_war.html%23item_8_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Carian+Retaliation&quot;&gt;Carian Retaliation&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_8_3&amp;id=ashesofwar_8_3&amp;link=/checklists/ashesof_war.html%23item_8_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Carian+Retaliation&quot;&gt;Carian Retaliation&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4698,9 +4418,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="ashesofwar_13_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_13_5&amp;id=ashesofwar_13_5&amp;link=/checklists/ashesof_war.html%23item_13_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+No+Skill&quot;&gt;No Skill&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_13_5&amp;id=ashesofwar_13_5&amp;link=/checklists/ashesof_war.html%23item_13_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+No+Skill&quot;&gt;No Skill&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4733,9 +4451,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="ashesofwar_20_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_20_1&amp;id=ashesofwar_20_1&amp;link=/checklists/ashesof_war.html%23item_20_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Dryleaf+Whirlwind&quot;&gt;Dryleaf Whirlwind&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_20_1&amp;id=ashesofwar_20_1&amp;link=/checklists/ashesof_war.html%23item_20_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War:+Dryleaf+Whirlwind&quot;&gt;Dryleaf Whirlwind&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4768,9 +4484,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="ashesofwar_20_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_20_4&amp;id=ashesofwar_20_4&amp;link=/checklists/ashesof_war.html%23item_20_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War+Palm+Blast&quot;&gt;Palm Blast&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_20_4&amp;id=ashesofwar_20_4&amp;link=/checklists/ashesof_war.html%23item_20_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War+Palm+Blast&quot;&gt;Palm Blast&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4803,9 +4517,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="ashesofwar_20_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_20_7&amp;id=ashesofwar_20_7&amp;link=/checklists/ashesof_war.html%23item_20_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War+Wall+of+Sparks&quot;&gt;Wall of Sparks&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_20_7&amp;id=ashesofwar_20_7&amp;link=/checklists/ashesof_war.html%23item_20_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War+Wall+of+Sparks&quot;&gt;Wall of Sparks&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4838,9 +4550,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="ashesofwar_20_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_20_8&amp;id=ashesofwar_20_8&amp;link=/checklists/ashesof_war.html%23item_20_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War+Rolling+Sparks&quot;&gt;Rolling Sparks&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_20_8&amp;id=ashesofwar_20_8&amp;link=/checklists/ashesof_war.html%23item_20_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War+Rolling+Sparks&quot;&gt;Rolling Sparks&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4873,9 +4583,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="ashesofwar_20_24" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_20_24&amp;id=ashesofwar_20_24&amp;link=/checklists/ashesof_war.html%23item_20_24&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War+Igon's+Drake+Hunt&quot;&gt;Igon's Drake Hunt&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_20_24&amp;id=ashesofwar_20_24&amp;link=/checklists/ashesof_war.html%23item_20_24&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War+Igon's+Drake+Hunt&quot;&gt;Igon's Drake Hunt&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4908,9 +4616,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="ashesofwar_20_25" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_20_25&amp;id=ashesofwar_20_25&amp;link=/checklists/ashesof_war.html%23item_20_25&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War+Shield+Strike&quot;&gt;Shield Strike&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_20_25&amp;id=ashesofwar_20_25&amp;link=/checklists/ashesof_war.html%23item_20_25&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ash+of+War+Shield+Strike&quot;&gt;Shield Strike&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4944,9 +4650,7 @@
         <div class="card shadow-sm mb-3" id="ashesofwar_section_13">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#ashesofwar_13Col" data-bs-toggle="collapse" href="#ashesofwar_13Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#ashesofwar_13Col" data-bs-toggle="collapse" href="#ashesofwar_13Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Misc.</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="ashesofwar_totals_13"></span>
             </h4>
@@ -4958,9 +4662,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -4984,9 +4686,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="13" id="ashesofwar_14_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=ashesofwar_14_1&amp;id=ashesofwar_14_1&amp;link=/checklists/ashesof_war.html%23item_14_1&amp;title=Lost Ashes of War">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=ashesofwar_14_1&amp;id=ashesofwar_14_1&amp;link=/checklists/ashesof_war.html%23item_14_1&amp;title=Lost Ashes of War"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">

--- a/docs/checklists/bell_bearings.html
+++ b/docs/checklists/bell_bearings.html
@@ -27,14 +27,10 @@
         <a class="navbar-brand me-auto ms-2" href="/index.html">Roundtable Guides</a>
         <form class="d-none d-sm-flex order-2 order-xl-3">
           <input aria-label="search" class="form-control me-2" name="search" placeholder="Search" type="search">
-          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit">
-            <i class="bi bi-search"></i>
-          </button>
+          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit"><i class="bi bi-search"></i></button>
         </form>
         <div class="d-sm-none order-2">
-          <a class="nav-link me-0" href="/search.html">
-            <i class="bi bi-search sb-icon-search"></i>
-          </a>
+          <a class="nav-link me-0" href="/search.html"><i class="bi bi-search sb-icon-search"></i></a>
         </div>
         <div class="collapse navbar-collapse order-3 order-xl-2 ms-xl-2" id="nav-collapse">
           <ul class="nav navbar-nav navbar-nav-scroll mr-auto">
@@ -179,14 +175,10 @@
               </ul>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/map.html">
-                <i class="bi bi-map"></i> Map
-              </a>
+              <a class="nav-link hide-buttons" href="/map.html"><i class="bi bi-map"></i> Map</a>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/options.html">
-                <i class="bi bi-gear-fill"></i> Options
-              </a>
+              <a class="nav-link hide-buttons" href="/options.html"><i class="bi bi-gear-fill"></i> Options</a>
             </li>
           </ul>
         </div>
@@ -207,9 +199,7 @@
       <p>Bell bearings should be given to the Twin Maiden Husks at the Roundtable Hold. Each one found unlocks a unique selection of items for the shop, either adding it to the base stock or creating a new special sub-inventory within "Bell bearing shops." Some are found in the world or as boss drops; additionally, every NPC who sells items will drop a bell bearing if they die so that you can still access what they sell. Some bell bearings, including all from the unnamed Merchants of the world, can only be collected by murder, the only benefit to which is the convenience of their inventory being available in the Roundtable Hold. Bell bearings from merchants and NPCs reset upon NG+, but the others don't.</p>
       <nav class="text-muted toc d-print-none">
         <strong class="d-block h5">
-          <a class="toc-button" data-bs-toggle="collapse" href="#toc_bell_bearings" role="button">
-            <i class="bi bi-plus-lg"></i>Table Of Contents
-          </a>
+          <a class="toc-button" data-bs-toggle="collapse" href="#toc_bell_bearings" role="button"><i class="bi bi-plus-lg"></i>Table Of Contents</a>
         </strong>
         <ul class="toc_page collapse" id="toc_bell_bearings">
           <li>
@@ -257,9 +247,7 @@
         <div class="card shadow-sm mb-3" id="bell_bearings_section_0">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#bell_bearings_0Col" data-bs-toggle="collapse" href="#bell_bearings_0Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#bell_bearings_0Col" data-bs-toggle="collapse" href="#bell_bearings_0Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <img class="me-1" data-src="/img/icons/keys/edited/03142.png" loading="lazy" style="height: 70px; width: 70px">
               <span class="d-print-inline">Smithing-Stone Miner's Bell Bearings</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="bell_bearings_totals_0"></span>
@@ -272,9 +260,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -303,9 +289,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="bell_bearings_1_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bell_bearings_1_1&amp;id=bell_bearings_1_1&amp;link=/checklists/bell_bearings.html%23item_1_1&amp;title=[1]">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bell_bearings_1_1&amp;id=bell_bearings_1_1&amp;link=/checklists/bell_bearings.html%23item_1_1&amp;title=[1]"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -335,9 +319,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="bell_bearings_1_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bell_bearings_1_2&amp;id=bell_bearings_1_2&amp;link=/checklists/bell_bearings.html%23item_1_2&amp;title=[2]">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bell_bearings_1_2&amp;id=bell_bearings_1_2&amp;link=/checklists/bell_bearings.html%23item_1_2&amp;title=[2]"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -367,9 +349,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="bell_bearings_1_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bell_bearings_1_3&amp;id=bell_bearings_1_3&amp;link=/checklists/bell_bearings.html%23item_1_3&amp;title=[3]">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bell_bearings_1_3&amp;id=bell_bearings_1_3&amp;link=/checklists/bell_bearings.html%23item_1_3&amp;title=[3]"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -399,9 +379,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="bell_bearings_1_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bell_bearings_1_4&amp;id=bell_bearings_1_4&amp;link=/checklists/bell_bearings.html%23item_1_4&amp;title=[4]">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bell_bearings_1_4&amp;id=bell_bearings_1_4&amp;link=/checklists/bell_bearings.html%23item_1_4&amp;title=[4]"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -432,9 +410,7 @@
         <div class="card shadow-sm mb-3" id="bell_bearings_section_1">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#bell_bearings_1Col" data-bs-toggle="collapse" href="#bell_bearings_1Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#bell_bearings_1Col" data-bs-toggle="collapse" href="#bell_bearings_1Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <img class="me-1" data-src="/img/icons/keys/edited/03142.png" loading="lazy" style="height: 70px; width: 70px">
               <span class="d-print-inline">Somberstone Miner's Bell Bearings</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="bell_bearings_totals_1"></span>
@@ -447,9 +423,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -478,9 +452,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="bell_bearings_2_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bell_bearings_2_1&amp;id=bell_bearings_2_1&amp;link=/checklists/bell_bearings.html%23item_2_1&amp;title=[1]">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bell_bearings_2_1&amp;id=bell_bearings_2_1&amp;link=/checklists/bell_bearings.html%23item_2_1&amp;title=[1]"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -510,9 +482,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="bell_bearings_2_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bell_bearings_2_2&amp;id=bell_bearings_2_2&amp;link=/checklists/bell_bearings.html%23item_2_2&amp;title=[2]">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bell_bearings_2_2&amp;id=bell_bearings_2_2&amp;link=/checklists/bell_bearings.html%23item_2_2&amp;title=[2]"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -542,9 +512,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="bell_bearings_2_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bell_bearings_2_3&amp;id=bell_bearings_2_3&amp;link=/checklists/bell_bearings.html%23item_2_3&amp;title=[3]">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bell_bearings_2_3&amp;id=bell_bearings_2_3&amp;link=/checklists/bell_bearings.html%23item_2_3&amp;title=[3]"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -574,9 +542,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="bell_bearings_2_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bell_bearings_2_4&amp;id=bell_bearings_2_4&amp;link=/checklists/bell_bearings.html%23item_2_4&amp;title=[4]">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bell_bearings_2_4&amp;id=bell_bearings_2_4&amp;link=/checklists/bell_bearings.html%23item_2_4&amp;title=[4]"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -606,9 +572,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="bell_bearings_2_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bell_bearings_2_5&amp;id=bell_bearings_2_5&amp;link=/checklists/bell_bearings.html%23item_2_5&amp;title=[5]">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bell_bearings_2_5&amp;id=bell_bearings_2_5&amp;link=/checklists/bell_bearings.html%23item_2_5&amp;title=[5]"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -639,9 +603,7 @@
         <div class="card shadow-sm mb-3" id="bell_bearings_section_2">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#bell_bearings_2Col" data-bs-toggle="collapse" href="#bell_bearings_2Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#bell_bearings_2Col" data-bs-toggle="collapse" href="#bell_bearings_2Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <img class="me-1" data-src="/img/icons/keys/edited/03142.png" loading="lazy" style="height: 70px; width: 70px">
               <span class="d-print-inline">Glovewort Picker's Bell Bearings</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="bell_bearings_totals_2"></span>
@@ -654,9 +616,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -685,9 +645,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="bell_bearings_3_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bell_bearings_3_1&amp;id=bell_bearings_3_1&amp;link=/checklists/bell_bearings.html%23item_3_1&amp;title=[1]">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bell_bearings_3_1&amp;id=bell_bearings_3_1&amp;link=/checklists/bell_bearings.html%23item_3_1&amp;title=[1]"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -717,9 +675,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="bell_bearings_3_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bell_bearings_3_2&amp;id=bell_bearings_3_2&amp;link=/checklists/bell_bearings.html%23item_3_2&amp;title=[2]">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bell_bearings_3_2&amp;id=bell_bearings_3_2&amp;link=/checklists/bell_bearings.html%23item_3_2&amp;title=[2]"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -749,9 +705,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="bell_bearings_3_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bell_bearings_3_3&amp;id=bell_bearings_3_3&amp;link=/checklists/bell_bearings.html%23item_3_3&amp;title=[3]">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bell_bearings_3_3&amp;id=bell_bearings_3_3&amp;link=/checklists/bell_bearings.html%23item_3_3&amp;title=[3]"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -782,9 +736,7 @@
         <div class="card shadow-sm mb-3" id="bell_bearings_section_3">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#bell_bearings_3Col" data-bs-toggle="collapse" href="#bell_bearings_3Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#bell_bearings_3Col" data-bs-toggle="collapse" href="#bell_bearings_3Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <img class="me-1" data-src="/img/icons/keys/edited/03142.png" loading="lazy" style="height: 70px; width: 70px">
               <span class="d-print-inline">Ghostform Picker's Bell Bearings</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="bell_bearings_totals_3"></span>
@@ -797,9 +749,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -828,9 +778,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="bell_bearings_4_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bell_bearings_4_1&amp;id=bell_bearings_4_1&amp;link=/checklists/bell_bearings.html%23item_4_1&amp;title=[1]">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bell_bearings_4_1&amp;id=bell_bearings_4_1&amp;link=/checklists/bell_bearings.html%23item_4_1&amp;title=[1]"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -860,9 +808,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="bell_bearings_4_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bell_bearings_4_2&amp;id=bell_bearings_4_2&amp;link=/checklists/bell_bearings.html%23item_4_2&amp;title=[2]">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bell_bearings_4_2&amp;id=bell_bearings_4_2&amp;link=/checklists/bell_bearings.html%23item_4_2&amp;title=[2]"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -892,9 +838,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="bell_bearings_4_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bell_bearings_4_3&amp;id=bell_bearings_4_3&amp;link=/checklists/bell_bearings.html%23item_4_3&amp;title=[3]">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bell_bearings_4_3&amp;id=bell_bearings_4_3&amp;link=/checklists/bell_bearings.html%23item_4_3&amp;title=[3]"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -925,9 +869,7 @@
         <div class="card shadow-sm mb-3" id="bell_bearings_section_4">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#bell_bearings_4Col" data-bs-toggle="collapse" href="#bell_bearings_4Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#bell_bearings_4Col" data-bs-toggle="collapse" href="#bell_bearings_4Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <img class="me-1" data-src="/img/icons/keys/edited/03142.png" loading="lazy" style="height: 70px; width: 70px">
               <span class="d-print-inline">Peddlers' Bell Bearings</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="bell_bearings_totals_4"></span>
@@ -940,9 +882,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -971,9 +911,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="bell_bearings_5_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bell_bearings_5_1&amp;id=bell_bearings_5_1&amp;link=/checklists/bell_bearings.html%23item_5_1&amp;title=Bone">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bell_bearings_5_1&amp;id=bell_bearings_5_1&amp;link=/checklists/bell_bearings.html%23item_5_1&amp;title=Bone"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1003,9 +941,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="bell_bearings_5_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bell_bearings_5_2&amp;id=bell_bearings_5_2&amp;link=/checklists/bell_bearings.html%23item_5_2&amp;title=Meat">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bell_bearings_5_2&amp;id=bell_bearings_5_2&amp;link=/checklists/bell_bearings.html%23item_5_2&amp;title=Meat"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1035,9 +971,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="bell_bearings_5_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bell_bearings_5_3&amp;id=bell_bearings_5_3&amp;link=/checklists/bell_bearings.html%23item_5_3&amp;title=Gravity">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bell_bearings_5_3&amp;id=bell_bearings_5_3&amp;link=/checklists/bell_bearings.html%23item_5_3&amp;title=Gravity"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1067,9 +1001,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="bell_bearings_5_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bell_bearings_5_4&amp;id=bell_bearings_5_4&amp;link=/checklists/bell_bearings.html%23item_5_4&amp;title=Medicine">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bell_bearings_5_4&amp;id=bell_bearings_5_4&amp;link=/checklists/bell_bearings.html%23item_5_4&amp;title=Medicine"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1100,9 +1032,7 @@
         <div class="card shadow-sm mb-3" id="bell_bearings_section_5">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#bell_bearings_5Col" data-bs-toggle="collapse" href="#bell_bearings_5Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#bell_bearings_5Col" data-bs-toggle="collapse" href="#bell_bearings_5Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">NPCs' Bell Bearings</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="bell_bearings_totals_5"></span>
             </h4>
@@ -1114,9 +1044,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -1145,9 +1073,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="bell_bearings_6_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bell_bearings_6_1&amp;id=bell_bearings_6_1&amp;link=/checklists/bell_bearings.html%23item_6_1&amp;title=&lt;a href=&quot;npc_questlines.html#item_36_5&quot;&gt;Bernahl&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bell_bearings_6_1&amp;id=bell_bearings_6_1&amp;link=/checklists/bell_bearings.html%23item_6_1&amp;title=&lt;a href=&quot;npc_questlines.html#item_36_5&quot;&gt;Bernahl&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1180,9 +1106,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="bell_bearings_6_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bell_bearings_6_2&amp;id=bell_bearings_6_2&amp;link=/checklists/bell_bearings.html%23item_6_2&amp;title=&lt;a href=&quot;npc_questlines.html#item_11_4&quot;&gt;Blackguard&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bell_bearings_6_2&amp;id=bell_bearings_6_2&amp;link=/checklists/bell_bearings.html%23item_6_2&amp;title=&lt;a href=&quot;npc_questlines.html#item_11_4&quot;&gt;Blackguard&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1215,9 +1139,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="bell_bearings_6_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bell_bearings_6_3&amp;id=bell_bearings_6_3&amp;link=/checklists/bell_bearings.html%23item_6_3&amp;title=&lt;a href=&quot;npc_questlines.html#item_7_8&quot;&gt;Corhyn&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bell_bearings_6_3&amp;id=bell_bearings_6_3&amp;link=/checklists/bell_bearings.html%23item_6_3&amp;title=&lt;a href=&quot;npc_questlines.html#item_7_8&quot;&gt;Corhyn&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1250,9 +1172,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="bell_bearings_6_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bell_bearings_6_4&amp;id=bell_bearings_6_4&amp;link=/checklists/bell_bearings.html%23item_6_4&amp;title=&lt;a href=&quot;npc_questlines.html#item_23_5&quot;&gt;D, Hunter of the Dead&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bell_bearings_6_4&amp;id=bell_bearings_6_4&amp;link=/checklists/bell_bearings.html%23item_6_4&amp;title=&lt;a href=&quot;npc_questlines.html#item_23_5&quot;&gt;D, Hunter of the Dead&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1285,9 +1205,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="bell_bearings_6_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bell_bearings_6_5&amp;id=bell_bearings_6_5&amp;link=/checklists/bell_bearings.html%23item_6_5&amp;title=&lt;a href=&quot;npc_questlines.html#npc_quests_section_15&quot;&gt;Gostoc&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bell_bearings_6_5&amp;id=bell_bearings_6_5&amp;link=/checklists/bell_bearings.html%23item_6_5&amp;title=&lt;a href=&quot;npc_questlines.html#npc_quests_section_15&quot;&gt;Gostoc&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1320,9 +1238,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="bell_bearings_6_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bell_bearings_6_6&amp;id=bell_bearings_6_6&amp;link=/checklists/bell_bearings.html%23item_6_6&amp;title=&lt;a href=&quot;npc_questlines.html#item_31_20&quot;&gt;Gowry&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bell_bearings_6_6&amp;id=bell_bearings_6_6&amp;link=/checklists/bell_bearings.html%23item_6_6&amp;title=&lt;a href=&quot;npc_questlines.html#item_31_20&quot;&gt;Gowry&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1355,9 +1271,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="bell_bearings_6_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bell_bearings_6_7&amp;id=bell_bearings_6_7&amp;link=/checklists/bell_bearings.html%23item_6_7&amp;title=&lt;a href=&quot;npc_questlines.html#item_41_5&quot;&gt;Iji&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bell_bearings_6_7&amp;id=bell_bearings_6_7&amp;link=/checklists/bell_bearings.html%23item_6_7&amp;title=&lt;a href=&quot;npc_questlines.html#item_41_5&quot;&gt;Iji&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1390,9 +1304,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="bell_bearings_6_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bell_bearings_6_8&amp;id=bell_bearings_6_8&amp;link=/checklists/bell_bearings.html%23item_6_8&amp;title=&lt;a href=&quot;npc_questlines.html#npc_quests_section_28&quot;&gt;Miriel&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bell_bearings_6_8&amp;id=bell_bearings_6_8&amp;link=/checklists/bell_bearings.html%23item_6_8&amp;title=&lt;a href=&quot;npc_questlines.html#npc_quests_section_28&quot;&gt;Miriel&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1425,9 +1337,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="bell_bearings_6_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bell_bearings_6_9&amp;id=bell_bearings_6_9&amp;link=/checklists/bell_bearings.html%23item_6_9&amp;title=&lt;a href=&quot;npc_questlines.html#npc_quests_section_30&quot;&gt;Patches&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bell_bearings_6_9&amp;id=bell_bearings_6_9&amp;link=/checklists/bell_bearings.html%23item_6_9&amp;title=&lt;a href=&quot;npc_questlines.html#npc_quests_section_30&quot;&gt;Patches&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1460,9 +1370,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="bell_bearings_6_10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bell_bearings_6_10&amp;id=bell_bearings_6_10&amp;link=/checklists/bell_bearings.html%23item_6_10&amp;title=&lt;a href=&quot;npc_questlines.html#item_18_2&quot;&gt;Pidia&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bell_bearings_6_10&amp;id=bell_bearings_6_10&amp;link=/checklists/bell_bearings.html%23item_6_10&amp;title=&lt;a href=&quot;npc_questlines.html#item_18_2&quot;&gt;Pidia&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1495,9 +1403,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="bell_bearings_6_11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bell_bearings_6_11&amp;id=bell_bearings_6_11&amp;link=/checklists/bell_bearings.html%23item_6_11&amp;title=&lt;a href=&quot;npc_questlines.html#item_21_7&quot;&gt;Rogier&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bell_bearings_6_11&amp;id=bell_bearings_6_11&amp;link=/checklists/bell_bearings.html%23item_6_11&amp;title=&lt;a href=&quot;npc_questlines.html#item_21_7&quot;&gt;Rogier&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1530,9 +1436,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="bell_bearings_6_12" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bell_bearings_6_12&amp;id=bell_bearings_6_12&amp;link=/checklists/bell_bearings.html%23item_6_12&amp;title=&lt;a href=&quot;npc_questlines.html#item_10_8&quot;&gt;Sellen&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bell_bearings_6_12&amp;id=bell_bearings_6_12&amp;link=/checklists/bell_bearings.html%23item_6_12&amp;title=&lt;a href=&quot;npc_questlines.html#item_10_8&quot;&gt;Sellen&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1565,9 +1469,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="bell_bearings_6_13" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bell_bearings_6_13&amp;id=bell_bearings_6_13&amp;link=/checklists/bell_bearings.html%23item_6_13&amp;title=&lt;a href=&quot;npc_questlines.html#item_19_7&quot;&gt;Seluvis&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bell_bearings_6_13&amp;id=bell_bearings_6_13&amp;link=/checklists/bell_bearings.html%23item_6_13&amp;title=&lt;a href=&quot;npc_questlines.html#item_19_7&quot;&gt;Seluvis&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1600,9 +1502,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="bell_bearings_6_14" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bell_bearings_6_14&amp;id=bell_bearings_6_14&amp;link=/checklists/bell_bearings.html%23item_6_14&amp;title=&lt;a href=&quot;npc_questlines.html#item_4_3&quot;&gt;Thops&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bell_bearings_6_14&amp;id=bell_bearings_6_14&amp;link=/checklists/bell_bearings.html%23item_6_14&amp;title=&lt;a href=&quot;npc_questlines.html#item_4_3&quot;&gt;Thops&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1636,9 +1536,7 @@
         <div class="card shadow-sm mb-3" id="bell_bearings_section_6">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#bell_bearings_6Col" data-bs-toggle="collapse" href="#bell_bearings_6Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#bell_bearings_6Col" data-bs-toggle="collapse" href="#bell_bearings_6Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <img class="me-1" data-src="/img/icons/keys/edited/03142.png" loading="lazy" style="height: 70px; width: 70px">
               <span class="d-print-inline">Merchants' Bell Bearings</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="bell_bearings_totals_6"></span>
@@ -1651,9 +1549,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -1677,9 +1573,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="bell_bearings_7_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bell_bearings_7_1&amp;id=bell_bearings_7_1&amp;link=/checklists/bell_bearings.html%23item_7_1&amp;title=Kalé">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bell_bearings_7_1&amp;id=bell_bearings_7_1&amp;link=/checklists/bell_bearings.html%23item_7_1&amp;title=Kalé"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1705,9 +1599,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="bell_bearings_7_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bell_bearings_7_2&amp;id=bell_bearings_7_2&amp;link=/checklists/bell_bearings.html%23item_7_2&amp;title=Nomadic Merchant (1)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bell_bearings_7_2&amp;id=bell_bearings_7_2&amp;link=/checklists/bell_bearings.html%23item_7_2&amp;title=Nomadic Merchant (1)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1733,9 +1625,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="bell_bearings_7_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bell_bearings_7_3&amp;id=bell_bearings_7_3&amp;link=/checklists/bell_bearings.html%23item_7_3&amp;title=Nomadic Merchant (2)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bell_bearings_7_3&amp;id=bell_bearings_7_3&amp;link=/checklists/bell_bearings.html%23item_7_3&amp;title=Nomadic Merchant (2)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1761,9 +1651,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="bell_bearings_7_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bell_bearings_7_4&amp;id=bell_bearings_7_4&amp;link=/checklists/bell_bearings.html%23item_7_4&amp;title=Nomadic Merchant (3)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bell_bearings_7_4&amp;id=bell_bearings_7_4&amp;link=/checklists/bell_bearings.html%23item_7_4&amp;title=Nomadic Merchant (3)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1789,9 +1677,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="bell_bearings_7_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bell_bearings_7_5&amp;id=bell_bearings_7_5&amp;link=/checklists/bell_bearings.html%23item_7_5&amp;title=Nomadic Merchant (4)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bell_bearings_7_5&amp;id=bell_bearings_7_5&amp;link=/checklists/bell_bearings.html%23item_7_5&amp;title=Nomadic Merchant (4)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1817,9 +1703,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="bell_bearings_7_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bell_bearings_7_6&amp;id=bell_bearings_7_6&amp;link=/checklists/bell_bearings.html%23item_7_6&amp;title=Nomadic Merchant (5)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bell_bearings_7_6&amp;id=bell_bearings_7_6&amp;link=/checklists/bell_bearings.html%23item_7_6&amp;title=Nomadic Merchant (5)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1845,9 +1729,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="bell_bearings_7_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bell_bearings_7_7&amp;id=bell_bearings_7_7&amp;link=/checklists/bell_bearings.html%23item_7_7&amp;title=Nomadic Merchant (6)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bell_bearings_7_7&amp;id=bell_bearings_7_7&amp;link=/checklists/bell_bearings.html%23item_7_7&amp;title=Nomadic Merchant (6)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1873,9 +1755,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="bell_bearings_7_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bell_bearings_7_8&amp;id=bell_bearings_7_8&amp;link=/checklists/bell_bearings.html%23item_7_8&amp;title=Nomadic Merchant (7)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bell_bearings_7_8&amp;id=bell_bearings_7_8&amp;link=/checklists/bell_bearings.html%23item_7_8&amp;title=Nomadic Merchant (7)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1901,9 +1781,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="bell_bearings_7_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bell_bearings_7_9&amp;id=bell_bearings_7_9&amp;link=/checklists/bell_bearings.html%23item_7_9&amp;title=Nomadic Merchant (8)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bell_bearings_7_9&amp;id=bell_bearings_7_9&amp;link=/checklists/bell_bearings.html%23item_7_9&amp;title=Nomadic Merchant (8)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1929,9 +1807,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="bell_bearings_7_10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bell_bearings_7_10&amp;id=bell_bearings_7_10&amp;link=/checklists/bell_bearings.html%23item_7_10&amp;title=Nomadic Merchant (9)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bell_bearings_7_10&amp;id=bell_bearings_7_10&amp;link=/checklists/bell_bearings.html%23item_7_10&amp;title=Nomadic Merchant (9)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1957,9 +1833,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="bell_bearings_7_11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bell_bearings_7_11&amp;id=bell_bearings_7_11&amp;link=/checklists/bell_bearings.html%23item_7_11&amp;title=Nomadic Merchant (10)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bell_bearings_7_11&amp;id=bell_bearings_7_11&amp;link=/checklists/bell_bearings.html%23item_7_11&amp;title=Nomadic Merchant (10)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1985,9 +1859,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="bell_bearings_7_12" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bell_bearings_7_12&amp;id=bell_bearings_7_12&amp;link=/checklists/bell_bearings.html%23item_7_12&amp;title=Isolated Merchant (1)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bell_bearings_7_12&amp;id=bell_bearings_7_12&amp;link=/checklists/bell_bearings.html%23item_7_12&amp;title=Isolated Merchant (1)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2013,9 +1885,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="bell_bearings_7_13" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bell_bearings_7_13&amp;id=bell_bearings_7_13&amp;link=/checklists/bell_bearings.html%23item_7_13&amp;title=Isolated Merchant (2)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bell_bearings_7_13&amp;id=bell_bearings_7_13&amp;link=/checklists/bell_bearings.html%23item_7_13&amp;title=Isolated Merchant (2)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2041,9 +1911,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="bell_bearings_7_14" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bell_bearings_7_14&amp;id=bell_bearings_7_14&amp;link=/checklists/bell_bearings.html%23item_7_14&amp;title=Isolated Merchant (3)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bell_bearings_7_14&amp;id=bell_bearings_7_14&amp;link=/checklists/bell_bearings.html%23item_7_14&amp;title=Isolated Merchant (3)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2069,9 +1937,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="bell_bearings_7_15" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bell_bearings_7_15&amp;id=bell_bearings_7_15&amp;link=/checklists/bell_bearings.html%23item_7_15&amp;title=Hermit Merchant (1)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bell_bearings_7_15&amp;id=bell_bearings_7_15&amp;link=/checklists/bell_bearings.html%23item_7_15&amp;title=Hermit Merchant (1)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2097,9 +1963,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="bell_bearings_7_16" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bell_bearings_7_16&amp;id=bell_bearings_7_16&amp;link=/checklists/bell_bearings.html%23item_7_16&amp;title=Hermit Merchant (2)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bell_bearings_7_16&amp;id=bell_bearings_7_16&amp;link=/checklists/bell_bearings.html%23item_7_16&amp;title=Hermit Merchant (2)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2125,9 +1989,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="bell_bearings_7_17" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bell_bearings_7_17&amp;id=bell_bearings_7_17&amp;link=/checklists/bell_bearings.html%23item_7_17&amp;title=Hermit Merchant (3)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bell_bearings_7_17&amp;id=bell_bearings_7_17&amp;link=/checklists/bell_bearings.html%23item_7_17&amp;title=Hermit Merchant (3)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2153,9 +2015,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="bell_bearings_7_18" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bell_bearings_7_18&amp;id=bell_bearings_7_18&amp;link=/checklists/bell_bearings.html%23item_7_18&amp;title=Abandoned Merchant">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bell_bearings_7_18&amp;id=bell_bearings_7_18&amp;link=/checklists/bell_bearings.html%23item_7_18&amp;title=Abandoned Merchant"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2181,9 +2041,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="bell_bearings_7_19" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bell_bearings_7_19&amp;id=bell_bearings_7_19&amp;link=/checklists/bell_bearings.html%23item_7_19&amp;title=Imprisoned Merchant">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bell_bearings_7_19&amp;id=bell_bearings_7_19&amp;link=/checklists/bell_bearings.html%23item_7_19&amp;title=Imprisoned Merchant"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2210,9 +2068,7 @@
         <div class="card shadow-sm mb-3" id="bell_bearings_section_7">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#bell_bearings_7Col" data-bs-toggle="collapse" href="#bell_bearings_7Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#bell_bearings_7Col" data-bs-toggle="collapse" href="#bell_bearings_7Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <img class="me-1" data-src="/img/icons/keys/edited/03142.png" loading="lazy" style="height: 70px; width: 70px">
               <span class="d-print-inline">Real of Shadow: NPCs' Bell Bearings</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="bell_bearings_totals_7"></span>
@@ -2225,9 +2081,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -2251,9 +2105,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="bell_bearings_10_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bell_bearings_10_1&amp;id=bell_bearings_10_1&amp;link=/checklists/bell_bearings.html%23item_10_1&amp;title=Moore's Bell Bearing">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bell_bearings_10_1&amp;id=bell_bearings_10_1&amp;link=/checklists/bell_bearings.html%23item_10_1&amp;title=Moore's Bell Bearing"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2279,9 +2131,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="bell_bearings_10_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bell_bearings_10_2&amp;id=bell_bearings_10_2&amp;link=/checklists/bell_bearings.html%23item_10_2&amp;title=Ymir's Bell Bearing">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bell_bearings_10_2&amp;id=bell_bearings_10_2&amp;link=/checklists/bell_bearings.html%23item_10_2&amp;title=Ymir's Bell Bearing"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2308,9 +2158,7 @@
         <div class="card shadow-sm mb-3" id="bell_bearings_section_8">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#bell_bearings_8Col" data-bs-toggle="collapse" href="#bell_bearings_8Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#bell_bearings_8Col" data-bs-toggle="collapse" href="#bell_bearings_8Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <img class="me-1" data-src="/img/icons/keys/edited/03142.png" loading="lazy" style="height: 70px; width: 70px">
               <span class="d-print-inline">Real of Shadow: Seller's Bell Bearings</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="bell_bearings_totals_8"></span>
@@ -2323,9 +2171,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -2354,9 +2200,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="bell_bearings_11_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bell_bearings_11_1&amp;id=bell_bearings_11_1&amp;link=/checklists/bell_bearings.html%23item_11_1&amp;title=Herbalist's Bell Bearing">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bell_bearings_11_1&amp;id=bell_bearings_11_1&amp;link=/checklists/bell_bearings.html%23item_11_1&amp;title=Herbalist's Bell Bearing"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2386,9 +2230,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="bell_bearings_11_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bell_bearings_11_2&amp;id=bell_bearings_11_2&amp;link=/checklists/bell_bearings.html%23item_11_2&amp;title=Mushroom-Seller's Bell Bearing [1]">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bell_bearings_11_2&amp;id=bell_bearings_11_2&amp;link=/checklists/bell_bearings.html%23item_11_2&amp;title=Mushroom-Seller's Bell Bearing [1]"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2418,9 +2260,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="bell_bearings_11_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bell_bearings_11_3&amp;id=bell_bearings_11_3&amp;link=/checklists/bell_bearings.html%23item_11_3&amp;title=Mushroom-Seller's Bell Bearing [2]">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bell_bearings_11_3&amp;id=bell_bearings_11_3&amp;link=/checklists/bell_bearings.html%23item_11_3&amp;title=Mushroom-Seller's Bell Bearing [2]"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2450,9 +2290,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="bell_bearings_11_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bell_bearings_11_4&amp;id=bell_bearings_11_4&amp;link=/checklists/bell_bearings.html%23item_11_4&amp;title=Greasemonger's Bell Bearing">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bell_bearings_11_4&amp;id=bell_bearings_11_4&amp;link=/checklists/bell_bearings.html%23item_11_4&amp;title=Greasemonger's Bell Bearing"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2482,9 +2320,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="bell_bearings_11_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bell_bearings_11_5&amp;id=bell_bearings_11_5&amp;link=/checklists/bell_bearings.html%23item_11_5&amp;title=Moldmonger's Bell Bearing">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bell_bearings_11_5&amp;id=bell_bearings_11_5&amp;link=/checklists/bell_bearings.html%23item_11_5&amp;title=Moldmonger's Bell Bearing"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2514,9 +2350,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="bell_bearings_11_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bell_bearings_11_6&amp;id=bell_bearings_11_6&amp;link=/checklists/bell_bearings.html%23item_11_6&amp;title=Igon's Bell Bearing">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bell_bearings_11_6&amp;id=bell_bearings_11_6&amp;link=/checklists/bell_bearings.html%23item_11_6&amp;title=Igon's Bell Bearing"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2546,9 +2380,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="bell_bearings_11_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bell_bearings_11_7&amp;id=bell_bearings_11_7&amp;link=/checklists/bell_bearings.html%23item_11_7&amp;title=Spellmachinist's Bell Bearing">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bell_bearings_11_7&amp;id=bell_bearings_11_7&amp;link=/checklists/bell_bearings.html%23item_11_7&amp;title=Spellmachinist's Bell Bearing"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2578,9 +2410,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="bell_bearings_11_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bell_bearings_11_8&amp;id=bell_bearings_11_8&amp;link=/checklists/bell_bearings.html%23item_11_8&amp;title=String-Seller's Bell Bearing">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bell_bearings_11_8&amp;id=bell_bearings_11_8&amp;link=/checklists/bell_bearings.html%23item_11_8&amp;title=String-Seller's Bell Bearing"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">

--- a/docs/checklists/bosses.html
+++ b/docs/checklists/bosses.html
@@ -27,14 +27,10 @@
         <a class="navbar-brand me-auto ms-2" href="/index.html">Roundtable Guides</a>
         <form class="d-none d-sm-flex order-2 order-xl-3">
           <input aria-label="search" class="form-control me-2" name="search" placeholder="Search" type="search">
-          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit">
-            <i class="bi bi-search"></i>
-          </button>
+          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit"><i class="bi bi-search"></i></button>
         </form>
         <div class="d-sm-none order-2">
-          <a class="nav-link me-0" href="/search.html">
-            <i class="bi bi-search sb-icon-search"></i>
-          </a>
+          <a class="nav-link me-0" href="/search.html"><i class="bi bi-search sb-icon-search"></i></a>
         </div>
         <div class="collapse navbar-collapse order-3 order-xl-2 ms-xl-2" id="nav-collapse">
           <ul class="nav navbar-nav navbar-nav-scroll mr-auto">
@@ -179,14 +175,10 @@
               </ul>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/map.html">
-                <i class="bi bi-map"></i> Map
-              </a>
+              <a class="nav-link hide-buttons" href="/map.html"><i class="bi bi-map"></i> Map</a>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/options.html">
-                <i class="bi bi-gear-fill"></i> Options
-              </a>
+              <a class="nav-link hide-buttons" href="/options.html"><i class="bi bi-gear-fill"></i> Options</a>
             </li>
           </ul>
         </div>
@@ -206,9 +198,7 @@
       </div>
       <nav class="text-muted toc d-print-none">
         <strong class="d-block h5">
-          <a class="toc-button" data-bs-toggle="collapse" href="#toc_bosses" role="button">
-            <i class="bi bi-plus-lg"></i>Table Of Contents
-          </a>
+          <a class="toc-button" data-bs-toggle="collapse" href="#toc_bosses" role="button"><i class="bi bi-plus-lg"></i>Table Of Contents</a>
         </strong>
         <ul class="toc_page collapse" id="toc_bosses">
           <li>
@@ -292,9 +282,7 @@
         <div class="card shadow-sm mb-3" id="bosses_section_0">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#bosses_0Col" data-bs-toggle="collapse" href="#bosses_0Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#bosses_0Col" data-bs-toggle="collapse" href="#bosses_0Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Limgrave</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="bosses_totals_0"></span>
             </h4>
@@ -306,9 +294,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -342,9 +328,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="bosses_2_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_2_1&amp;id=bosses_2_1&amp;link=/checklists/bosses.html%23item_2_1&amp;title=Soldier of Godrick (Tutorial)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_2_1&amp;id=bosses_2_1&amp;link=/checklists/bosses.html%23item_2_1&amp;title=Soldier of Godrick (Tutorial)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -378,9 +362,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="bosses_2_14" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_2_14&amp;id=bosses_2_14&amp;link=/checklists/bosses.html%23item_2_14&amp;title=Tree Sentinel">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_2_14&amp;id=bosses_2_14&amp;link=/checklists/bosses.html%23item_2_14&amp;title=Tree Sentinel"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -414,9 +396,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="bosses_2_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_2_2&amp;id=bosses_2_2&amp;link=/checklists/bosses.html%23item_2_2&amp;title=Demi-Human Chief (x2)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_2_2&amp;id=bosses_2_2&amp;link=/checklists/bosses.html%23item_2_2&amp;title=Demi-Human Chief (x2)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -450,9 +430,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="bosses_2_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_2_3&amp;id=bosses_2_3&amp;link=/checklists/bosses.html%23item_2_3&amp;title=Erdtree Burial Watchdog">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_2_3&amp;id=bosses_2_3&amp;link=/checklists/bosses.html%23item_2_3&amp;title=Erdtree Burial Watchdog"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -485,9 +463,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="bosses_2_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_2_4&amp;id=bosses_2_4&amp;link=/checklists/bosses.html%23item_2_4&amp;title=Beastman of Farum Azula">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_2_4&amp;id=bosses_2_4&amp;link=/checklists/bosses.html%23item_2_4&amp;title=Beastman of Farum Azula"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -520,9 +496,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="bosses_2_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_2_5&amp;id=bosses_2_5&amp;link=/checklists/bosses.html%23item_2_5&amp;title=Stonedigger Troll">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_2_5&amp;id=bosses_2_5&amp;link=/checklists/bosses.html%23item_2_5&amp;title=Stonedigger Troll"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -555,9 +529,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="bosses_2_13" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_2_13&amp;id=bosses_2_13&amp;link=/checklists/bosses.html%23item_2_13&amp;title=Night's Cavalry (Night only)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_2_13&amp;id=bosses_2_13&amp;link=/checklists/bosses.html%23item_2_13&amp;title=Night's Cavalry (Night only)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -591,9 +563,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="bosses_2_12" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_2_12&amp;id=bosses_2_12&amp;link=/checklists/bosses.html%23item_2_12&amp;title=Mad Pumpkin Head">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_2_12&amp;id=bosses_2_12&amp;link=/checklists/bosses.html%23item_2_12&amp;title=Mad Pumpkin Head"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -626,9 +596,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="bosses_2_18" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_2_18&amp;id=bosses_2_18&amp;link=/checklists/bosses.html%23item_2_18&amp;title=Bloodhound Knight Darriwil">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_2_18&amp;id=bosses_2_18&amp;link=/checklists/bosses.html%23item_2_18&amp;title=Bloodhound Knight Darriwil"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -662,9 +630,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="bosses_2_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_2_7&amp;id=bosses_2_7&amp;link=/checklists/bosses.html%23item_2_7&amp;title=Bloody Finger Nerijus (NPC Invader)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_2_7&amp;id=bosses_2_7&amp;link=/checklists/bosses.html%23item_2_7&amp;title=Bloody Finger Nerijus (NPC Invader)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -698,9 +664,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="bosses_2_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_2_8&amp;id=bosses_2_8&amp;link=/checklists/bosses.html%23item_2_8&amp;title=Patches">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_2_8&amp;id=bosses_2_8&amp;link=/checklists/bosses.html%23item_2_8&amp;title=Patches"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -734,9 +698,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="bosses_2_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_2_6&amp;id=bosses_2_6&amp;link=/checklists/bosses.html%23item_2_6&amp;title=Grave Warden Duelist">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_2_6&amp;id=bosses_2_6&amp;link=/checklists/bosses.html%23item_2_6&amp;title=Grave Warden Duelist"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -769,9 +731,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="bosses_2_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_2_9&amp;id=bosses_2_9&amp;link=/checklists/bosses.html%23item_2_9&amp;title=Guardian Golem">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_2_9&amp;id=bosses_2_9&amp;link=/checklists/bosses.html%23item_2_9&amp;title=Guardian Golem"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -804,9 +764,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="bosses_2_10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_2_10&amp;id=bosses_2_10&amp;link=/checklists/bosses.html%23item_2_10&amp;title=Black Knife Assassin">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_2_10&amp;id=bosses_2_10&amp;link=/checklists/bosses.html%23item_2_10&amp;title=Black Knife Assassin"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -839,9 +797,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="bosses_2_15" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_2_15&amp;id=bosses_2_15&amp;link=/checklists/bosses.html%23item_2_15&amp;title=Flying Dragon Agheel">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_2_15&amp;id=bosses_2_15&amp;link=/checklists/bosses.html%23item_2_15&amp;title=Flying Dragon Agheel"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -875,9 +831,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="bosses_2_16" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_2_16&amp;id=bosses_2_16&amp;link=/checklists/bosses.html%23item_2_16&amp;title=Tibia Mariner">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_2_16&amp;id=bosses_2_16&amp;link=/checklists/bosses.html%23item_2_16&amp;title=Tibia Mariner"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -911,9 +865,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="bosses_2_32" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_2_32&amp;id=bosses_2_32&amp;link=/checklists/bosses.html%23item_2_32&amp;title=Godrick Knight (During Kenneth Haight Questline)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_2_32&amp;id=bosses_2_32&amp;link=/checklists/bosses.html%23item_2_32&amp;title=Godrick Knight (During Kenneth Haight Questline)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -946,9 +898,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="bosses_2_17" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_2_17&amp;id=bosses_2_17&amp;link=/checklists/bosses.html%23item_2_17&amp;title=Anastasia, Tarnished-Eater (NPC Invader)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_2_17&amp;id=bosses_2_17&amp;link=/checklists/bosses.html%23item_2_17&amp;title=Anastasia, Tarnished-Eater (NPC Invader)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -981,9 +931,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="bosses_2_19" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_2_19&amp;id=bosses_2_19&amp;link=/checklists/bosses.html%23item_2_19&amp;title=Crucible Knight">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_2_19&amp;id=bosses_2_19&amp;link=/checklists/bosses.html%23item_2_19&amp;title=Crucible Knight"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1016,9 +964,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="bosses_2_20" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_2_20&amp;id=bosses_2_20&amp;link=/checklists/bosses.html%23item_2_20&amp;title=Bell Bearing Hunter (Night only)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_2_20&amp;id=bosses_2_20&amp;link=/checklists/bosses.html%23item_2_20&amp;title=Bell Bearing Hunter (Night only)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1052,9 +998,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="bosses_2_21" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_2_21&amp;id=bosses_2_21&amp;link=/checklists/bosses.html%23item_2_21&amp;title=Deathbird (Night only)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_2_21&amp;id=bosses_2_21&amp;link=/checklists/bosses.html%23item_2_21&amp;title=Deathbird (Night only)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1088,9 +1032,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="bosses_2_11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_2_11&amp;id=bosses_2_11&amp;link=/checklists/bosses.html%23item_2_11&amp;title=Recusant Henricus (NPC Invader)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_2_11&amp;id=bosses_2_11&amp;link=/checklists/bosses.html%23item_2_11&amp;title=Recusant Henricus (NPC Invader)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1124,9 +1066,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="bosses_2_30" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_2_30&amp;id=bosses_2_30&amp;link=/checklists/bosses.html%23item_2_30&amp;title=Grafted Scion (x2)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_2_30&amp;id=bosses_2_30&amp;link=/checklists/bosses.html%23item_2_30&amp;title=Grafted Scion (x2)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1160,9 +1100,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="bosses_2_23" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_2_23&amp;id=bosses_2_23&amp;link=/checklists/bosses.html%23item_2_23&amp;title=Ulcerated Tree Spirit">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_2_23&amp;id=bosses_2_23&amp;link=/checklists/bosses.html%23item_2_23&amp;title=Ulcerated Tree Spirit"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1195,9 +1133,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="bosses_2_24" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_2_24&amp;id=bosses_2_24&amp;link=/checklists/bosses.html%23item_2_24&amp;title=Ulcerated Tree Spirit">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_2_24&amp;id=bosses_2_24&amp;link=/checklists/bosses.html%23item_2_24&amp;title=Ulcerated Tree Spirit"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1231,9 +1167,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="bosses_2_25" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_2_25&amp;id=bosses_2_25&amp;link=/checklists/bosses.html%23item_2_25&amp;title=Crucible Knight">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_2_25&amp;id=bosses_2_25&amp;link=/checklists/bosses.html%23item_2_25&amp;title=Crucible Knight"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1267,9 +1201,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="bosses_2_26" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_2_26&amp;id=bosses_2_26&amp;link=/checklists/bosses.html%23item_2_26&amp;title=Grafted Scion">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_2_26&amp;id=bosses_2_26&amp;link=/checklists/bosses.html%23item_2_26&amp;title=Grafted Scion"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1303,9 +1235,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="bosses_2_27" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_2_27&amp;id=bosses_2_27&amp;link=/checklists/bosses.html%23item_2_27&amp;title=Lion Guardian">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_2_27&amp;id=bosses_2_27&amp;link=/checklists/bosses.html%23item_2_27&amp;title=Lion Guardian"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1339,9 +1269,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="bosses_2_28" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_2_28&amp;id=bosses_2_28&amp;link=/checklists/bosses.html%23item_2_28&amp;title=Margit, the Fell Omen">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_2_28&amp;id=bosses_2_28&amp;link=/checklists/bosses.html%23item_2_28&amp;title=Margit, the Fell Omen"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1375,9 +1303,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="bosses_2_29" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_2_29&amp;id=bosses_2_29&amp;link=/checklists/bosses.html%23item_2_29&amp;title=Godrick the Grafted">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_2_29&amp;id=bosses_2_29&amp;link=/checklists/bosses.html%23item_2_29&amp;title=Godrick the Grafted"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1411,9 +1337,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="bosses_2_22" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_2_22&amp;id=bosses_2_22&amp;link=/checklists/bosses.html%23item_2_22&amp;title=Old Knight Istvan (Volcano Manor Questline)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_2_22&amp;id=bosses_2_22&amp;link=/checklists/bosses.html%23item_2_22&amp;title=Old Knight Istvan (Volcano Manor Questline)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1448,9 +1372,7 @@
         <div class="card shadow-sm mb-3" id="bosses_section_1">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#bosses_1Col" data-bs-toggle="collapse" href="#bosses_1Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#bosses_1Col" data-bs-toggle="collapse" href="#bosses_1Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Weeping Peninsula</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="bosses_totals_1"></span>
             </h4>
@@ -1462,9 +1384,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -1498,9 +1418,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="bosses_1_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_1_2&amp;id=bosses_1_2&amp;link=/checklists/bosses.html%23item_1_2&amp;title=Runebear">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_1_2&amp;id=bosses_1_2&amp;link=/checklists/bosses.html%23item_1_2&amp;title=Runebear"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1533,9 +1451,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="bosses_1_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_1_3&amp;id=bosses_1_3&amp;link=/checklists/bosses.html%23item_1_3&amp;title=Demi-Human Queen">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_1_3&amp;id=bosses_1_3&amp;link=/checklists/bosses.html%23item_1_3&amp;title=Demi-Human Queen"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1569,9 +1485,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="bosses_1_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_1_8&amp;id=bosses_1_8&amp;link=/checklists/bosses.html%23item_1_8&amp;title=Scaly Misbegotten">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_1_8&amp;id=bosses_1_8&amp;link=/checklists/bosses.html%23item_1_8&amp;title=Scaly Misbegotten"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1604,9 +1518,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="bosses_1_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_1_4&amp;id=bosses_1_4&amp;link=/checklists/bosses.html%23item_1_4&amp;title=Night's Cavalry (Night only)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_1_4&amp;id=bosses_1_4&amp;link=/checklists/bosses.html%23item_1_4&amp;title=Night's Cavalry (Night only)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1640,9 +1552,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="bosses_1_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_1_1&amp;id=bosses_1_1&amp;link=/checklists/bosses.html%23item_1_1&amp;title=Erdtree Burial Watchdog">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_1_1&amp;id=bosses_1_1&amp;link=/checklists/bosses.html%23item_1_1&amp;title=Erdtree Burial Watchdog"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1676,9 +1586,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="bosses_1_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_1_7&amp;id=bosses_1_7&amp;link=/checklists/bosses.html%23item_1_7&amp;title=Erdtree Avatar">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_1_7&amp;id=bosses_1_7&amp;link=/checklists/bosses.html%23item_1_7&amp;title=Erdtree Avatar"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1712,9 +1620,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="bosses_1_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_1_6&amp;id=bosses_1_6&amp;link=/checklists/bosses.html%23item_1_6&amp;title=Cemetery Shade">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_1_6&amp;id=bosses_1_6&amp;link=/checklists/bosses.html%23item_1_6&amp;title=Cemetery Shade"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1747,9 +1653,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="bosses_1_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_1_9&amp;id=bosses_1_9&amp;link=/checklists/bosses.html%23item_1_9&amp;title=Miranda, the Blighted Bloom">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_1_9&amp;id=bosses_1_9&amp;link=/checklists/bosses.html%23item_1_9&amp;title=Miranda, the Blighted Bloom"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1782,9 +1686,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="bosses_1_10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_1_10&amp;id=bosses_1_10&amp;link=/checklists/bosses.html%23item_1_10&amp;title=Ancient Hero of Zamor">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_1_10&amp;id=bosses_1_10&amp;link=/checklists/bosses.html%23item_1_10&amp;title=Ancient Hero of Zamor"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1817,9 +1719,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="bosses_1_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_1_5&amp;id=bosses_1_5&amp;link=/checklists/bosses.html%23item_1_5&amp;title=Deathbird (Night only)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_1_5&amp;id=bosses_1_5&amp;link=/checklists/bosses.html%23item_1_5&amp;title=Deathbird (Night only)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1853,9 +1753,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="bosses_1_11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_1_11&amp;id=bosses_1_11&amp;link=/checklists/bosses.html%23item_1_11&amp;title=Leonine Misbegotten">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_1_11&amp;id=bosses_1_11&amp;link=/checklists/bosses.html%23item_1_11&amp;title=Leonine Misbegotten"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1890,9 +1788,7 @@
         <div class="card shadow-sm mb-3" id="bosses_section_2">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#bosses_2Col" data-bs-toggle="collapse" href="#bosses_2Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#bosses_2Col" data-bs-toggle="collapse" href="#bosses_2Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Roundtable Hold</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="bosses_totals_2"></span>
             </h4>
@@ -1904,9 +1800,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -1940,9 +1834,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="bosses_3_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_3_1&amp;id=bosses_3_1&amp;link=/checklists/bosses.html%23item_3_1&amp;title=Mad Tongue Alberich">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_3_1&amp;id=bosses_3_1&amp;link=/checklists/bosses.html%23item_3_1&amp;title=Mad Tongue Alberich"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1976,9 +1868,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="bosses_3_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_3_2&amp;id=bosses_3_2&amp;link=/checklists/bosses.html%23item_3_2&amp;title=Ensha of the Royal Remains">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_3_2&amp;id=bosses_3_2&amp;link=/checklists/bosses.html%23item_3_2&amp;title=Ensha of the Royal Remains"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2013,9 +1903,7 @@
         <div class="card shadow-sm mb-3" id="bosses_section_3">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#bosses_3Col" data-bs-toggle="collapse" href="#bosses_3Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#bosses_3Col" data-bs-toggle="collapse" href="#bosses_3Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Liurnia of the Lakes</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="bosses_totals_3"></span>
             </h4>
@@ -2027,9 +1915,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -2063,9 +1949,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="bosses_4_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_4_1&amp;id=bosses_4_1&amp;link=/checklists/bosses.html%23item_4_1&amp;title=Cleanrot Knight">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_4_1&amp;id=bosses_4_1&amp;link=/checklists/bosses.html%23item_4_1&amp;title=Cleanrot Knight"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2098,9 +1982,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="bosses_4_37" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_4_37&amp;id=bosses_4_37&amp;link=/checklists/bosses.html%23item_4_37&amp;title=Bloodhound Knight">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_4_37&amp;id=bosses_4_37&amp;link=/checklists/bosses.html%23item_4_37&amp;title=Bloodhound Knight"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2134,9 +2016,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="bosses_4_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_4_2&amp;id=bosses_4_2&amp;link=/checklists/bosses.html%23item_4_2&amp;title=Adan, Thief of Fire">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_4_2&amp;id=bosses_4_2&amp;link=/checklists/bosses.html%23item_4_2&amp;title=Adan, Thief of Fire"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2169,9 +2049,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="bosses_4_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_4_3&amp;id=bosses_4_3&amp;link=/checklists/bosses.html%23item_4_3&amp;title=Erdtree Burial Watchdog">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_4_3&amp;id=bosses_4_3&amp;link=/checklists/bosses.html%23item_4_3&amp;title=Erdtree Burial Watchdog"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2204,9 +2082,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="bosses_4_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_4_4&amp;id=bosses_4_4&amp;link=/checklists/bosses.html%23item_4_4&amp;title=Tibia Mariner">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_4_4&amp;id=bosses_4_4&amp;link=/checklists/bosses.html%23item_4_4&amp;title=Tibia Mariner"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2240,9 +2116,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="bosses_4_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_4_6&amp;id=bosses_4_6&amp;link=/checklists/bosses.html%23item_4_6&amp;title=Preceptor Miriam (NPC invader)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_4_6&amp;id=bosses_4_6&amp;link=/checklists/bosses.html%23item_4_6&amp;title=Preceptor Miriam (NPC invader)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2276,9 +2150,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="bosses_4_39" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_4_39&amp;id=bosses_4_39&amp;link=/checklists/bosses.html%23item_4_39&amp;title=Preceptor Miriam (NPC invader)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_4_39&amp;id=bosses_4_39&amp;link=/checklists/bosses.html%23item_4_39&amp;title=Preceptor Miriam (NPC invader)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2312,9 +2184,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="bosses_4_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_4_7&amp;id=bosses_4_7&amp;link=/checklists/bosses.html%23item_4_7&amp;title=Godskin Noble">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_4_7&amp;id=bosses_4_7&amp;link=/checklists/bosses.html%23item_4_7&amp;title=Godskin Noble"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2347,9 +2217,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="bosses_4_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_4_5&amp;id=bosses_4_5&amp;link=/checklists/bosses.html%23item_4_5&amp;title=Night's Cavalry (Night only)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_4_5&amp;id=bosses_4_5&amp;link=/checklists/bosses.html%23item_4_5&amp;title=Night's Cavalry (Night only)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2383,9 +2251,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="bosses_4_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_4_8&amp;id=bosses_4_8&amp;link=/checklists/bosses.html%23item_4_8&amp;title=Deathbird (Night only)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_4_8&amp;id=bosses_4_8&amp;link=/checklists/bosses.html%23item_4_8&amp;title=Deathbird (Night only)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2419,9 +2285,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="bosses_4_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_4_9&amp;id=bosses_4_9&amp;link=/checklists/bosses.html%23item_4_9&amp;title=Grafted Scion (Kill the Lobster first)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_4_9&amp;id=bosses_4_9&amp;link=/checklists/bosses.html%23item_4_9&amp;title=Grafted Scion (Kill the Lobster first)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2455,9 +2319,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="bosses_4_10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_4_10&amp;id=bosses_4_10&amp;link=/checklists/bosses.html%23item_4_10&amp;title=Glintstone Dragon Smarag">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_4_10&amp;id=bosses_4_10&amp;link=/checklists/bosses.html%23item_4_10&amp;title=Glintstone Dragon Smarag"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2491,9 +2353,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="bosses_4_11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_4_11&amp;id=bosses_4_11&amp;link=/checklists/bosses.html%23item_4_11&amp;title=Crystalian (Spear) &amp; Crystalian (Staff)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_4_11&amp;id=bosses_4_11&amp;link=/checklists/bosses.html%23item_4_11&amp;title=Crystalian (Spear) &amp; Crystalian (Staff)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2527,9 +2387,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="bosses_4_12" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_4_12&amp;id=bosses_4_12&amp;link=/checklists/bosses.html%23item_4_12&amp;title=Death Rite Bird (Night only)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_4_12&amp;id=bosses_4_12&amp;link=/checklists/bosses.html%23item_4_12&amp;title=Death Rite Bird (Night only)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2563,9 +2421,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="bosses_4_13" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_4_13&amp;id=bosses_4_13&amp;link=/checklists/bosses.html%23item_4_13&amp;title=Crystalian (Ringblade)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_4_13&amp;id=bosses_4_13&amp;link=/checklists/bosses.html%23item_4_13&amp;title=Crystalian (Ringblade)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2599,9 +2455,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="bosses_4_14" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_4_14&amp;id=bosses_4_14&amp;link=/checklists/bosses.html%23item_4_14&amp;title=Bell Bearing Hunter (Night only)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_4_14&amp;id=bosses_4_14&amp;link=/checklists/bosses.html%23item_4_14&amp;title=Bell Bearing Hunter (Night only)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2635,9 +2489,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="bosses_4_16" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_4_16&amp;id=bosses_4_16&amp;link=/checklists/bosses.html%23item_4_16&amp;title=Cemetery Shade">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_4_16&amp;id=bosses_4_16&amp;link=/checklists/bosses.html%23item_4_16&amp;title=Cemetery Shade"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2671,9 +2523,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="bosses_4_17" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_4_17&amp;id=bosses_4_17&amp;link=/checklists/bosses.html%23item_4_17&amp;title=Black Knife Assassin">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_4_17&amp;id=bosses_4_17&amp;link=/checklists/bosses.html%23item_4_17&amp;title=Black Knife Assassin"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2707,9 +2557,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="bosses_4_18" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_4_18&amp;id=bosses_4_18&amp;link=/checklists/bosses.html%23item_4_18&amp;title=Festering Fingerprint Vyke (NPC invader)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_4_18&amp;id=bosses_4_18&amp;link=/checklists/bosses.html%23item_4_18&amp;title=Festering Fingerprint Vyke (NPC invader)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2743,9 +2591,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="bosses_4_15" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_4_15&amp;id=bosses_4_15&amp;link=/checklists/bosses.html%23item_4_15&amp;title=Erdtree Avatar">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_4_15&amp;id=bosses_4_15&amp;link=/checklists/bosses.html%23item_4_15&amp;title=Erdtree Avatar"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2779,9 +2625,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="bosses_4_19" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_4_19&amp;id=bosses_4_19&amp;link=/checklists/bosses.html%23item_4_19&amp;title=Night's Cavalry (Night only)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_4_19&amp;id=bosses_4_19&amp;link=/checklists/bosses.html%23item_4_19&amp;title=Night's Cavalry (Night only)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2815,9 +2659,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="bosses_4_26" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_4_26&amp;id=bosses_4_26&amp;link=/checklists/bosses.html%23item_4_26&amp;title=Omenkiller (Underground, Village of the Albinaurics)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_4_26&amp;id=bosses_4_26&amp;link=/checklists/bosses.html%23item_4_26&amp;title=Omenkiller (Underground, Village of the Albinaurics)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2851,9 +2693,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="bosses_4_24" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_4_24&amp;id=bosses_4_24&amp;link=/checklists/bosses.html%23item_4_24&amp;title=Erdtree Avatar">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_4_24&amp;id=bosses_4_24&amp;link=/checklists/bosses.html%23item_4_24&amp;title=Erdtree Avatar"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2887,9 +2727,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="bosses_4_25" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_4_25&amp;id=bosses_4_25&amp;link=/checklists/bosses.html%23item_4_25&amp;title=Spirit-Caller Snail">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_4_25&amp;id=bosses_4_25&amp;link=/checklists/bosses.html%23item_4_25&amp;title=Spirit-Caller Snail"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2923,9 +2761,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="bosses_4_23" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_4_23&amp;id=bosses_4_23&amp;link=/checklists/bosses.html%23item_4_23&amp;title=Edgar, the Revenger (NPC invader)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_4_23&amp;id=bosses_4_23&amp;link=/checklists/bosses.html%23item_4_23&amp;title=Edgar, the Revenger (NPC invader)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2959,9 +2795,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="bosses_4_22" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_4_22&amp;id=bosses_4_22&amp;link=/checklists/bosses.html%23item_4_22&amp;title=Bols, Carian Knight">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_4_22&amp;id=bosses_4_22&amp;link=/checklists/bosses.html%23item_4_22&amp;title=Bols, Carian Knight"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2994,9 +2828,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="bosses_4_21" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_4_21&amp;id=bosses_4_21&amp;link=/checklists/bosses.html%23item_4_21&amp;title=Grafted Scion (via The Four Belfries in Western Liurnia)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_4_21&amp;id=bosses_4_21&amp;link=/checklists/bosses.html%23item_4_21&amp;title=Grafted Scion (via The Four Belfries in Western Liurnia)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3030,9 +2862,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="bosses_4_20" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_4_20&amp;id=bosses_4_20&amp;link=/checklists/bosses.html%23item_4_20&amp;title=Royal Revenant">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_4_20&amp;id=bosses_4_20&amp;link=/checklists/bosses.html%23item_4_20&amp;title=Royal Revenant"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3066,9 +2896,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="bosses_4_27" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_4_27&amp;id=bosses_4_27&amp;link=/checklists/bosses.html%23item_4_27&amp;title=Royal Knight Loretta">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_4_27&amp;id=bosses_4_27&amp;link=/checklists/bosses.html%23item_4_27&amp;title=Royal Knight Loretta"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3102,9 +2930,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="bosses_4_28" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_4_28&amp;id=bosses_4_28&amp;link=/checklists/bosses.html%23item_4_28&amp;title=Red Wolf">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_4_28&amp;id=bosses_4_28&amp;link=/checklists/bosses.html%23item_4_28&amp;title=Red Wolf"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3138,9 +2964,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="bosses_4_29" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_4_29&amp;id=bosses_4_29&amp;link=/checklists/bosses.html%23item_4_29&amp;title=Alabaster Lord (Onyx Lord)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_4_29&amp;id=bosses_4_29&amp;link=/checklists/bosses.html%23item_4_29&amp;title=Alabaster Lord (Onyx Lord)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3173,9 +2997,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="bosses_4_30" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_4_30&amp;id=bosses_4_30&amp;link=/checklists/bosses.html%23item_4_30&amp;title=Glintstone Dragon Adula">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_4_30&amp;id=bosses_4_30&amp;link=/checklists/bosses.html%23item_4_30&amp;title=Glintstone Dragon Adula"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3209,9 +3031,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="bosses_4_40" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_4_40&amp;id=bosses_4_40&amp;link=/checklists/bosses.html%23item_4_40&amp;title=Glintstone Dragon Adula">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_4_40&amp;id=bosses_4_40&amp;link=/checklists/bosses.html%23item_4_40&amp;title=Glintstone Dragon Adula"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3245,9 +3065,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="bosses_4_31" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_4_31&amp;id=bosses_4_31&amp;link=/checklists/bosses.html%23item_4_31&amp;title=Red Wolf">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_4_31&amp;id=bosses_4_31&amp;link=/checklists/bosses.html%23item_4_31&amp;title=Red Wolf"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3281,9 +3099,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="bosses_4_32" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_4_32&amp;id=bosses_4_32&amp;link=/checklists/bosses.html%23item_4_32&amp;title=Alecto, Black Knife Ringleader">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_4_32&amp;id=bosses_4_32&amp;link=/checklists/bosses.html%23item_4_32&amp;title=Alecto, Black Knife Ringleader"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3317,9 +3133,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="bosses_4_34" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_4_34&amp;id=bosses_4_34&amp;link=/checklists/bosses.html%23item_4_34&amp;title=Bloody Finger Ravenmount Assassin">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_4_34&amp;id=bosses_4_34&amp;link=/checklists/bosses.html%23item_4_34&amp;title=Bloody Finger Ravenmount Assassin"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3353,9 +3167,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="bosses_4_35" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_4_35&amp;id=bosses_4_35&amp;link=/checklists/bosses.html%23item_4_35&amp;title=Red Wolf of Radagon">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_4_35&amp;id=bosses_4_35&amp;link=/checklists/bosses.html%23item_4_35&amp;title=Red Wolf of Radagon"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3389,9 +3201,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="bosses_4_38" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_4_38&amp;id=bosses_4_38&amp;link=/checklists/bosses.html%23item_4_38&amp;title=Moongrum, Carian Knight">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_4_38&amp;id=bosses_4_38&amp;link=/checklists/bosses.html%23item_4_38&amp;title=Moongrum, Carian Knight"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3425,9 +3235,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="bosses_4_36" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_4_36&amp;id=bosses_4_36&amp;link=/checklists/bosses.html%23item_4_36&amp;title=Rennala, Queen of the Full Moon">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_4_36&amp;id=bosses_4_36&amp;link=/checklists/bosses.html%23item_4_36&amp;title=Rennala, Queen of the Full Moon"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3461,9 +3269,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="bosses_4_33" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_4_33&amp;id=bosses_4_33&amp;link=/checklists/bosses.html%23item_4_33&amp;title=Magma Wyrm Makar">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_4_33&amp;id=bosses_4_33&amp;link=/checklists/bosses.html%23item_4_33&amp;title=Magma Wyrm Makar"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3498,9 +3304,7 @@
         <div class="card shadow-sm mb-3" id="bosses_section_4">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#bosses_4Col" data-bs-toggle="collapse" href="#bosses_4Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#bosses_4Col" data-bs-toggle="collapse" href="#bosses_4Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Caelid</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="bosses_totals_4"></span>
             </h4>
@@ -3512,9 +3316,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -3548,9 +3350,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="bosses_5_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_5_1&amp;id=bosses_5_1&amp;link=/checklists/bosses.html%23item_5_1&amp;title=Magma Wyrm">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_5_1&amp;id=bosses_5_1&amp;link=/checklists/bosses.html%23item_5_1&amp;title=Magma Wyrm"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3583,9 +3383,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="bosses_5_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_5_2&amp;id=bosses_5_2&amp;link=/checklists/bosses.html%23item_5_2&amp;title=Putrid Avatar">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_5_2&amp;id=bosses_5_2&amp;link=/checklists/bosses.html%23item_5_2&amp;title=Putrid Avatar"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3618,9 +3416,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="bosses_5_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_5_3&amp;id=bosses_5_3&amp;link=/checklists/bosses.html%23item_5_3&amp;title=Erdtree Burial Watchdog (Sword) &amp; Erdtree Burial Watchdog (Staff)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_5_3&amp;id=bosses_5_3&amp;link=/checklists/bosses.html%23item_5_3&amp;title=Erdtree Burial Watchdog (Sword) &amp; Erdtree Burial Watchdog (Staff)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3653,9 +3449,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="bosses_5_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_5_4&amp;id=bosses_5_4&amp;link=/checklists/bosses.html%23item_5_4&amp;title=Mad Pumpkin Head (Hammer) &amp; Mad Pumpkin Head (Flail)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_5_4&amp;id=bosses_5_4&amp;link=/checklists/bosses.html%23item_5_4&amp;title=Mad Pumpkin Head (Hammer) &amp; Mad Pumpkin Head (Flail)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3688,9 +3482,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="bosses_5_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_5_5&amp;id=bosses_5_5&amp;link=/checklists/bosses.html%23item_5_5&amp;title=Knight of the Great Jar (x3) (NPC Invaders)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_5_5&amp;id=bosses_5_5&amp;link=/checklists/bosses.html%23item_5_5&amp;title=Knight of the Great Jar (x3) (NPC Invaders)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3724,9 +3516,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="bosses_5_30" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_5_30&amp;id=bosses_5_30&amp;link=/checklists/bosses.html%23item_5_30&amp;title=Lion Guardian">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_5_30&amp;id=bosses_5_30&amp;link=/checklists/bosses.html%23item_5_30&amp;title=Lion Guardian"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3760,9 +3550,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="bosses_5_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_5_6&amp;id=bosses_5_6&amp;link=/checklists/bosses.html%23item_5_6&amp;title=Frenzied Duelist">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_5_6&amp;id=bosses_5_6&amp;link=/checklists/bosses.html%23item_5_6&amp;title=Frenzied Duelist"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3796,9 +3584,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="bosses_5_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_5_7&amp;id=bosses_5_7&amp;link=/checklists/bosses.html%23item_5_7&amp;title=Decaying Ekzykes">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_5_7&amp;id=bosses_5_7&amp;link=/checklists/bosses.html%23item_5_7&amp;title=Decaying Ekzykes"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3832,9 +3618,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="bosses_5_28" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_5_28&amp;id=bosses_5_28&amp;link=/checklists/bosses.html%23item_5_28&amp;title=Cemetery Shade">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_5_28&amp;id=bosses_5_28&amp;link=/checklists/bosses.html%23item_5_28&amp;title=Cemetery Shade"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3867,9 +3651,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="bosses_5_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_5_8&amp;id=bosses_5_8&amp;link=/checklists/bosses.html%23item_5_8&amp;title=Night's Cavalry (Night only)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_5_8&amp;id=bosses_5_8&amp;link=/checklists/bosses.html%23item_5_8&amp;title=Night's Cavalry (Night only)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3903,9 +3685,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="bosses_5_31" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_5_31&amp;id=bosses_5_31&amp;link=/checklists/bosses.html%23item_5_31&amp;title=Lion Guardian">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_5_31&amp;id=bosses_5_31&amp;link=/checklists/bosses.html%23item_5_31&amp;title=Lion Guardian"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3939,9 +3719,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="bosses_5_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_5_9&amp;id=bosses_5_9&amp;link=/checklists/bosses.html%23item_5_9&amp;title=Death Rite Bird (Night only)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_5_9&amp;id=bosses_5_9&amp;link=/checklists/bosses.html%23item_5_9&amp;title=Death Rite Bird (Night only)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3975,9 +3753,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="bosses_5_10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_5_10&amp;id=bosses_5_10&amp;link=/checklists/bosses.html%23item_5_10&amp;title=Commander O'Neil">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_5_10&amp;id=bosses_5_10&amp;link=/checklists/bosses.html%23item_5_10&amp;title=Commander O'Neil"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4010,9 +3786,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="bosses_5_11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_5_11&amp;id=bosses_5_11&amp;link=/checklists/bosses.html%23item_5_11&amp;title=Milicent (NPC Invader)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_5_11&amp;id=bosses_5_11&amp;link=/checklists/bosses.html%23item_5_11&amp;title=Milicent (NPC Invader)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4046,9 +3820,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="bosses_5_12" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_5_12&amp;id=bosses_5_12&amp;link=/checklists/bosses.html%23item_5_12&amp;title=Nox Priest &amp; Nox Swordstress">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_5_12&amp;id=bosses_5_12&amp;link=/checklists/bosses.html%23item_5_12&amp;title=Nox Priest &amp; Nox Swordstress"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4082,9 +3854,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="bosses_5_32" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_5_32&amp;id=bosses_5_32&amp;link=/checklists/bosses.html%23item_5_32&amp;title=Bloodhound Knight">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_5_32&amp;id=bosses_5_32&amp;link=/checklists/bosses.html%23item_5_32&amp;title=Bloodhound Knight"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4117,9 +3887,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="bosses_5_33" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_5_33&amp;id=bosses_5_33&amp;link=/checklists/bosses.html%23item_5_33&amp;title=Pot Throwing Troll">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_5_33&amp;id=bosses_5_33&amp;link=/checklists/bosses.html%23item_5_33&amp;title=Pot Throwing Troll"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4152,9 +3920,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="bosses_5_13" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_5_13&amp;id=bosses_5_13&amp;link=/checklists/bosses.html%23item_5_13&amp;title=Fallingstar Beast">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_5_13&amp;id=bosses_5_13&amp;link=/checklists/bosses.html%23item_5_13&amp;title=Fallingstar Beast"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4187,9 +3953,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="bosses_5_14" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_5_14&amp;id=bosses_5_14&amp;link=/checklists/bosses.html%23item_5_14&amp;title=Cleanrot Knight (Sickle) &amp; Cleanrot Knight (Spear)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_5_14&amp;id=bosses_5_14&amp;link=/checklists/bosses.html%23item_5_14&amp;title=Cleanrot Knight (Sickle) &amp; Cleanrot Knight (Spear)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4222,9 +3986,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="bosses_5_15" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_5_15&amp;id=bosses_5_15&amp;link=/checklists/bosses.html%23item_5_15&amp;title=Battlemage Hugues">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_5_15&amp;id=bosses_5_15&amp;link=/checklists/bosses.html%23item_5_15&amp;title=Battlemage Hugues"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4257,9 +4019,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="bosses_5_16" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_5_16&amp;id=bosses_5_16&amp;link=/checklists/bosses.html%23item_5_16&amp;title=Elder Dragon Greyoll">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_5_16&amp;id=bosses_5_16&amp;link=/checklists/bosses.html%23item_5_16&amp;title=Elder Dragon Greyoll"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4293,9 +4053,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="bosses_5_17" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_5_17&amp;id=bosses_5_17&amp;link=/checklists/bosses.html%23item_5_17&amp;title=Putrid Crystalian (Spear, Ringblade &amp; Staff)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_5_17&amp;id=bosses_5_17&amp;link=/checklists/bosses.html%23item_5_17&amp;title=Putrid Crystalian (Spear, Ringblade &amp; Staff)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4329,9 +4087,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="bosses_5_18" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_5_18&amp;id=bosses_5_18&amp;link=/checklists/bosses.html%23item_5_18&amp;title=Godskin Apostle">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_5_18&amp;id=bosses_5_18&amp;link=/checklists/bosses.html%23item_5_18&amp;title=Godskin Apostle"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4365,9 +4121,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="bosses_5_20" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_5_20&amp;id=bosses_5_20&amp;link=/checklists/bosses.html%23item_5_20&amp;title=Putrid Avatar">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_5_20&amp;id=bosses_5_20&amp;link=/checklists/bosses.html%23item_5_20&amp;title=Putrid Avatar"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4401,9 +4155,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="bosses_5_19" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_5_19&amp;id=bosses_5_19&amp;link=/checklists/bosses.html%23item_5_19&amp;title=Bell Bearing Hunter (Night only)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_5_19&amp;id=bosses_5_19&amp;link=/checklists/bosses.html%23item_5_19&amp;title=Bell Bearing Hunter (Night only)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4437,9 +4189,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="bosses_5_21" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_5_21&amp;id=bosses_5_21&amp;link=/checklists/bosses.html%23item_5_21&amp;title=Beastman of Farum Azula (Greatsword &amp; Throwing Knife)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_5_21&amp;id=bosses_5_21&amp;link=/checklists/bosses.html%23item_5_21&amp;title=Beastman of Farum Azula (Greatsword &amp; Throwing Knife)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4472,9 +4222,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="bosses_5_35" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_5_35&amp;id=bosses_5_35&amp;link=/checklists/bosses.html%23item_5_35&amp;title=Mage Golem">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_5_35&amp;id=bosses_5_35&amp;link=/checklists/bosses.html%23item_5_35&amp;title=Mage Golem"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4507,9 +4255,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="bosses_5_23" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_5_23&amp;id=bosses_5_23&amp;link=/checklists/bosses.html%23item_5_23&amp;title=Flying Dragon Greyll">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_5_23&amp;id=bosses_5_23&amp;link=/checklists/bosses.html%23item_5_23&amp;title=Flying Dragon Greyll"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4542,9 +4288,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="bosses_5_24" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_5_24&amp;id=bosses_5_24&amp;link=/checklists/bosses.html%23item_5_24&amp;title=Black Blade Kindred">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_5_24&amp;id=bosses_5_24&amp;link=/checklists/bosses.html%23item_5_24&amp;title=Black Blade Kindred"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4577,9 +4321,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="bosses_5_25" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_5_25&amp;id=bosses_5_25&amp;link=/checklists/bosses.html%23item_5_25&amp;title=Gurranq, Beast Clergyman">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_5_25&amp;id=bosses_5_25&amp;link=/checklists/bosses.html%23item_5_25&amp;title=Gurranq, Beast Clergyman"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4613,9 +4355,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="bosses_5_22" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_5_22&amp;id=bosses_5_22&amp;link=/checklists/bosses.html%23item_5_22&amp;title=Night's Cavalry (Night only)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_5_22&amp;id=bosses_5_22&amp;link=/checklists/bosses.html%23item_5_22&amp;title=Night's Cavalry (Night only)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4649,9 +4389,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="bosses_5_34" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_5_34&amp;id=bosses_5_34&amp;link=/checklists/bosses.html%23item_5_34&amp;title=Lion Guardian (x2)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_5_34&amp;id=bosses_5_34&amp;link=/checklists/bosses.html%23item_5_34&amp;title=Lion Guardian (x2)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4684,9 +4422,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="bosses_5_26" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_5_26&amp;id=bosses_5_26&amp;link=/checklists/bosses.html%23item_5_26&amp;title=Misbegotten Warrior &amp; Crucible Knight">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_5_26&amp;id=bosses_5_26&amp;link=/checklists/bosses.html%23item_5_26&amp;title=Misbegotten Warrior &amp; Crucible Knight"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4720,9 +4456,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="bosses_5_27" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_5_27&amp;id=bosses_5_27&amp;link=/checklists/bosses.html%23item_5_27&amp;title=Starscourge Radahn">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_5_27&amp;id=bosses_5_27&amp;link=/checklists/bosses.html%23item_5_27&amp;title=Starscourge Radahn"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4756,9 +4490,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="bosses_5_29" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_5_29&amp;id=bosses_5_29&amp;link=/checklists/bosses.html%23item_5_29&amp;title=Putrid Tree Spirit">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_5_29&amp;id=bosses_5_29&amp;link=/checklists/bosses.html%23item_5_29&amp;title=Putrid Tree Spirit"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4793,9 +4525,7 @@
         <div class="card shadow-sm mb-3" id="bosses_section_5">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#bosses_5Col" data-bs-toggle="collapse" href="#bosses_5Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#bosses_5Col" data-bs-toggle="collapse" href="#bosses_5Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Altus Plateau</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="bosses_totals_5"></span>
             </h4>
@@ -4807,9 +4537,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -4843,9 +4571,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="bosses_6_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_6_1&amp;id=bosses_6_1&amp;link=/checklists/bosses.html%23item_6_1&amp;title=Godefroy the Grafted">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_6_1&amp;id=bosses_6_1&amp;link=/checklists/bosses.html%23item_6_1&amp;title=Godefroy the Grafted"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4878,9 +4604,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="bosses_7_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_7_4&amp;id=bosses_7_4&amp;link=/checklists/bosses.html%23item_7_4&amp;title=Necromancer Garris">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_7_4&amp;id=bosses_7_4&amp;link=/checklists/bosses.html%23item_7_4&amp;title=Necromancer Garris"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4914,9 +4638,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="bosses_6_17" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_6_17&amp;id=bosses_6_17&amp;link=/checklists/bosses.html%23item_6_17&amp;title=Black Knife Assassin">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_6_17&amp;id=bosses_6_17&amp;link=/checklists/bosses.html%23item_6_17&amp;title=Black Knife Assassin"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4950,9 +4672,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="bosses_7_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_7_6&amp;id=bosses_7_6&amp;link=/checklists/bosses.html%23item_7_6&amp;title=Stonedigger Troll">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_7_6&amp;id=bosses_7_6&amp;link=/checklists/bosses.html%23item_7_6&amp;title=Stonedigger Troll"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4986,9 +4706,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="bosses_6_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_6_2&amp;id=bosses_6_2&amp;link=/checklists/bosses.html%23item_6_2&amp;title=Night's Cavalry">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_6_2&amp;id=bosses_6_2&amp;link=/checklists/bosses.html%23item_6_2&amp;title=Night's Cavalry"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5022,9 +4740,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="bosses_6_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_6_3&amp;id=bosses_6_3&amp;link=/checklists/bosses.html%23item_6_3&amp;title=Demi-Human Queen Gilika">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_6_3&amp;id=bosses_6_3&amp;link=/checklists/bosses.html%23item_6_3&amp;title=Demi-Human Queen Gilika"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5058,9 +4774,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="bosses_6_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_6_4&amp;id=bosses_6_4&amp;link=/checklists/bosses.html%23item_6_4&amp;title=Eleonora, Violet Bloody Finger (NPC invader)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_6_4&amp;id=bosses_6_4&amp;link=/checklists/bosses.html%23item_6_4&amp;title=Eleonora, Violet Bloody Finger (NPC invader)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5094,9 +4808,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="bosses_6_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_6_5&amp;id=bosses_6_5&amp;link=/checklists/bosses.html%23item_6_5&amp;title=Rileigh the Idle">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_6_5&amp;id=bosses_6_5&amp;link=/checklists/bosses.html%23item_6_5&amp;title=Rileigh the Idle"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5130,9 +4842,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="bosses_6_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_6_6&amp;id=bosses_6_6&amp;link=/checklists/bosses.html%23item_6_6&amp;title=Sanguine Noble">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_6_6&amp;id=bosses_6_6&amp;link=/checklists/bosses.html%23item_6_6&amp;title=Sanguine Noble"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5166,9 +4876,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="bosses_6_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_6_7&amp;id=bosses_6_7&amp;link=/checklists/bosses.html%23item_6_7&amp;title=Wormface">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_6_7&amp;id=bosses_6_7&amp;link=/checklists/bosses.html%23item_6_7&amp;title=Wormface"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5202,9 +4910,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="bosses_6_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_6_8&amp;id=bosses_6_8&amp;link=/checklists/bosses.html%23item_6_8&amp;title=Godskin Apostle">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_6_8&amp;id=bosses_6_8&amp;link=/checklists/bosses.html%23item_6_8&amp;title=Godskin Apostle"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5237,9 +4943,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="bosses_6_19" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_6_19&amp;id=bosses_6_19&amp;link=/checklists/bosses.html%23item_6_19&amp;title=Lion Guardian">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_6_19&amp;id=bosses_6_19&amp;link=/checklists/bosses.html%23item_6_19&amp;title=Lion Guardian"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5273,9 +4977,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="bosses_6_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_6_9&amp;id=bosses_6_9&amp;link=/checklists/bosses.html%23item_6_9&amp;title=Crystalian (Spear) &amp; Crystalian (Ringblade)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_6_9&amp;id=bosses_6_9&amp;link=/checklists/bosses.html%23item_6_9&amp;title=Crystalian (Spear) &amp; Crystalian (Ringblade)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5308,9 +5010,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="bosses_6_10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_6_10&amp;id=bosses_6_10&amp;link=/checklists/bosses.html%23item_6_10&amp;title=Black Knife Assassin">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_6_10&amp;id=bosses_6_10&amp;link=/checklists/bosses.html%23item_6_10&amp;title=Black Knife Assassin"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5343,9 +5043,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="bosses_6_20" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_6_20&amp;id=bosses_6_20&amp;link=/checklists/bosses.html%23item_6_20&amp;title=Duelist (Shadow)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_6_20&amp;id=bosses_6_20&amp;link=/checklists/bosses.html%23item_6_20&amp;title=Duelist (Shadow)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5378,9 +5076,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="bosses_6_11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_6_11&amp;id=bosses_6_11&amp;link=/checklists/bosses.html%23item_6_11&amp;title=Ancient Hero of Zamor">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_6_11&amp;id=bosses_6_11&amp;link=/checklists/bosses.html%23item_6_11&amp;title=Ancient Hero of Zamor"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5413,9 +5109,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="bosses_6_18" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_6_18&amp;id=bosses_6_18&amp;link=/checklists/bosses.html%23item_6_18&amp;title=Malformed Star">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_6_18&amp;id=bosses_6_18&amp;link=/checklists/bosses.html%23item_6_18&amp;title=Malformed Star"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5449,9 +5143,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="bosses_6_12" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_6_12&amp;id=bosses_6_12&amp;link=/checklists/bosses.html%23item_6_12&amp;title=Omenkiller &amp; Miranda, the Blighted Bloom">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_6_12&amp;id=bosses_6_12&amp;link=/checklists/bosses.html%23item_6_12&amp;title=Omenkiller &amp; Miranda, the Blighted Bloom"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5484,9 +5176,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="bosses_6_13" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_6_13&amp;id=bosses_6_13&amp;link=/checklists/bosses.html%23item_6_13&amp;title=Fallingstar Beast">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_6_13&amp;id=bosses_6_13&amp;link=/checklists/bosses.html%23item_6_13&amp;title=Fallingstar Beast"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5519,9 +5209,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="bosses_6_14" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_6_14&amp;id=bosses_6_14&amp;link=/checklists/bosses.html%23item_6_14&amp;title=Ancient Dragon Lansseax (Part 2)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_6_14&amp;id=bosses_6_14&amp;link=/checklists/bosses.html%23item_6_14&amp;title=Ancient Dragon Lansseax (Part 2)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5555,9 +5243,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="bosses_6_15" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_6_15&amp;id=bosses_6_15&amp;link=/checklists/bosses.html%23item_6_15&amp;title=Tree Sentinel (x2)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_6_15&amp;id=bosses_6_15&amp;link=/checklists/bosses.html%23item_6_15&amp;title=Tree Sentinel (x2)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5591,9 +5277,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="bosses_6_16" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_6_16&amp;id=bosses_6_16&amp;link=/checklists/bosses.html%23item_6_16&amp;title=Bell Bearing Hunter">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_6_16&amp;id=bosses_6_16&amp;link=/checklists/bosses.html%23item_6_16&amp;title=Bell Bearing Hunter"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5628,9 +5312,7 @@
         <div class="card shadow-sm mb-3" id="bosses_section_6">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#bosses_6Col" data-bs-toggle="collapse" href="#bosses_6Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#bosses_6Col" data-bs-toggle="collapse" href="#bosses_6Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Mt. Gelmir</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="bosses_totals_6"></span>
             </h4>
@@ -5642,9 +5324,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -5678,9 +5358,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="bosses_7_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_7_1&amp;id=bosses_7_1&amp;link=/checklists/bosses.html%23item_7_1&amp;title=Ancient Dragon Lansseax (Part 1)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_7_1&amp;id=bosses_7_1&amp;link=/checklists/bosses.html%23item_7_1&amp;title=Ancient Dragon Lansseax (Part 1)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5714,9 +5392,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="bosses_7_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_7_2&amp;id=bosses_7_2&amp;link=/checklists/bosses.html%23item_7_2&amp;title=Perfumer Tricia &amp; Misbegotten Warrior">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_7_2&amp;id=bosses_7_2&amp;link=/checklists/bosses.html%23item_7_2&amp;title=Perfumer Tricia &amp; Misbegotten Warrior"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5750,9 +5426,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="bosses_7_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_7_3&amp;id=bosses_7_3&amp;link=/checklists/bosses.html%23item_7_3&amp;title=Tibia Mariner">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_7_3&amp;id=bosses_7_3&amp;link=/checklists/bosses.html%23item_7_3&amp;title=Tibia Mariner"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5786,9 +5460,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="bosses_7_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_7_5&amp;id=bosses_7_5&amp;link=/checklists/bosses.html%23item_7_5&amp;title=Erdtree Burial Watchdog">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_7_5&amp;id=bosses_7_5&amp;link=/checklists/bosses.html%23item_7_5&amp;title=Erdtree Burial Watchdog"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5822,9 +5494,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="bosses_7_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_7_7&amp;id=bosses_7_7&amp;link=/checklists/bosses.html%23item_7_7&amp;title=Maleigh Marais, Shaded Castle Castellan">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_7_7&amp;id=bosses_7_7&amp;link=/checklists/bosses.html%23item_7_7&amp;title=Maleigh Marais, Shaded Castle Castellan"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5858,9 +5528,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="bosses_7_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_7_8&amp;id=bosses_7_8&amp;link=/checklists/bosses.html%23item_7_8&amp;title=Elemer of the Briar">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_7_8&amp;id=bosses_7_8&amp;link=/checklists/bosses.html%23item_7_8&amp;title=Elemer of the Briar"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5894,9 +5562,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="bosses_7_10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_7_10&amp;id=bosses_7_10&amp;link=/checklists/bosses.html%23item_7_10&amp;title=Grafted Scion">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_7_10&amp;id=bosses_7_10&amp;link=/checklists/bosses.html%23item_7_10&amp;title=Grafted Scion"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5930,9 +5596,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="bosses_7_11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_7_11&amp;id=bosses_7_11&amp;link=/checklists/bosses.html%23item_7_11&amp;title=Demi-Human Queen Margot">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_7_11&amp;id=bosses_7_11&amp;link=/checklists/bosses.html%23item_7_11&amp;title=Demi-Human Queen Margot"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5966,9 +5630,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="bosses_7_12" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_7_12&amp;id=bosses_7_12&amp;link=/checklists/bosses.html%23item_7_12&amp;title=Ulcerated Tree Spirit">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_7_12&amp;id=bosses_7_12&amp;link=/checklists/bosses.html%23item_7_12&amp;title=Ulcerated Tree Spirit"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6002,9 +5664,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="bosses_7_13" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_7_13&amp;id=bosses_7_13&amp;link=/checklists/bosses.html%23item_7_13&amp;title=Kindred of Rot (x2)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_7_13&amp;id=bosses_7_13&amp;link=/checklists/bosses.html%23item_7_13&amp;title=Kindred of Rot (x2)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6037,9 +5697,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="bosses_7_14" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_7_14&amp;id=bosses_7_14&amp;link=/checklists/bosses.html%23item_7_14&amp;title=Red Wolf of the Champion">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_7_14&amp;id=bosses_7_14&amp;link=/checklists/bosses.html%23item_7_14&amp;title=Red Wolf of the Champion"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6072,9 +5730,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="bosses_7_15" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_7_15&amp;id=bosses_7_15&amp;link=/checklists/bosses.html%23item_7_15&amp;title=Full-Grown Fallingstar Beast">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_7_15&amp;id=bosses_7_15&amp;link=/checklists/bosses.html%23item_7_15&amp;title=Full-Grown Fallingstar Beast"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6108,9 +5764,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="bosses_7_17" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_7_17&amp;id=bosses_7_17&amp;link=/checklists/bosses.html%23item_7_17&amp;title=Fire Prelate">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_7_17&amp;id=bosses_7_17&amp;link=/checklists/bosses.html%23item_7_17&amp;title=Fire Prelate"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6144,9 +5798,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="bosses_7_18" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_7_18&amp;id=bosses_7_18&amp;link=/checklists/bosses.html%23item_7_18&amp;title=Magma Wyrm">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_7_18&amp;id=bosses_7_18&amp;link=/checklists/bosses.html%23item_7_18&amp;title=Magma Wyrm"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6179,9 +5831,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="bosses_7_19" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_7_19&amp;id=bosses_7_19&amp;link=/checklists/bosses.html%23item_7_19&amp;title=Demi-Human Queen Maggie">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_7_19&amp;id=bosses_7_19&amp;link=/checklists/bosses.html%23item_7_19&amp;title=Demi-Human Queen Maggie"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6214,9 +5864,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="bosses_7_27" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_7_27&amp;id=bosses_7_27&amp;link=/checklists/bosses.html%23item_7_27&amp;title=Anastasia, Tarnished-Eater">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_7_27&amp;id=bosses_7_27&amp;link=/checklists/bosses.html%23item_7_27&amp;title=Anastasia, Tarnished-Eater"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6250,9 +5898,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="bosses_7_28" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_7_28&amp;id=bosses_7_28&amp;link=/checklists/bosses.html%23item_7_28&amp;title=Omenkiller">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_7_28&amp;id=bosses_7_28&amp;link=/checklists/bosses.html%23item_7_28&amp;title=Omenkiller"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6285,9 +5931,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="bosses_7_20" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_7_20&amp;id=bosses_7_20&amp;link=/checklists/bosses.html%23item_7_20&amp;title=Abductor Virgins (x2)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_7_20&amp;id=bosses_7_20&amp;link=/checklists/bosses.html%23item_7_20&amp;title=Abductor Virgins (x2)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6321,9 +5965,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="bosses_7_21" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_7_21&amp;id=bosses_7_21&amp;link=/checklists/bosses.html%23item_7_21&amp;title=Inquisitor Ghiza">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_7_21&amp;id=bosses_7_21&amp;link=/checklists/bosses.html%23item_7_21&amp;title=Inquisitor Ghiza"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6356,9 +5998,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="bosses_7_22" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_7_22&amp;id=bosses_7_22&amp;link=/checklists/bosses.html%23item_7_22&amp;title=Magma Wyrm">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_7_22&amp;id=bosses_7_22&amp;link=/checklists/bosses.html%23item_7_22&amp;title=Magma Wyrm"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6391,9 +6031,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="bosses_7_23" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_7_23&amp;id=bosses_7_23&amp;link=/checklists/bosses.html%23item_7_23&amp;title=Godskin Noble">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_7_23&amp;id=bosses_7_23&amp;link=/checklists/bosses.html%23item_7_23&amp;title=Godskin Noble"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6427,9 +6065,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="bosses_7_25" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_7_25&amp;id=bosses_7_25&amp;link=/checklists/bosses.html%23item_7_25&amp;title=God-Devouring Serpent">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_7_25&amp;id=bosses_7_25&amp;link=/checklists/bosses.html%23item_7_25&amp;title=God-Devouring Serpent"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6462,9 +6098,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="bosses_7_26" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_7_26&amp;id=bosses_7_26&amp;link=/checklists/bosses.html%23item_7_26&amp;title=Rykard, Lord of Blasphemy">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_7_26&amp;id=bosses_7_26&amp;link=/checklists/bosses.html%23item_7_26&amp;title=Rykard, Lord of Blasphemy"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6498,9 +6132,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="bosses_7_24" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_7_24&amp;id=bosses_7_24&amp;link=/checklists/bosses.html%23item_7_24&amp;title=Tanith's Knight">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_7_24&amp;id=bosses_7_24&amp;link=/checklists/bosses.html%23item_7_24&amp;title=Tanith's Knight"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6535,9 +6167,7 @@
         <div class="card shadow-sm mb-3" id="bosses_section_7">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#bosses_7Col" data-bs-toggle="collapse" href="#bosses_7Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#bosses_7Col" data-bs-toggle="collapse" href="#bosses_7Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Leyndell, Royal Capital</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="bosses_totals_7"></span>
             </h4>
@@ -6549,9 +6179,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -6585,9 +6213,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="bosses_8_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_8_1&amp;id=bosses_8_1&amp;link=/checklists/bosses.html%23item_8_1&amp;title=Ulcerated Tree Spirit">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_8_1&amp;id=bosses_8_1&amp;link=/checklists/bosses.html%23item_8_1&amp;title=Ulcerated Tree Spirit"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6621,9 +6247,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="bosses_8_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_8_2&amp;id=bosses_8_2&amp;link=/checklists/bosses.html%23item_8_2&amp;title=Valiant Gargoyle">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_8_2&amp;id=bosses_8_2&amp;link=/checklists/bosses.html%23item_8_2&amp;title=Valiant Gargoyle"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6656,9 +6280,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="bosses_8_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_8_3&amp;id=bosses_8_3&amp;link=/checklists/bosses.html%23item_8_3&amp;title=Margit, the Fell Omen">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_8_3&amp;id=bosses_8_3&amp;link=/checklists/bosses.html%23item_8_3&amp;title=Margit, the Fell Omen"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6691,9 +6313,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="bosses_8_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_8_4&amp;id=bosses_8_4&amp;link=/checklists/bosses.html%23item_8_4&amp;title=Deathbird">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_8_4&amp;id=bosses_8_4&amp;link=/checklists/bosses.html%23item_8_4&amp;title=Deathbird"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6727,9 +6347,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="bosses_8_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_8_5&amp;id=bosses_8_5&amp;link=/checklists/bosses.html%23item_8_5&amp;title=Onyx Lord">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_8_5&amp;id=bosses_8_5&amp;link=/checklists/bosses.html%23item_8_5&amp;title=Onyx Lord"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6762,9 +6380,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="bosses_8_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_8_6&amp;id=bosses_8_6&amp;link=/checklists/bosses.html%23item_8_6&amp;title=The Loathsome Dung Eater">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_8_6&amp;id=bosses_8_6&amp;link=/checklists/bosses.html%23item_8_6&amp;title=The Loathsome Dung Eater"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6798,9 +6414,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="bosses_8_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_8_7&amp;id=bosses_8_7&amp;link=/checklists/bosses.html%23item_8_7&amp;title=Draconic Tree Sentinel">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_8_7&amp;id=bosses_8_7&amp;link=/checklists/bosses.html%23item_8_7&amp;title=Draconic Tree Sentinel"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6834,9 +6448,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="bosses_8_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_8_8&amp;id=bosses_8_8&amp;link=/checklists/bosses.html%23item_8_8&amp;title=Grave Warden Duelist">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_8_8&amp;id=bosses_8_8&amp;link=/checklists/bosses.html%23item_8_8&amp;title=Grave Warden Duelist"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6869,9 +6481,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="bosses_8_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_8_9&amp;id=bosses_8_9&amp;link=/checklists/bosses.html%23item_8_9&amp;title=Crucible Knight Ordovis &amp; Crucible Knight">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_8_9&amp;id=bosses_8_9&amp;link=/checklists/bosses.html%23item_8_9&amp;title=Crucible Knight Ordovis &amp; Crucible Knight"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6904,9 +6514,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="bosses_8_10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_8_10&amp;id=bosses_8_10&amp;link=/checklists/bosses.html%23item_8_10&amp;title=Erdtree Avatar">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_8_10&amp;id=bosses_8_10&amp;link=/checklists/bosses.html%23item_8_10&amp;title=Erdtree Avatar"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6939,9 +6547,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="bosses_8_11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_8_11&amp;id=bosses_8_11&amp;link=/checklists/bosses.html%23item_8_11&amp;title=Ulcerated Tree Spirit">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_8_11&amp;id=bosses_8_11&amp;link=/checklists/bosses.html%23item_8_11&amp;title=Ulcerated Tree Spirit"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6975,9 +6581,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="bosses_8_12" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_8_12&amp;id=bosses_8_12&amp;link=/checklists/bosses.html%23item_8_12&amp;title=Valiant Gargoyle">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_8_12&amp;id=bosses_8_12&amp;link=/checklists/bosses.html%23item_8_12&amp;title=Valiant Gargoyle"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7010,9 +6614,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="bosses_8_13" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_8_13&amp;id=bosses_8_13&amp;link=/checklists/bosses.html%23item_8_13&amp;title=Vargram the Raging Wolf &amp; Errant Sorcerer Wilhelm">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_8_13&amp;id=bosses_8_13&amp;link=/checklists/bosses.html%23item_8_13&amp;title=Vargram the Raging Wolf &amp; Errant Sorcerer Wilhelm"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7046,9 +6648,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="bosses_8_14" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_8_14&amp;id=bosses_8_14&amp;link=/checklists/bosses.html%23item_8_14&amp;title=Black Knife Assassin">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_8_14&amp;id=bosses_8_14&amp;link=/checklists/bosses.html%23item_8_14&amp;title=Black Knife Assassin"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7080,9 +6680,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="bosses_8_15" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_8_15&amp;id=bosses_8_15&amp;link=/checklists/bosses.html%23item_8_15&amp;title=Fell Twins (x2)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_8_15&amp;id=bosses_8_15&amp;link=/checklists/bosses.html%23item_8_15&amp;title=Fell Twins (x2)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7116,9 +6714,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="bosses_8_19" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_8_19&amp;id=bosses_8_19&amp;link=/checklists/bosses.html%23item_8_19&amp;title=Esgar, Priest of Blood">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_8_19&amp;id=bosses_8_19&amp;link=/checklists/bosses.html%23item_8_19&amp;title=Esgar, Priest of Blood"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7151,9 +6747,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="bosses_8_16" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_8_16&amp;id=bosses_8_16&amp;link=/checklists/bosses.html%23item_8_16&amp;title=Mohg, the Omen">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_8_16&amp;id=bosses_8_16&amp;link=/checklists/bosses.html%23item_8_16&amp;title=Mohg, the Omen"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7187,9 +6781,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="bosses_8_17" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_8_17&amp;id=bosses_8_17&amp;link=/checklists/bosses.html%23item_8_17&amp;title=Godfrey, First Elden Lord (Golden Shade)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_8_17&amp;id=bosses_8_17&amp;link=/checklists/bosses.html%23item_8_17&amp;title=Godfrey, First Elden Lord (Golden Shade)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7223,9 +6815,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="bosses_8_18" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_8_18&amp;id=bosses_8_18&amp;link=/checklists/bosses.html%23item_8_18&amp;title=Morgott, the Omen King">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_8_18&amp;id=bosses_8_18&amp;link=/checklists/bosses.html%23item_8_18&amp;title=Morgott, the Omen King"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7260,9 +6850,7 @@
         <div class="card shadow-sm mb-3" id="bosses_section_8">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#bosses_8Col" data-bs-toggle="collapse" href="#bosses_8Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#bosses_8Col" data-bs-toggle="collapse" href="#bosses_8Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Mountaintops of the Giants</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="bosses_totals_8"></span>
             </h4>
@@ -7274,9 +6862,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -7310,9 +6896,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="bosses_9_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_9_1&amp;id=bosses_9_1&amp;link=/checklists/bosses.html%23item_9_1&amp;title=Night's Cavalry">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_9_1&amp;id=bosses_9_1&amp;link=/checklists/bosses.html%23item_9_1&amp;title=Night's Cavalry"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7346,9 +6930,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="bosses_9_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_9_2&amp;id=bosses_9_2&amp;link=/checklists/bosses.html%23item_9_2&amp;title=Black Blade Kindred">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_9_2&amp;id=bosses_9_2&amp;link=/checklists/bosses.html%23item_9_2&amp;title=Black Blade Kindred"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7381,9 +6963,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="bosses_9_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_9_3&amp;id=bosses_9_3&amp;link=/checklists/bosses.html%23item_9_3&amp;title=Ancient Hero of Zamor">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_9_3&amp;id=bosses_9_3&amp;link=/checklists/bosses.html%23item_9_3&amp;title=Ancient Hero of Zamor"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7416,9 +6996,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="bosses_9_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_9_4&amp;id=bosses_9_4&amp;link=/checklists/bosses.html%23item_9_4&amp;title=Ulcerated Tree Spirit">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_9_4&amp;id=bosses_9_4&amp;link=/checklists/bosses.html%23item_9_4&amp;title=Ulcerated Tree Spirit"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7451,9 +7029,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="bosses_9_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_9_5&amp;id=bosses_9_5&amp;link=/checklists/bosses.html%23item_9_5&amp;title=Erdtree Avatar">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_9_5&amp;id=bosses_9_5&amp;link=/checklists/bosses.html%23item_9_5&amp;title=Erdtree Avatar"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7487,9 +7063,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="bosses_9_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_9_6&amp;id=bosses_9_6&amp;link=/checklists/bosses.html%23item_9_6&amp;title=Juno Hoslow, Knight of Blood">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_9_6&amp;id=bosses_9_6&amp;link=/checklists/bosses.html%23item_9_6&amp;title=Juno Hoslow, Knight of Blood"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7522,9 +7096,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="bosses_9_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_9_7&amp;id=bosses_9_7&amp;link=/checklists/bosses.html%23item_9_7&amp;title=Death Rite Bird">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_9_7&amp;id=bosses_9_7&amp;link=/checklists/bosses.html%23item_9_7&amp;title=Death Rite Bird"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7558,9 +7130,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="bosses_9_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_9_8&amp;id=bosses_9_8&amp;link=/checklists/bosses.html%23item_9_8&amp;title=Tibia Mariner">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_9_8&amp;id=bosses_9_8&amp;link=/checklists/bosses.html%23item_9_8&amp;title=Tibia Mariner"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7594,9 +7164,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="bosses_9_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_9_9&amp;id=bosses_9_9&amp;link=/checklists/bosses.html%23item_9_9&amp;title=Commander Niall">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_9_9&amp;id=bosses_9_9&amp;link=/checklists/bosses.html%23item_9_9&amp;title=Commander Niall"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7630,9 +7198,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="bosses_9_10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_9_10&amp;id=bosses_9_10&amp;link=/checklists/bosses.html%23item_9_10&amp;title=Vyke, Knight of the Roundtable">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_9_10&amp;id=bosses_9_10&amp;link=/checklists/bosses.html%23item_9_10&amp;title=Vyke, Knight of the Roundtable"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7665,9 +7231,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="bosses_9_11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_9_11&amp;id=bosses_9_11&amp;link=/checklists/bosses.html%23item_9_11&amp;title=Borealis, the Freezing Fog">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_9_11&amp;id=bosses_9_11&amp;link=/checklists/bosses.html%23item_9_11&amp;title=Borealis, the Freezing Fog"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7700,9 +7264,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="bosses_9_12" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_9_12&amp;id=bosses_9_12&amp;link=/checklists/bosses.html%23item_9_12&amp;title=Bloody Finger Okina">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_9_12&amp;id=bosses_9_12&amp;link=/checklists/bosses.html%23item_9_12&amp;title=Bloody Finger Okina"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7736,9 +7298,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="bosses_9_13" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_9_13&amp;id=bosses_9_13&amp;link=/checklists/bosses.html%23item_9_13&amp;title=Godskin Apostle and Godskin Noble (Spectral Duo)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_9_13&amp;id=bosses_9_13&amp;link=/checklists/bosses.html%23item_9_13&amp;title=Godskin Apostle and Godskin Noble (Spectral Duo)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7772,9 +7332,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="bosses_9_15" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_9_15&amp;id=bosses_9_15&amp;link=/checklists/bosses.html%23item_9_15&amp;title=Fire Giant">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_9_15&amp;id=bosses_9_15&amp;link=/checklists/bosses.html%23item_9_15&amp;title=Fire Giant"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7809,9 +7367,7 @@
         <div class="card shadow-sm mb-3" id="bosses_section_9">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#bosses_9Col" data-bs-toggle="collapse" href="#bosses_9Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#bosses_9Col" data-bs-toggle="collapse" href="#bosses_9Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Consecrated Snowfield</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="bosses_totals_9"></span>
             </h4>
@@ -7823,9 +7379,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -7859,9 +7413,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="bosses_10_13" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_10_13&amp;id=bosses_10_13&amp;link=/checklists/bosses.html%23item_10_13&amp;title=Stray Mimic Tear">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_10_13&amp;id=bosses_10_13&amp;link=/checklists/bosses.html%23item_10_13&amp;title=Stray Mimic Tear"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7895,9 +7447,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="bosses_10_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_10_1&amp;id=bosses_10_1&amp;link=/checklists/bosses.html%23item_10_1&amp;title=Putrid Grave Warden Duelist">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_10_1&amp;id=bosses_10_1&amp;link=/checklists/bosses.html%23item_10_1&amp;title=Putrid Grave Warden Duelist"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7930,9 +7480,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="bosses_10_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_10_2&amp;id=bosses_10_2&amp;link=/checklists/bosses.html%23item_10_2&amp;title=Night's Cavalry (x2)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_10_2&amp;id=bosses_10_2&amp;link=/checklists/bosses.html%23item_10_2&amp;title=Night's Cavalry (x2)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7966,9 +7514,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="bosses_10_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_10_3&amp;id=bosses_10_3&amp;link=/checklists/bosses.html%23item_10_3&amp;title=Astel, Stars of Darkness">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_10_3&amp;id=bosses_10_3&amp;link=/checklists/bosses.html%23item_10_3&amp;title=Astel, Stars of Darkness"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8001,9 +7547,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="bosses_10_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_10_4&amp;id=bosses_10_4&amp;link=/checklists/bosses.html%23item_10_4&amp;title=Sanguine Noble">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_10_4&amp;id=bosses_10_4&amp;link=/checklists/bosses.html%23item_10_4&amp;title=Sanguine Noble"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8036,9 +7580,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="bosses_10_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_10_5&amp;id=bosses_10_5&amp;link=/checklists/bosses.html%23item_10_5&amp;title=Great Wyrm Theodorix">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_10_5&amp;id=bosses_10_5&amp;link=/checklists/bosses.html%23item_10_5&amp;title=Great Wyrm Theodorix"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8071,9 +7613,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="bosses_10_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_10_6&amp;id=bosses_10_6&amp;link=/checklists/bosses.html%23item_10_6&amp;title=Misbegotten Crusader">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_10_6&amp;id=bosses_10_6&amp;link=/checklists/bosses.html%23item_10_6&amp;title=Misbegotten Crusader"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8106,9 +7646,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="bosses_10_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_10_7&amp;id=bosses_10_7&amp;link=/checklists/bosses.html%23item_10_7&amp;title=Putrid Avatar">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_10_7&amp;id=bosses_10_7&amp;link=/checklists/bosses.html%23item_10_7&amp;title=Putrid Avatar"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8142,9 +7680,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="bosses_10_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_10_8&amp;id=bosses_10_8&amp;link=/checklists/bosses.html%23item_10_8&amp;title=Death Rite Bird">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_10_8&amp;id=bosses_10_8&amp;link=/checklists/bosses.html%23item_10_8&amp;title=Death Rite Bird"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8178,9 +7714,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="bosses_10_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_10_9&amp;id=bosses_10_9&amp;link=/checklists/bosses.html%23item_10_9&amp;title=Black Knife Assassin">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_10_9&amp;id=bosses_10_9&amp;link=/checklists/bosses.html%23item_10_9&amp;title=Black Knife Assassin"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8212,9 +7746,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="bosses_10_12" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_10_12&amp;id=bosses_10_12&amp;link=/checklists/bosses.html%23item_10_12&amp;title=Anastasia, Tarnished-Eater">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_10_12&amp;id=bosses_10_12&amp;link=/checklists/bosses.html%23item_10_12&amp;title=Anastasia, Tarnished-Eater"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8248,9 +7780,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="bosses_10_10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_10_10&amp;id=bosses_10_10&amp;link=/checklists/bosses.html%23item_10_10&amp;title=Loretta, Knight of the Haligtree">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_10_10&amp;id=bosses_10_10&amp;link=/checklists/bosses.html%23item_10_10&amp;title=Loretta, Knight of the Haligtree"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8284,9 +7814,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="bosses_10_11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_10_11&amp;id=bosses_10_11&amp;link=/checklists/bosses.html%23item_10_11&amp;title=Malenia, Blade of Miquella">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_10_11&amp;id=bosses_10_11&amp;link=/checklists/bosses.html%23item_10_11&amp;title=Malenia, Blade of Miquella"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8321,9 +7849,7 @@
         <div class="card shadow-sm mb-3" id="bosses_section_10">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#bosses_10Col" data-bs-toggle="collapse" href="#bosses_10Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#bosses_10Col" data-bs-toggle="collapse" href="#bosses_10Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Crumbling Farum Azula</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="bosses_totals_10"></span>
             </h4>
@@ -8335,9 +7861,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -8371,9 +7895,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="10" id="bosses_11_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_11_1&amp;id=bosses_11_1&amp;link=/checklists/bosses.html%23item_11_1&amp;title=Wormface">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_11_1&amp;id=bosses_11_1&amp;link=/checklists/bosses.html%23item_11_1&amp;title=Wormface"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8407,9 +7929,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="10" id="bosses_11_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_11_2&amp;id=bosses_11_2&amp;link=/checklists/bosses.html%23item_11_2&amp;title=Godskin Duo (Godskin Noble &amp; Godskin Apostle)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_11_2&amp;id=bosses_11_2&amp;link=/checklists/bosses.html%23item_11_2&amp;title=Godskin Duo (Godskin Noble &amp; Godskin Apostle)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8443,9 +7963,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="10" id="bosses_11_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_11_3&amp;id=bosses_11_3&amp;link=/checklists/bosses.html%23item_11_3&amp;title=Recusant Bernahl">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_11_3&amp;id=bosses_11_3&amp;link=/checklists/bosses.html%23item_11_3&amp;title=Recusant Bernahl"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8479,9 +7997,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="10" id="bosses_11_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_11_4&amp;id=bosses_11_4&amp;link=/checklists/bosses.html%23item_11_4&amp;title=Draconic Tree Sentinel">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_11_4&amp;id=bosses_11_4&amp;link=/checklists/bosses.html%23item_11_4&amp;title=Draconic Tree Sentinel"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8515,9 +8031,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="10" id="bosses_11_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_11_5&amp;id=bosses_11_5&amp;link=/checklists/bosses.html%23item_11_5&amp;title=Dragonlord Placidusax">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_11_5&amp;id=bosses_11_5&amp;link=/checklists/bosses.html%23item_11_5&amp;title=Dragonlord Placidusax"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8551,9 +8065,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="10" id="bosses_11_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_11_6&amp;id=bosses_11_6&amp;link=/checklists/bosses.html%23item_11_6&amp;title=Maliketh, the Black Blade">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_11_6&amp;id=bosses_11_6&amp;link=/checklists/bosses.html%23item_11_6&amp;title=Maliketh, the Black Blade"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8588,9 +8100,7 @@
         <div class="card shadow-sm mb-3" id="bosses_section_11">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#bosses_11Col" data-bs-toggle="collapse" href="#bosses_11Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#bosses_11Col" data-bs-toggle="collapse" href="#bosses_11Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Leyndell, Ashen Capital</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="bosses_totals_11"></span>
             </h4>
@@ -8602,9 +8112,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -8638,9 +8146,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="11" id="bosses_12_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_12_1&amp;id=bosses_12_1&amp;link=/checklists/bosses.html%23item_12_1&amp;title=Sir Gideon Ofnir, The All-Knowing">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_12_1&amp;id=bosses_12_1&amp;link=/checklists/bosses.html%23item_12_1&amp;title=Sir Gideon Ofnir, The All-Knowing"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8674,9 +8180,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="11" id="bosses_12_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_12_2&amp;id=bosses_12_2&amp;link=/checklists/bosses.html%23item_12_2&amp;title=Godfrey, First Elden Lord (Hoarah Loux)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_12_2&amp;id=bosses_12_2&amp;link=/checklists/bosses.html%23item_12_2&amp;title=Godfrey, First Elden Lord (Hoarah Loux)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8710,9 +8214,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="11" id="bosses_12_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_12_3&amp;id=bosses_12_3&amp;link=/checklists/bosses.html%23item_12_3&amp;title=Radagon of the Golden Order">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_12_3&amp;id=bosses_12_3&amp;link=/checklists/bosses.html%23item_12_3&amp;title=Radagon of the Golden Order"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8746,9 +8248,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="11" id="bosses_12_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_12_4&amp;id=bosses_12_4&amp;link=/checklists/bosses.html%23item_12_4&amp;title=Elden Beast">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_12_4&amp;id=bosses_12_4&amp;link=/checklists/bosses.html%23item_12_4&amp;title=Elden Beast"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8783,9 +8283,7 @@
         <div class="card shadow-sm mb-3" id="bosses_section_12">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#bosses_12Col" data-bs-toggle="collapse" href="#bosses_12Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#bosses_12Col" data-bs-toggle="collapse" href="#bosses_12Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Siofra River</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="bosses_totals_12"></span>
             </h4>
@@ -8797,9 +8295,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -8833,9 +8329,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="bosses_13_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_13_1&amp;id=bosses_13_1&amp;link=/checklists/bosses.html%23item_13_1&amp;title=Dragonkin Soldier">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_13_1&amp;id=bosses_13_1&amp;link=/checklists/bosses.html%23item_13_1&amp;title=Dragonkin Soldier"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8869,9 +8363,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="bosses_13_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_13_2&amp;id=bosses_13_2&amp;link=/checklists/bosses.html%23item_13_2&amp;title=Ancestor Spirit">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_13_2&amp;id=bosses_13_2&amp;link=/checklists/bosses.html%23item_13_2&amp;title=Ancestor Spirit"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8906,9 +8398,7 @@
         <div class="card shadow-sm mb-3" id="bosses_section_13">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#bosses_13Col" data-bs-toggle="collapse" href="#bosses_13Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#bosses_13Col" data-bs-toggle="collapse" href="#bosses_13Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Nokron, Eternal City</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="bosses_totals_13"></span>
             </h4>
@@ -8920,9 +8410,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -8956,9 +8444,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="13" id="bosses_14_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_14_1&amp;id=bosses_14_1&amp;link=/checklists/bosses.html%23item_14_1&amp;title=Mimic Tear">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_14_1&amp;id=bosses_14_1&amp;link=/checklists/bosses.html%23item_14_1&amp;title=Mimic Tear"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8992,9 +8478,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="13" id="bosses_14_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_14_4&amp;id=bosses_14_4&amp;link=/checklists/bosses.html%23item_14_4&amp;title=Lesser Red Wolf Of Radagon">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_14_4&amp;id=bosses_14_4&amp;link=/checklists/bosses.html%23item_14_4&amp;title=Lesser Red Wolf Of Radagon"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -9027,9 +8511,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="13" id="bosses_14_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_14_2&amp;id=bosses_14_2&amp;link=/checklists/bosses.html%23item_14_2&amp;title=Regal Ancestor Spirit">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_14_2&amp;id=bosses_14_2&amp;link=/checklists/bosses.html%23item_14_2&amp;title=Regal Ancestor Spirit"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -9063,9 +8545,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="13" id="bosses_14_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_14_5&amp;id=bosses_14_5&amp;link=/checklists/bosses.html%23item_14_5&amp;title=Lesser Crucible Knight">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_14_5&amp;id=bosses_14_5&amp;link=/checklists/bosses.html%23item_14_5&amp;title=Lesser Crucible Knight"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -9098,9 +8578,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="13" id="bosses_14_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_14_6&amp;id=bosses_14_6&amp;link=/checklists/bosses.html%23item_14_6&amp;title=Crucible Tree Knight">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_14_6&amp;id=bosses_14_6&amp;link=/checklists/bosses.html%23item_14_6&amp;title=Crucible Tree Knight"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -9133,9 +8611,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="13" id="bosses_14_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_14_3&amp;id=bosses_14_3&amp;link=/checklists/bosses.html%23item_14_3&amp;title=Valiant Gargoyle &amp; Valiant Gargoyle (Twinblade)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_14_3&amp;id=bosses_14_3&amp;link=/checklists/bosses.html%23item_14_3&amp;title=Valiant Gargoyle &amp; Valiant Gargoyle (Twinblade)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -9170,9 +8646,7 @@
         <div class="card shadow-sm mb-3" id="bosses_section_14">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#bosses_14Col" data-bs-toggle="collapse" href="#bosses_14Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#bosses_14Col" data-bs-toggle="collapse" href="#bosses_14Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Mohgwyn Palace</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="bosses_totals_14"></span>
             </h4>
@@ -9184,9 +8658,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -9220,9 +8692,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="14" id="bosses_15_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_15_1&amp;id=bosses_15_1&amp;link=/checklists/bosses.html%23item_15_1&amp;title=Nameless White Mask (x3)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_15_1&amp;id=bosses_15_1&amp;link=/checklists/bosses.html%23item_15_1&amp;title=Nameless White Mask (x3)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -9256,9 +8726,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="14" id="bosses_15_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_15_2&amp;id=bosses_15_2&amp;link=/checklists/bosses.html%23item_15_2&amp;title=White-Faced Varré">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_15_2&amp;id=bosses_15_2&amp;link=/checklists/bosses.html%23item_15_2&amp;title=White-Faced Varré"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -9292,9 +8760,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="14" id="bosses_15_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_15_3&amp;id=bosses_15_3&amp;link=/checklists/bosses.html%23item_15_3&amp;title=Mohg, Lord of Blood">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_15_3&amp;id=bosses_15_3&amp;link=/checklists/bosses.html%23item_15_3&amp;title=Mohg, Lord of Blood"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -9329,9 +8795,7 @@
         <div class="card shadow-sm mb-3" id="bosses_section_15">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#bosses_15Col" data-bs-toggle="collapse" href="#bosses_15Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#bosses_15Col" data-bs-toggle="collapse" href="#bosses_15Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Ainsel River</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="bosses_totals_15"></span>
             </h4>
@@ -9343,9 +8807,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -9379,9 +8841,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="15" id="bosses_16_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_16_3&amp;id=bosses_16_3&amp;link=/checklists/bosses.html%23item_16_3&amp;title=Malformed Star">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_16_3&amp;id=bosses_16_3&amp;link=/checklists/bosses.html%23item_16_3&amp;title=Malformed Star"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -9414,9 +8874,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="15" id="bosses_16_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_16_1&amp;id=bosses_16_1&amp;link=/checklists/bosses.html%23item_16_1&amp;title=Dragonkin Soldier of Nokstella">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_16_1&amp;id=bosses_16_1&amp;link=/checklists/bosses.html%23item_16_1&amp;title=Dragonkin Soldier of Nokstella"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -9450,9 +8908,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="15" id="bosses_16_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_16_2&amp;id=bosses_16_2&amp;link=/checklists/bosses.html%23item_16_2&amp;title=Baleful Shadow">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_16_2&amp;id=bosses_16_2&amp;link=/checklists/bosses.html%23item_16_2&amp;title=Baleful Shadow"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -9487,9 +8943,7 @@
         <div class="card shadow-sm mb-3" id="bosses_section_16">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#bosses_16Col" data-bs-toggle="collapse" href="#bosses_16Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#bosses_16Col" data-bs-toggle="collapse" href="#bosses_16Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Lake of Rot</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="bosses_totals_16"></span>
             </h4>
@@ -9501,9 +8955,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -9537,9 +8989,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="16" id="bosses_17_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_17_1&amp;id=bosses_17_1&amp;link=/checklists/bosses.html%23item_17_1&amp;title=Dragonkin Soldier">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_17_1&amp;id=bosses_17_1&amp;link=/checklists/bosses.html%23item_17_1&amp;title=Dragonkin Soldier"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -9573,9 +9023,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="16" id="bosses_17_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_17_3&amp;id=bosses_17_3&amp;link=/checklists/bosses.html%23item_17_3&amp;title=Lesser Putrid Tree Spirit">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_17_3&amp;id=bosses_17_3&amp;link=/checklists/bosses.html%23item_17_3&amp;title=Lesser Putrid Tree Spirit"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -9609,9 +9057,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="16" id="bosses_17_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_17_2&amp;id=bosses_17_2&amp;link=/checklists/bosses.html%23item_17_2&amp;title=Astel, Naturalborn of the Void">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_17_2&amp;id=bosses_17_2&amp;link=/checklists/bosses.html%23item_17_2&amp;title=Astel, Naturalborn of the Void"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -9646,9 +9092,7 @@
         <div class="card shadow-sm mb-3" id="bosses_section_17">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#bosses_17Col" data-bs-toggle="collapse" href="#bosses_17Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#bosses_17Col" data-bs-toggle="collapse" href="#bosses_17Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Deeproot Depths</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="bosses_totals_17"></span>
             </h4>
@@ -9660,9 +9104,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -9696,9 +9138,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="17" id="bosses_18_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_18_1&amp;id=bosses_18_1&amp;link=/checklists/bosses.html%23item_18_1&amp;title=Erdtree Avatar">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_18_1&amp;id=bosses_18_1&amp;link=/checklists/bosses.html%23item_18_1&amp;title=Erdtree Avatar"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -9732,9 +9172,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="17" id="bosses_18_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=bosses_18_2&amp;id=bosses_18_2&amp;link=/checklists/bosses.html%23item_18_2&amp;title=Crucible Knight Siluria">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=bosses_18_2&amp;id=bosses_18_2&amp;link=/checklists/bosses.html%23item_18_2&amp;title=Crucible Knight Siluria"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -9768,9 +9206,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="17" id="bosses_18_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_18_3&amp;id=bosses_18_3&amp;link=/checklists/bosses.html%23item_18_3&amp;title=Fia's Champions">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_18_3&amp;id=bosses_18_3&amp;link=/checklists/bosses.html%23item_18_3&amp;title=Fia's Champions"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -9804,9 +9240,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="17" id="bosses_18_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=bosses_18_4&amp;id=bosses_18_4&amp;link=/checklists/bosses.html%23item_18_4&amp;title=Lichdragon Fortissax">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=bosses_18_4&amp;id=bosses_18_4&amp;link=/checklists/bosses.html%23item_18_4&amp;title=Lichdragon Fortissax"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">

--- a/docs/checklists/cookbooks.html
+++ b/docs/checklists/cookbooks.html
@@ -290,6 +290,16 @@
       <div class="input-group d-print-none">
         <input class="form-control my-3" id="cookbooks_search" placeholder="Start typing to filter results..." type="search">
       </div>
+      <div class="row d-print-none mb-3">
+        <div class="col-auto d-flex align-items-center gap-2">
+          <label class="mb-0" for="dlc_filter">Show:</label>
+          <select class="form-select form-select-sm" id="dlc_filter">
+            <option selected="selected" value="both">Both</option>
+            <option value="base">Base Game</option>
+            <option value="dlc">DLC</option>
+          </select>
+        </div>
+      </div>
       <div id="cookbooks_list">
         <div class="card shadow-sm mb-3" id="cookbooks_section_0">
           <div class="card-body">
@@ -301,168 +311,168 @@
             </h4>
             <div aria-expanded="true" class="collapse show" id="cookbooks_0Col">
               <ul class="list-group-flush mb-0 ps-0 ps-md-4">
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_1_1" id="item_1_1">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_1_1" id="item_1_1">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="cookbooks_1_1" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_1_1">1. Sold by Kalé in Church of Elleh</label>
                     <a class="ms-2" href="/map.html?target=cookbooks_1_1&amp;id=cookbooks_1_1&amp;link=/checklists/cookbooks.html%23item_1_1&amp;title=Nomadic Warrior's Cookbook [1]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_1_2" id="item_1_2">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_1_2" id="item_1_2">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="cookbooks_1_2" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_1_2">2. Sold by Kalé in Church of Elleh</label>
                     <a class="ms-2" href="/map.html?target=cookbooks_1_2&amp;id=cookbooks_1_2&amp;link=/checklists/cookbooks.html%23item_1_2&amp;title=Nomadic Warrior's Cookbook [2]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_1_3" id="item_1_3">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_1_3" id="item_1_3">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="cookbooks_1_3" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_1_3">3. Sold by Nomadic Merchant in north Limgrave, west of Summonwater Village</label>
                     <a class="ms-2" href="/map.html?target=cookbooks_1_3&amp;id=cookbooks_1_3&amp;link=/checklists/cookbooks.html%23item_1_3&amp;title=Nomadic Warrior's Cookbook [3]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_1_4" id="item_1_4">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_1_4" id="item_1_4">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="cookbooks_1_4" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_1_4">4. Next to giant bear by Patches teleport (open the trapped chest in Murkwater Cave, located in the river going north from the lake in Limgrave)</label>
                     <a class="ms-2" href="/map.html?target=cookbooks_1_4&amp;id=cookbooks_1_4&amp;link=/checklists/cookbooks.html%23item_1_4&amp;title=Nomadic Warrior's Cookbook [4]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_1_5" id="item_1_5">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_1_5" id="item_1_5">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="cookbooks_1_5" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_1_5">5. Sold by Nomadic Merchant Northwest of Fort Haight in the southeast section of the forest in east Limgrave</label>
                     <a class="ms-2" href="/map.html?target=cookbooks_1_5&amp;id=cookbooks_1_5&amp;link=/checklists/cookbooks.html%23item_1_5&amp;title=Nomadic Warrior's Cookbook [5]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_1_6" id="item_1_6">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_1_6" id="item_1_6">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="cookbooks_1_6" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_1_6">6. Fort Haight in the southeast section of the forest in east Limgrave, in the room under the stairs</label>
                     <a class="ms-2" href="/map.html?target=cookbooks_1_6&amp;id=cookbooks_1_6&amp;link=/checklists/cookbooks.html%23item_1_6&amp;title=Nomadic Warrior's Cookbook [6]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_1_7" id="item_1_7">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_1_7" id="item_1_7">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="cookbooks_1_7" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_1_7">7. North of Stormhill Shack at the edge of the broken bridge past the Finger Reader Crone</label>
                     <a class="ms-2" href="/map.html?target=cookbooks_1_7&amp;id=cookbooks_1_7&amp;link=/checklists/cookbooks.html%23item_1_7&amp;title=Nomadic Warrior's Cookbook [7]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_1_8" id="item_1_8">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_1_8" id="item_1_8">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="cookbooks_1_8" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_1_8">8. Tombsward Cave, southeast of Fourth Church of Marika in northwest Weeping Peninsula</label>
                     <a class="ms-2" href="/map.html?target=cookbooks_1_8&amp;id=cookbooks_1_8&amp;link=/checklists/cookbooks.html%23item_1_8&amp;title=Nomadic Warrior's Cookbook [8]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_1_9" id="item_1_9">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_1_9" id="item_1_9">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="cookbooks_1_9" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_1_9">9. Tombsward Catacombs, south of Church of the Pilgrimage in north Weeping Peninsula.</label>
                     <a class="ms-2" href="/map.html?target=cookbooks_1_9&amp;id=cookbooks_1_9&amp;link=/checklists/cookbooks.html%23item_1_9&amp;title=Nomadic Warrior's Cookbook [9]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_1_10" id="item_1_10">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_1_10" id="item_1_10">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="cookbooks_1_10" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_1_10">10. In Stormveil Castle, from Rampart Tower Grace, go through the north door and jump to the roof in the east. Keep going this way and you'll find it.</label>
                     <a class="ms-2" href="/map.html?target=cookbooks_1_10&amp;id=cookbooks_1_10&amp;link=/checklists/cookbooks.html%23item_1_10&amp;title=Nomadic Warrior's Cookbook [10]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_1_11" id="item_1_11">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_1_11" id="item_1_11">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="cookbooks_1_11" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_1_11">11. Sold by Nomadic Merchant at the Liurnia Lake Shore Grace</label>
                     <a class="ms-2" href="/map.html?target=cookbooks_1_11&amp;id=cookbooks_1_11&amp;link=/checklists/cookbooks.html%23item_1_11&amp;title=Nomadic Warrior's Cookbook [11]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_1_12" id="item_1_12">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_1_12" id="item_1_12">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="cookbooks_1_12" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_1_12">12. Rose Church, southwest of Raya Lucaria</label>
                     <a class="ms-2" href="/map.html?target=cookbooks_1_12&amp;id=cookbooks_1_12&amp;link=/checklists/cookbooks.html%23item_1_12&amp;title=Nomadic Warrior's Cookbook [12]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_1_13" id="item_1_13">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_1_13" id="item_1_13">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="cookbooks_1_13" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_1_13">13. Sold by Nomadic Merchant north of Bellum Church in northeast Liurnia of the Lakes</label>
                     <a class="ms-2" href="/map.html?target=cookbooks_1_13&amp;id=cookbooks_1_13&amp;link=/checklists/cookbooks.html%23item_1_13&amp;title=Nomadic Warrior's Cookbook [13]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_1_14" id="item_1_14">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_1_14" id="item_1_14">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="cookbooks_1_14" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_1_14">14. Smoldering Church, northeast Limgrave/northwest Caelid</label>
                     <a class="ms-2" href="/map.html?target=cookbooks_1_14&amp;id=cookbooks_1_14&amp;link=/checklists/cookbooks.html%23item_1_14&amp;title=Nomadic Warrior's Cookbook [14]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_1_15" id="item_1_15">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_1_15" id="item_1_15">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="cookbooks_1_15" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_1_15">15. Sold by Nomadic Merchant south of Caelid swamp at fork in the road.</label>
                     <a class="ms-2" href="/map.html?target=cookbooks_1_15&amp;id=cookbooks_1_15&amp;link=/checklists/cookbooks.html%23item_1_15&amp;title=Nomadic Warrior's Cookbook [15]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_1_16" id="item_1_16">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_1_16" id="item_1_16">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="cookbooks_1_16" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_1_16">16. Sold by Hermit Merchant in south/central of Ainsel River.</label>
                     <a class="ms-2" href="/map.html?target=cookbooks_1_16&amp;id=cookbooks_1_16&amp;link=/checklists/cookbooks.html%23item_1_16&amp;title=Nomadic Warrior's Cookbook [16]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_1_17" id="item_1_17">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_1_17" id="item_1_17">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="cookbooks_1_17" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_1_17">17. Sold by Abandoned Merchant in center of Siofra River on top of wooden house.</label>
                     <a class="ms-2" href="/map.html?target=cookbooks_1_17&amp;id=cookbooks_1_17&amp;link=/checklists/cookbooks.html%23item_1_17&amp;title=Nomadic Warrior's Cookbook [17]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_1_18" id="item_1_18">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_1_18" id="item_1_18">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="cookbooks_1_18" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_1_18">18. Sold by Abandoned Merchant in center of Siofra River on top of wooden house.</label>
                     <a class="ms-2" href="/map.html?target=cookbooks_1_18&amp;id=cookbooks_1_18&amp;link=/checklists/cookbooks.html%23item_1_18&amp;title=Nomadic Warrior's Cookbook [18]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_1_19" id="item_1_19">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_1_19" id="item_1_19">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="cookbooks_1_19" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_1_19">19. Woodfolk Ruins, east of the Minor Erdtree in north Altus Plateau</label>
                     <a class="ms-2" href="/map.html?target=cookbooks_1_19&amp;id=cookbooks_1_19&amp;link=/checklists/cookbooks.html%23item_1_19&amp;title=Nomadic Warrior's Cookbook [19]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_1_20" id="item_1_20">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_1_20" id="item_1_20">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="cookbooks_1_20" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_1_20">20. Sold by Nomadic Merchant in north Mt. Gelmir, northeast of Volcano Manor</label>
                     <a class="ms-2" href="/map.html?target=cookbooks_1_20&amp;id=cookbooks_1_20&amp;link=/checklists/cookbooks.html%23item_1_20&amp;title=Nomadic Warrior's Cookbook [20]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_1_21" id="item_1_21">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_1_21" id="item_1_21">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="cookbooks_1_21" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_1_21">21. Volcano Manor in the area hidden behind the Illusory Wall in one of the hallway rooms.</label>
                     <a class="ms-2" href="/map.html?target=cookbooks_1_21&amp;id=cookbooks_1_21&amp;link=/checklists/cookbooks.html%23item_1_21&amp;title=Nomadic Warrior's Cookbook [21]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_1_22" id="item_1_22">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_1_22" id="item_1_22">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="cookbooks_1_22" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_1_22">22. Chest in west Lake of Rot, west of Ainsel River underground. May require Ranni's questline.</label>
                     <a class="ms-2" href="/map.html?target=cookbooks_1_22&amp;id=cookbooks_1_22&amp;link=/checklists/cookbooks.html%23item_1_22&amp;title=Nomadic Warrior's Cookbook [22]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_1_23" id="item_1_23">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_1_23" id="item_1_23">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="cookbooks_1_23" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_1_23">23. Consecrated Snowfield, north of the first Grace. Requires Haligtree Medallion</label>
                     <a class="ms-2" href="/map.html?target=cookbooks_1_23&amp;id=cookbooks_1_23&amp;link=/checklists/cookbooks.html%23item_1_23&amp;title=Nomadic Warrior's Cookbook [23]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_1_24" id="item_1_24">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_1_24" id="item_1_24">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="cookbooks_1_24" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_1_24">24. Mohgwyn Palace on the edge of the cliffs past the swamp. Requires Haligtree Medallion or completion of White-Faced Varré's Questline.</label>
@@ -483,49 +493,49 @@
             </h4>
             <div aria-expanded="true" class="collapse show" id="cookbooks_1Col">
               <ul class="list-group-flush mb-0 ps-0 ps-md-4">
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_3_1" id="item_3_1">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_3_1" id="item_3_1">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="cookbooks_3_1" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_3_1">1. In camp northeast of north Agheel Lake Grace</label>
                     <a class="ms-2" href="/map.html?target=cookbooks_3_1&amp;id=cookbooks_3_1&amp;link=/checklists/cookbooks.html%23item_3_1&amp;title=Armorer's Cookbook [1]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_3_2" id="item_3_2">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_3_2" id="item_3_2">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="cookbooks_3_2" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_3_2">2. Sold by Nomadic Merchant by Coastal Cave in southwest Limgrave</label>
                     <a class="ms-2" href="/map.html?target=cookbooks_3_2&amp;id=cookbooks_3_2&amp;link=/checklists/cookbooks.html%23item_3_2&amp;title=Armorer's Cookbook [2]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_3_3" id="item_3_3">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_3_3" id="item_3_3">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="cookbooks_3_3" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_3_3">3. Sold by Nomadic Merchant Northwest of Fort Haight in the southeast section of the forest in east Limgrave</label>
                     <a class="ms-2" href="/map.html?target=cookbooks_3_3&amp;id=cookbooks_3_3&amp;link=/checklists/cookbooks.html%23item_3_3&amp;title=Armorer's Cookbook [3]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_3_4" id="item_3_4">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_3_4" id="item_3_4">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="cookbooks_3_4" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_3_4">4. Castle Redmane in southeast Caelid in the northwest gatehouse</label>
                     <a class="ms-2" href="/map.html?target=cookbooks_3_4&amp;id=cookbooks_3_4&amp;link=/checklists/cookbooks.html%23item_3_4&amp;title=Armorer's Cookbook [4]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_3_5" id="item_3_5">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_3_5" id="item_3_5">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="cookbooks_3_5" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_3_5">5. Castle Redmane in southeast Caelid. Follow the path going through the door in the southwest.</label>
                     <a class="ms-2" href="/map.html?target=cookbooks_3_5&amp;id=cookbooks_3_5&amp;link=/checklists/cookbooks.html%23item_3_5&amp;title=Armorer's Cookbook [5]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_3_6" id="item_3_6">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_3_6" id="item_3_6">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="cookbooks_3_6" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_3_6">6. Siofra River. west of the Siofra River Bank Grace</label>
                     <a class="ms-2" href="/map.html?target=cookbooks_3_6&amp;id=cookbooks_3_6&amp;link=/checklists/cookbooks.html%23item_3_6&amp;title=Armorer's Cookbook [6]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_3_7" id="item_3_7">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_3_7" id="item_3_7">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="cookbooks_3_7" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_3_7">7. Fort Laiedd in west Mt. Gelmir. west of Volcano Manor.</label>
@@ -546,56 +556,56 @@
             </h4>
             <div aria-expanded="true" class="collapse show" id="cookbooks_2Col">
               <ul class="list-group-flush mb-0 ps-0 ps-md-4">
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_5_1" id="item_5_1">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_5_1" id="item_5_1">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="2" id="cookbooks_5_1" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_5_1">1. In outpost south of Liurnia Lake Shore Grace</label>
                     <a class="ms-2" href="/map.html?target=cookbooks_5_1&amp;id=cookbooks_5_1&amp;link=/checklists/cookbooks.html%23item_5_1&amp;title=Glintstone Craftsman's Cookbook [1]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_5_2" id="item_5_2">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_5_2" id="item_5_2">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="2" id="cookbooks_5_2" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_5_2">2. Directly next to the Laskyar Ruins Grace in southeast Liurnia of the Lakes</label>
                     <a class="ms-2" href="/map.html?target=cookbooks_5_2&amp;id=cookbooks_5_2&amp;link=/checklists/cookbooks.html%23item_5_2&amp;title=Glintstone Craftsman's Cookbook [2]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_5_3" id="item_5_3">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_5_3" id="item_5_3">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="2" id="cookbooks_5_3" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_5_3">3. Highway Lookout Tower in east Liurnia of the Lakes, northwest of Liurnia Highway North Grace</label>
                     <a class="ms-2" href="/map.html?target=cookbooks_5_3&amp;id=cookbooks_5_3&amp;link=/checklists/cookbooks.html%23item_5_3&amp;title=Glintstone Craftsman's Cookbook [3]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_5_4" id="item_5_4">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_5_4" id="item_5_4">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="2" id="cookbooks_5_4" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_5_4">4. Academy Gate Town southeast of Raya Lucaria Academy. It's in a chest northwest of the Grace.</label>
                     <a class="ms-2" href="/map.html?target=cookbooks_5_4&amp;id=cookbooks_5_4&amp;link=/checklists/cookbooks.html%23item_5_4&amp;title=Glintstone Craftsman's Cookbook [4]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_5_5" id="item_5_5">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_5_5" id="item_5_5">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="2" id="cookbooks_5_5" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_5_5">5. Academy of Raya Lucaria in a chest past the Schoolhouse Classroom Grace</label>
                     <a class="ms-2" href="/map.html?target=cookbooks_5_5&amp;id=cookbooks_5_5&amp;link=/checklists/cookbooks.html%23item_5_5&amp;title=Glintstone Craftsman's Cookbook [5]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_5_6" id="item_5_6">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_5_6" id="item_5_6">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="2" id="cookbooks_5_6" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_5_6">6. Caria Manor in a room southeast of the courtyard.</label>
                     <a class="ms-2" href="/map.html?target=cookbooks_5_6&amp;id=cookbooks_5_6&amp;link=/checklists/cookbooks.html%23item_5_6&amp;title=Glintstone Craftsman's Cookbook [6]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_5_7" id="item_5_7">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_5_7" id="item_5_7">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="2" id="cookbooks_5_7" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_5_7">7. Sold by Pidia in Caria Manor. Complete Caria Manor then go to Seluvis's Rise west of it and then go east and drop onto the rampart from the cliff.</label>
                     <a class="ms-2" href="/map.html?target=cookbooks_5_7&amp;id=cookbooks_5_7&amp;link=/checklists/cookbooks.html%23item_5_7&amp;title=Glintstone Craftsman's Cookbook [7]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_5_8" id="item_5_8">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_5_8" id="item_5_8">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="2" id="cookbooks_5_8" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_5_8">8. Southwest of Albinaurics Rise in east Consecrated Snowfield. Requires Haligtree Medallion.</label>
@@ -616,49 +626,49 @@
             </h4>
             <div aria-expanded="true" class="collapse show" id="cookbooks_3Col">
               <ul class="list-group-flush mb-0 ps-0 ps-md-4">
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_2_1" id="item_2_1">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_2_1" id="item_2_1">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="cookbooks_2_1" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_2_1">1. Sold by Kalé in Church of Elleh</label>
                     <a class="ms-2" href="/map.html?target=cookbooks_2_1&amp;id=cookbooks_2_1&amp;link=/checklists/cookbooks.html%23item_2_1&amp;title=Missionary's Cookbook [1]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_2_2" id="item_2_2">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_2_2" id="item_2_2">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="cookbooks_2_2" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_2_2">2. Sold by Patches in Murkwater Cave located in the river going north from the lake in Limgrave.</label>
                     <a class="ms-2" href="/map.html?target=cookbooks_2_2&amp;id=cookbooks_2_2&amp;link=/checklists/cookbooks.html%23item_2_2&amp;title=Missionary's Cookbook [2]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_2_3" id="item_2_3">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_2_3" id="item_2_3">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="cookbooks_2_3" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_2_3">3. Smoldering Church in northeast Limgrave/northwest Caelid</label>
                     <a class="ms-2" href="/map.html?target=cookbooks_2_3&amp;id=cookbooks_2_3&amp;link=/checklists/cookbooks.html%23item_2_3&amp;title=Missionary's Cookbook [3]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_2_4" id="item_2_4">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_2_4" id="item_2_4">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="cookbooks_2_4" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_2_4">4. Minor Erdtree Church in southwest Capital Outskirts.</label>
                     <a class="ms-2" href="/map.html?target=cookbooks_2_4&amp;id=cookbooks_2_4&amp;link=/checklists/cookbooks.html%23item_2_4&amp;title=Missionary's Cookbook [4]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_2_5" id="item_2_5">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_2_5" id="item_2_5">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="cookbooks_2_5" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_2_5">5. Siofra Aqueduct (accessed from Nokron), northeast of the Aqueduct-Facing Cliffs Grace. Drop onto the beam and into the room at the end, then exit to the west. It's in the room past the bridge with a Crucible Knight.</label>
                     <a class="ms-2" href="/map.html?target=cookbooks_2_5&amp;id=cookbooks_2_5&amp;link=/checklists/cookbooks.html%23item_2_5&amp;title=Missionary's Cookbook [5]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_2_6" id="item_2_6">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_2_6" id="item_2_6">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="cookbooks_2_6" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_2_6">6. Volcano Manor, from Temple of Eiglay Grace, go up the elevator and hop down into the lava. Go through the window guarded by an Iron Maiden, down a ladder, and down the stairs. It's in a small cell in the room at the bottom.</label>
                     <a class="ms-2" href="/map.html?target=cookbooks_2_6&amp;id=cookbooks_2_6&amp;link=/checklists/cookbooks.html%23item_2_6&amp;title=Missionary's Cookbook [6]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_2_7" id="item_2_7">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_2_7" id="item_2_7">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="cookbooks_2_7" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_2_7">7. Sold by Hermit Merchant in Mountaintops of the Giants, near the Ancient Snow Valley Ruins Grace.</label>
@@ -679,28 +689,28 @@
             </h4>
             <div aria-expanded="true" class="collapse show" id="cookbooks_4Col">
               <ul class="list-group-flush mb-0 ps-0 ps-md-4">
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_8_1" id="item_8_1">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_8_1" id="item_8_1">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="4" id="cookbooks_8_1" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_8_1">1. Wyndham Catacombs in west Altus Plateau. southeast of Volcano Manor. Under the spike trap, guarded by giant crabs</label>
                     <a class="ms-2" href="/map.html?target=cookbooks_8_1&amp;id=cookbooks_8_1&amp;link=/checklists/cookbooks.html%23item_8_1&amp;title=Ancient Dragon Apostle's Cookbook [1]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_8_2" id="item_8_2">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_8_2" id="item_8_2">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="4" id="cookbooks_8_2" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_8_2">2. Sold by Nomadic Merchant just north of the Forest-Spanning Greatbridge Grace on the south side of the broken bridge in north/central Altus Plateau.</label>
                     <a class="ms-2" href="/map.html?target=cookbooks_8_2&amp;id=cookbooks_8_2&amp;link=/checklists/cookbooks.html%23item_8_2&amp;title=Ancient Dragon Apostle's Cookbook [2]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_8_3" id="item_8_3">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_8_3" id="item_8_3">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="4" id="cookbooks_8_3" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_8_3">3. Cathedral of Dragon Communion in south Caelid, west of Castle Redmane.</label>
                     <a class="ms-2" href="/map.html?target=cookbooks_8_3&amp;id=cookbooks_8_3&amp;link=/checklists/cookbooks.html%23item_8_3&amp;title=Ancient Dragon Apostle's Cookbook [3]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_8_4" id="item_8_4">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_8_4" id="item_8_4">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="4" id="cookbooks_8_4" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_8_4">4. Crumbling Farum Azula on a roof in the southwest section past a dragon.</label>
@@ -721,28 +731,28 @@
             </h4>
             <div aria-expanded="true" class="collapse show" id="cookbooks_5Col">
               <ul class="list-group-flush mb-0 ps-0 ps-md-4">
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_7_1" id="item_7_1">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_7_1" id="item_7_1">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="cookbooks_7_1" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_7_1">1. Perfumer's Ruins, northwest of Abandoned Coffin Grace in Altus Plateau, found by going through the "Coward's" path past the Magma Wyrm.</label>
                     <a class="ms-2" href="/map.html?target=cookbooks_7_1&amp;id=cookbooks_7_1&amp;link=/checklists/cookbooks.html%23item_7_1&amp;title=Perfumer's Cookbook [1]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_7_2" id="item_7_2">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_7_2" id="item_7_2">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="cookbooks_7_2" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_7_2">2. Rooftops of Shaded Castle in north Altus Plateau</label>
                     <a class="ms-2" href="/map.html?target=cookbooks_7_2&amp;id=cookbooks_7_2&amp;link=/checklists/cookbooks.html%23item_7_2&amp;title=Perfumer's Cookbook [2]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_7_3" id="item_7_3">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_7_3" id="item_7_3">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="cookbooks_7_3" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_7_3">3. Auriza Side Tomb northeast of Leyndell. Open the chest in the room with a lot of benches.</label>
                     <a class="ms-2" href="/map.html?target=cookbooks_7_3&amp;id=cookbooks_7_3&amp;link=/checklists/cookbooks.html%23item_7_3&amp;title=Perfumer's Cookbook [3]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_7_4" id="item_7_4">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_7_4" id="item_7_4">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="cookbooks_7_4" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_7_4">4. Sold by Hermit Merchant in south/central Ainsel River</label>
@@ -763,21 +773,21 @@
             </h4>
             <div aria-expanded="true" class="collapse show" id="cookbooks_6Col">
               <ul class="list-group-flush mb-0 ps-0 ps-md-4">
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_4_1" id="item_4_1">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_4_1" id="item_4_1">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="cookbooks_4_1" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_4_1">1. On a stone tomb south of Summonwater Village in northeast Limgrave</label>
                     <a class="ms-2" href="/map.html?target=cookbooks_4_1&amp;id=cookbooks_4_1&amp;link=/checklists/cookbooks.html%23item_4_1&amp;title=Fevor's Cookbook [1]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_4_2" id="item_4_2">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_4_2" id="item_4_2">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="cookbooks_4_2" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_4_2">2. Sold by Isolated Merchant east of Main Academy Gate Grace. Requires Glintstone Key gotten next to the Dragon west of Raya Lucaria.</label>
                     <a class="ms-2" href="/map.html?target=cookbooks_4_2&amp;id=cookbooks_4_2&amp;link=/checklists/cookbooks.html%23item_4_2&amp;title=Fevor's Cookbook [2]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_4_3" id="item_4_3">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_4_3" id="item_4_3">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="cookbooks_4_3" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_4_3">3. Reward from Gideon Ofnir for information on Mohgwyn Dynasty Medallion. Requires either Haligtree Medallion or finishing White-Faced Varré's Questline.</label>
@@ -798,14 +808,14 @@
             </h4>
             <div aria-expanded="true" class="collapse show" id="cookbooks_7Col">
               <ul class="list-group-flush mb-0 ps-0 ps-md-4">
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_6_1" id="item_6_1">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_6_1" id="item_6_1">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="7" id="cookbooks_6_1" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_6_1">1. Frenzied Flame Village in northeast Liurnia of the Lakes</label>
                     <a class="ms-2" href="/map.html?target=cookbooks_6_1&amp;id=cookbooks_6_1&amp;link=/checklists/cookbooks.html%23item_6_1&amp;title=Frenzied's Cookbook [1]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_6_2" id="item_6_2">
+                <li class="list-group-item searchable ps-0" data-dlc="false" data-id="cookbooks_6_2" id="item_6_2">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="7" id="cookbooks_6_2" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_6_2">2. On the path down to the Frenzied Flame.</label>
@@ -826,43 +836,43 @@
             </h4>
             <div aria-expanded="true" class="collapse show" id="cookbooks_8Col">
               <ul class="list-group-flush mb-0 ps-0 ps-md-4">
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_10_1" id="item_10_1">
+                <li class="list-group-item searchable ps-0" data-dlc="true" data-id="cookbooks_10_1" id="item_10_1">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="8" id="cookbooks_10_1" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_10_1">1. Acquired from a pest who hands it to you if you interact with him just west of Ruined Forge of Starfall Past along the cliffside.<br><strong><span style="color: #ff0000;">NOTE:</span> </strong>You can lock yourself out of the Forager Brood Cookbooks if Moore dies during his questline, and will not be able to pick them up anymore.</label>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_10_2" id="item_10_2">
+                <li class="list-group-item searchable ps-0" data-dlc="true" data-id="cookbooks_10_2" id="item_10_2">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="8" id="cookbooks_10_2" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_10_2">2. Given by a Non-hostile Servant of Rot. From the pond located to the east of the Cliffroad Terminus Site of Grace, exactly all the way south on the map. It may require certain well-timed jumps from Torrent.<br><strong><span style="color: #ff0000;">NOTE:</span> </strong>You can lock yourself out of the Forager Brood Cookbooks if Moore dies during his questline, and will not be able to pick them up anymore.</label>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_10_3" id="item_10_3">
+                <li class="list-group-item searchable ps-0" data-dlc="true" data-id="cookbooks_10_3" id="item_10_3">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="8" id="cookbooks_10_3" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_10_3">3. Acquired from a pest who hands it to you if you interact with it at the north-east corner of the forest of lightning rams near the Furnace Golem on the Ellac River. Closest Site of Grace is Cerulean Coast.<br><strong><span style="color: #ff0000;">NOTE:</span> </strong>You can lock yourself out of the Forager Brood Cookbooks if Moore dies during his questline, and will not be able to pick them up anymore.</label>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_10_4" id="item_10_4">
+                <li class="list-group-item searchable ps-0" data-dlc="true" data-id="cookbooks_10_4" id="item_10_4">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="8" id="cookbooks_10_4" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_10_4">4. Acquired by interacting with a pest found north of Church of the Crusade. The pest will be found shivering and unresponsive. Use a Warming Stone or Sunwarmth Stone to warm it up, and reload the area by teleporting or logging out. It can now be interacted with and will grant the cookbook.<br><strong><span style="color: #ff0000;">NOTE:</span> </strong>You can lock yourself out of the Forager Brood Cookbooks if Moore dies during his questline, and will not be able to pick them up anymore.</label>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_10_5" id="item_10_5">
+                <li class="list-group-item searchable ps-0" data-dlc="true" data-id="cookbooks_10_5" id="item_10_5">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="8" id="cookbooks_10_5" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_10_5">5. Acquired by interacting with the pest found along the right cliff edge in the Deathbird-infested poisonous swamp north of Moorth ruins. The swamp can be reached by going through the cave with the Miranda flowers and Perfumers.<br><strong><span style="color: #ff0000;">NOTE:</span> </strong>You can lock yourself out of the Forager Brood Cookbooks if Moore dies during his questline, and will not be able to pick them up anymore.</label>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_10_6" id="item_10_6">
+                <li class="list-group-item searchable ps-0" data-dlc="true" data-id="cookbooks_10_6" id="item_10_6">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="8" id="cookbooks_10_6" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_10_6">6. Acquired by interacting with the pest found east outside of the Shadow Keep. It can be accessed from the Church District Highroad site of grace and traveling West up the cliff above the tunnel road, then continuing West to the outer wall of the keep.<br><br><strong><span style="color: #ff0000;">NOTE:</span> </strong>You can lock yourself out of the Forager Brood Cookbooks if Moore dies during his questline, and will not be able to pick them up anymore.</label>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_10_7" id="item_10_7">
+                <li class="list-group-item searchable ps-0" data-dlc="true" data-id="cookbooks_10_7" id="item_10_7">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="8" id="cookbooks_10_7" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_10_7">7. Acquired by selecting the option "Talk to Moore" when speaking with Moore. Requires having all of the other Forager Brood Cookbooks.<br><span style="color: #ff0000;">NOTE:</span><strong> </strong>You can lock yourself out of the Forager Brood Cookbooks if Moore dies during his questline, and will not be able to pick them up anymore.</label>
@@ -882,13 +892,13 @@
             </h4>
             <div aria-expanded="true" class="collapse show" id="cookbooks_9Col">
               <ul class="list-group-flush mb-0 ps-0 ps-md-4">
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_11_1" id="item_11_1">
+                <li class="list-group-item searchable ps-0" data-dlc="true" data-id="cookbooks_11_1" id="item_11_1">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="9" id="cookbooks_11_1" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_11_1">1. Can be found on a corpse in the broken tower just before the Grand Altar of Dragon Communion.</label>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_11_2" id="item_11_2">
+                <li class="list-group-item searchable ps-0" data-dlc="true" data-id="cookbooks_11_2" id="item_11_2">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="9" id="cookbooks_11_2" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_11_2">2. Can be found at the edge of a cliff near the Jagged Peak Mountainside site of grace.</label>
@@ -908,13 +918,13 @@
             </h4>
             <div aria-expanded="true" class="collapse show" id="cookbooks_10Col">
               <ul class="list-group-flush mb-0 ps-0 ps-md-4">
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_12_1" id="item_12_1">
+                <li class="list-group-item searchable ps-0" data-dlc="true" data-id="cookbooks_12_1" id="item_12_1">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="10" id="cookbooks_12_1" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_12_1">1. Found at Finger-Weaver's Hovel. Accessible via Finger Ruins of Rhia following the path to the left and heading straight underneath the Grand Altar of Dragon Communion.</label>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_12_2" id="item_12_2">
+                <li class="list-group-item searchable ps-0" data-dlc="true" data-id="cookbooks_12_2" id="item_12_2">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="10" id="cookbooks_12_2" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_12_2">2. Found on a corpse before the bell in Finger Ruins of Miyr. Only accessible after progressing Ymir's questline and finding the secret path under the Catherdal.</label>
@@ -934,85 +944,85 @@
             </h4>
             <div aria-expanded="true" class="collapse show" id="cookbooks_11Col">
               <ul class="list-group-flush mb-0 ps-0 ps-md-4">
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_13_1" id="item_13_1">
+                <li class="list-group-item searchable ps-0" data-dlc="true" data-id="cookbooks_13_1" id="item_13_1">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="11" id="cookbooks_13_1" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_13_1">1. Scorched Ruins: From the Hefty Cracked Pot, just head right until a set of stairs is on your left. Take them and continue forward to find the cookbook.</label>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_13_2" id="item_13_2">
+                <li class="list-group-item searchable ps-0" data-dlc="true" data-id="cookbooks_13_2" id="item_13_2">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="11" id="cookbooks_13_2" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_13_2">2. Looted from a body that's inside the Run-Down Traveler's Rest location.</label>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_13_3" id="item_13_3">
+                <li class="list-group-item searchable ps-0" data-dlc="true" data-id="cookbooks_13_3" id="item_13_3">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="11" id="cookbooks_13_3" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_13_3">3. Across the wooden bridge heading west from Fog Rift Fort, just after the first small tower.</label>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_13_4" id="item_13_4">
+                <li class="list-group-item searchable ps-0" data-dlc="true" data-id="cookbooks_13_4" id="item_13_4">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="11" id="cookbooks_13_4" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_13_4">4. East of Cathedral of Manu Metyr. Can be found on a corpse sitting on the ground, surrounded by multiple Marionette Soldiers.</label>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_13_5" id="item_13_5">
+                <li class="list-group-item searchable ps-0" data-dlc="true" data-id="cookbooks_13_5" id="item_13_5">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="11" id="cookbooks_13_5" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_13_5">5. Found in the forest area, there are two thunder cows in the area. From Prospect Town, just follow the cliff south to find it.</label>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_13_6" id="item_13_6">
+                <li class="list-group-item searchable ps-0" data-dlc="true" data-id="cookbooks_13_6" id="item_13_6">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="11" id="cookbooks_13_6" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_13_6">6. Found on a cliff edge corpse north of the spiritspring used to launch up towards the Foot of the Jagged Peak grace.</label>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_13_7" id="item_13_7">
+                <li class="list-group-item searchable ps-0" data-dlc="true" data-id="cookbooks_13_7" id="item_13_7">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="11" id="cookbooks_13_7" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_13_7">7. Found in the swamp area, on the east side of the area where the Bloodfiends and Messmer soldiers are fighting. A Giant Poison Miranda Sprout and several smaller ones protect it. It allows you to create a Hefty Poison Pot.</label>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_13_8" id="item_13_8">
+                <li class="list-group-item searchable ps-0" data-dlc="true" data-id="cookbooks_13_8" id="item_13_8">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="11" id="cookbooks_13_8" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_13_8">8. Rauh Base: From the Ravine North site of grace, follow the river west to the west-most area near a water-logged cemetery. The orange side of the river will have a large green mound  full of Horn-Strewn Excrement; The Cookbook will be on top of the mound.</label>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_13_9" id="item_13_9">
+                <li class="list-group-item searchable ps-0" data-dlc="true" data-id="cookbooks_13_9" id="item_13_9">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="11" id="cookbooks_13_9" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_13_9">9. After getting past the scarlet rot swamp area, head outside and you'll find this item on a corpse near the wall.</label>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_13_10" id="item_13_10">
+                <li class="list-group-item searchable ps-0" data-dlc="true" data-id="cookbooks_13_10" id="item_13_10">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="11" id="cookbooks_13_10" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_13_10">10. The item is looted from a body that is inside a dilapidated building. You can use your mount to jump onto the roof where you'll find a hole that you can jump through.</label>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_13_11" id="item_13_11">
+                <li class="list-group-item searchable ps-0" data-dlc="true" data-id="cookbooks_13_11" id="item_13_11">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="11" id="cookbooks_13_11" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_13_11">11. Belurat Gaol: Found within the jar labyrinth.</label>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_13_12" id="item_13_12">
+                <li class="list-group-item searchable ps-0" data-dlc="true" data-id="cookbooks_13_12" id="item_13_12">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="11" id="cookbooks_13_12" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_13_12">12. To find the book, descend from the top of the waterfall using the rocks as steps. The book can be looted from a corpse leaning on one of the elevated rocks.</label>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_13_13" id="item_13_13">
+                <li class="list-group-item searchable ps-0" data-dlc="true" data-id="cookbooks_13_13" id="item_13_13">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="11" id="cookbooks_13_13" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_13_13">13. Ruined Forge Lava Intake. Take the first ladder down, and go up the set of stairs on the right, you will find it on a body near the back wall. This cookbook allows you to craft a Hefty Volcano Pot.</label>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_13_14" id="item_13_14">
+                <li class="list-group-item searchable ps-0" data-dlc="true" data-id="cookbooks_13_14" id="item_13_14">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="11" id="cookbooks_13_14" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_13_14">14. Going through the north-west path from the Charo's Hidden Grave grace, hug the water to the left until you stumble upon a corpse holding the cookbook, guarded by a large poison Miranda Flower and several smaller Miranda Flowers.</label>
@@ -1032,13 +1042,13 @@
             </h4>
             <div aria-expanded="true" class="collapse show" id="cookbooks_12Col">
               <ul class="list-group-flush mb-0 ps-0 ps-md-4">
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_14_1" id="item_14_1">
+                <li class="list-group-item searchable ps-0" data-dlc="true" data-id="cookbooks_14_1" id="item_14_1">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="12" id="cookbooks_14_1" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_14_1">1. Fog Rift Catacombs. After the room with the sorcerer, the path opens up. Take the right side first, fight the two goblins and grab this item from the ground.</label>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_14_2" id="item_14_2">
+                <li class="list-group-item searchable ps-0" data-dlc="true" data-id="cookbooks_14_2" id="item_14_2">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="12" id="cookbooks_14_2" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_14_2">2. Found in a chest in <strong>Scorpion River Catacombs</strong>. Right after the room with the annoying elevated sorcerer and two imps, you'll come across a bridge patrolled by more death eyes. You can drop off the side onto a path which eventually leads to the chest for this.</label>
@@ -1058,19 +1068,19 @@
             </h4>
             <div aria-expanded="true" class="collapse show" id="cookbooks_13Col">
               <ul class="list-group-flush mb-0 ps-0 ps-md-4">
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_15_1" id="item_15_1">
+                <li class="list-group-item searchable ps-0" data-dlc="true" data-id="cookbooks_15_1" id="item_15_1">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="13" id="cookbooks_15_1" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_15_1">1. Abyssal Woods: West from the Divided Falls Site of Grace, up the rocks that lead to the waterfall.</label>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_15_2" id="item_15_2">
+                <li class="list-group-item searchable ps-0" data-dlc="true" data-id="cookbooks_15_2" id="item_15_2">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="13" id="cookbooks_15_2" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_15_2">2. Abyssal Woods: Found on a corpse among large roots in the upper areas in the middle portion of the map. Access by going west and climbing up. [Elden Ring Map]</label>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_15_3" id="item_15_3">
+                <li class="list-group-item searchable ps-0" data-dlc="true" data-id="cookbooks_15_3" id="item_15_3">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="13" id="cookbooks_15_3" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_15_3">3. Found in Midra's Manse, just before the second site of grace. Walk across the rafters and jump into a room filled with frenzy rats. The cookbook is found on a body in that room.</label>
@@ -1090,19 +1100,19 @@
             </h4>
             <div aria-expanded="true" class="collapse show" id="cookbooks_14Col">
               <ul class="list-group-flush mb-0 ps-0 ps-md-4">
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_16_1" id="item_16_1">
+                <li class="list-group-item searchable ps-0" data-dlc="true" data-id="cookbooks_16_1" id="item_16_1">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="14" id="cookbooks_16_1" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_16_1">1. Cerulean Coast: From the Cerulean Coast Cross site of grace, head north, across a coffin ship, and while mounted, double jump to the hill with a large wilted tree being guarded by a Cemetery Shade. There will be a sitting corpse under the tree, which holds the Cookbook.</label>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_16_2" id="item_16_2">
+                <li class="list-group-item searchable ps-0" data-dlc="true" data-id="cookbooks_16_2" id="item_16_2">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="14" id="cookbooks_16_2" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_16_2">2. From Cerulean Coast Cross follow the path south until the very end to the highest cliff of the mountain.</label>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_16_3" id="item_16_3">
+                <li class="list-group-item searchable ps-0" data-dlc="true" data-id="cookbooks_16_3" id="item_16_3">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="14" id="cookbooks_16_3" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_16_3">3. Found in the Garden of Deep Purple after defeating the Putrescent Knight. The cookbook is inside the small cave nearby.</label>
@@ -1122,13 +1132,13 @@
             </h4>
             <div aria-expanded="true" class="collapse show" id="cookbooks_15Col">
               <ul class="list-group-flush mb-0 ps-0 ps-md-4">
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_17_1" id="item_17_1">
+                <li class="list-group-item searchable ps-0" data-dlc="true" data-id="cookbooks_17_1" id="item_17_1">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="15" id="cookbooks_17_1" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_17_1">1. East of the Highroad Cross Site of Grace, there is a messmer soldiers encampment. On one of the tents you can find this item.</label>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_17_2" id="item_17_2">
+                <li class="list-group-item searchable ps-0" data-dlc="true" data-id="cookbooks_17_2" id="item_17_2">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="15" id="cookbooks_17_2" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_17_2">2. In the soldier camp past Ellac Greatbridge, found inside one of the tents. Beware of the black knight in the area.</label>
@@ -1148,7 +1158,7 @@
             </h4>
             <div aria-expanded="true" class="collapse show" id="cookbooks_16Col">
               <ul class="list-group-flush mb-0 ps-0 ps-md-4">
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_18_1" id="item_18_1">
+                <li class="list-group-item searchable ps-0" data-dlc="true" data-id="cookbooks_18_1" id="item_18_1">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="16" id="cookbooks_18_1" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_18_1">The Loyal Knight's Cookbook can be found inside a chest. The chest is located inside an armory room.</label>
@@ -1168,25 +1178,25 @@
             </h4>
             <div aria-expanded="true" class="collapse show" id="cookbooks_17Col">
               <ul class="list-group-flush mb-0 ps-0 ps-md-4">
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_19_1" id="item_19_1">
+                <li class="list-group-item searchable ps-0" data-dlc="true" data-id="cookbooks_19_1" id="item_19_1">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="17" id="cookbooks_19_1" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_19_1">1. Shadow Keep. Facing the Queen Marika's statue from the front, take the right room and continue towards the stairs, to reach the upper level in which this cookbook can be found.</label>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_19_2" id="item_19_2">
+                <li class="list-group-item searchable ps-0" data-dlc="true" data-id="cookbooks_19_2" id="item_19_2">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="17" id="cookbooks_19_2" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_19_2">2. Fort Reprimand. Take the stairs up after defeating Black Knight Edreed. It is inside the chest at the top.</label>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_19_3" id="item_19_3">
+                <li class="list-group-item searchable ps-0" data-dlc="true" data-id="cookbooks_19_3" id="item_19_3">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="17" id="cookbooks_19_3" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_19_3">3. The item can be looted from a corpse, located inside an army tent.</label>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_19_4" id="item_19_4">
+                <li class="list-group-item searchable ps-0" data-dlc="true" data-id="cookbooks_19_4" id="item_19_4">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="17" id="cookbooks_19_4" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_19_4">4. Shadow Keep: Take the left lift down from the Storehouse, first floor site of grace. take the first exit to the right and continue forwad until the end of thehallway. Kill the enemy, and take the left route, hit the wall to reveal a path. The Battlefield Priest's Cookbook 4] is on a corpse, after the revealed hidden door.</label>
@@ -1206,13 +1216,13 @@
             </h4>
             <div aria-expanded="true" class="collapse show" id="cookbooks_18Col">
               <ul class="list-group-flush mb-0 ps-0 ps-md-4">
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_20_1" id="item_20_1">
+                <li class="list-group-item searchable ps-0" data-dlc="true" data-id="cookbooks_20_1" id="item_20_1">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="18" id="cookbooks_20_1" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_20_1">1. From cerulean coast west, head south east until you reach a small grave with a tree. There should be a tree on your map not that far from the grace.</label>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_20_2" id="item_20_2">
+                <li class="list-group-item searchable ps-0" data-dlc="true" data-id="cookbooks_20_2" id="item_20_2">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="18" id="cookbooks_20_2" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_20_2">2. Located shortly after entering Charo's Hidden Grave. It's by a pile of rocks and turtles when you first reach the water.</label>
@@ -1232,13 +1242,13 @@
             </h4>
             <div aria-expanded="true" class="collapse show" id="cookbooks_19Col">
               <ul class="list-group-flush mb-0 ps-0 ps-md-4">
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_21_1" id="item_21_1">
+                <li class="list-group-item searchable ps-0" data-dlc="true" data-id="cookbooks_21_1" id="item_21_1">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="19" id="cookbooks_21_1" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_21_1">1. North of the temple town ruins site of grace, past the red servants of rot, there is a cave, inside it you will find a Shadowpothead enemy. Beware of the poison traps littered around. Drops x3 Fire Spritestone, and Antiquity Scholar's Cookbook 1].</label>
                   </div>
                 </li>
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_21_2" id="item_21_2">
+                <li class="list-group-item searchable ps-0" data-dlc="true" data-id="cookbooks_21_2" id="item_21_2">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="19" id="cookbooks_21_2" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_21_2">2. From the entrance of the Ancient Ruins of Rauh, head north towards the edge, and head west, you will find an area with an item below in which you can jump.</label>
@@ -1258,7 +1268,7 @@
             </h4>
             <div aria-expanded="true" class="collapse show" id="cookbooks_20Col">
               <ul class="list-group-flush mb-0 ps-0 ps-md-4">
-                <li class="list-group-item searchable ps-0" data-id="cookbooks_22_1" id="item_22_1">
+                <li class="list-group-item searchable ps-0" data-dlc="true" data-id="cookbooks_22_1" id="item_22_1">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="20" id="cookbooks_22_1" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_22_1">Dropped by Tibia Mariner upon defeat, located west of Finger-Weaver's Hovel.</label>

--- a/docs/checklists/cookbooks.html
+++ b/docs/checklists/cookbooks.html
@@ -27,14 +27,10 @@
         <a class="navbar-brand me-auto ms-2" href="/index.html">Roundtable Guides</a>
         <form class="d-none d-sm-flex order-2 order-xl-3">
           <input aria-label="search" class="form-control me-2" name="search" placeholder="Search" type="search">
-          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit">
-            <i class="bi bi-search"></i>
-          </button>
+          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit"><i class="bi bi-search"></i></button>
         </form>
         <div class="d-sm-none order-2">
-          <a class="nav-link me-0" href="/search.html">
-            <i class="bi bi-search sb-icon-search"></i>
-          </a>
+          <a class="nav-link me-0" href="/search.html"><i class="bi bi-search sb-icon-search"></i></a>
         </div>
         <div class="collapse navbar-collapse order-3 order-xl-2 ms-xl-2" id="nav-collapse">
           <ul class="nav navbar-nav navbar-nav-scroll mr-auto">
@@ -179,14 +175,10 @@
               </ul>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/map.html">
-                <i class="bi bi-map"></i> Map
-              </a>
+              <a class="nav-link hide-buttons" href="/map.html"><i class="bi bi-map"></i> Map</a>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/options.html">
-                <i class="bi bi-gear-fill"></i> Options
-              </a>
+              <a class="nav-link hide-buttons" href="/options.html"><i class="bi bi-gear-fill"></i> Options</a>
             </li>
           </ul>
         </div>
@@ -206,9 +198,7 @@
       </div>
       <nav class="text-muted toc d-print-none">
         <strong class="d-block h5">
-          <a class="toc-button" data-bs-toggle="collapse" href="#toc_cookbooks" role="button">
-            <i class="bi bi-plus-lg"></i>Table Of Contents
-          </a>
+          <a class="toc-button" data-bs-toggle="collapse" href="#toc_cookbooks" role="button"><i class="bi bi-plus-lg"></i>Table Of Contents</a>
         </strong>
         <ul class="toc_page collapse" id="toc_cookbooks">
           <li>
@@ -304,9 +294,7 @@
         <div class="card shadow-sm mb-3" id="cookbooks_section_0">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#cookbooks_0Col" data-bs-toggle="collapse" href="#cookbooks_0Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#cookbooks_0Col" data-bs-toggle="collapse" href="#cookbooks_0Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <img class="me-1" data-src="/img/icons/keys/cookbooks/edited/03119.png" loading="lazy" style="height: 70px; width: 70px">
               <span class="d-print-inline">Nomadic Warrior's Cookbooks</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="cookbooks_totals_0"></span>
@@ -317,216 +305,168 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="cookbooks_1_1" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_1_1">1. Sold by Kalé in Church of Elleh</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_1_1&amp;id=cookbooks_1_1&amp;link=/checklists/cookbooks.html%23item_1_1&amp;title=Nomadic Warrior's Cookbook [1]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_1_1&amp;id=cookbooks_1_1&amp;link=/checklists/cookbooks.html%23item_1_1&amp;title=Nomadic Warrior's Cookbook [1]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="cookbooks_1_2" id="item_1_2">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="cookbooks_1_2" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_1_2">2. Sold by Kalé in Church of Elleh</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_1_2&amp;id=cookbooks_1_2&amp;link=/checklists/cookbooks.html%23item_1_2&amp;title=Nomadic Warrior's Cookbook [2]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_1_2&amp;id=cookbooks_1_2&amp;link=/checklists/cookbooks.html%23item_1_2&amp;title=Nomadic Warrior's Cookbook [2]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="cookbooks_1_3" id="item_1_3">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="cookbooks_1_3" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_1_3">3. Sold by Nomadic Merchant in north Limgrave, west of Summonwater Village</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_1_3&amp;id=cookbooks_1_3&amp;link=/checklists/cookbooks.html%23item_1_3&amp;title=Nomadic Warrior's Cookbook [3]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_1_3&amp;id=cookbooks_1_3&amp;link=/checklists/cookbooks.html%23item_1_3&amp;title=Nomadic Warrior's Cookbook [3]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="cookbooks_1_4" id="item_1_4">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="cookbooks_1_4" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_1_4">4. Next to giant bear by Patches teleport (open the trapped chest in Murkwater Cave, located in the river going north from the lake in Limgrave)</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_1_4&amp;id=cookbooks_1_4&amp;link=/checklists/cookbooks.html%23item_1_4&amp;title=Nomadic Warrior's Cookbook [4]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_1_4&amp;id=cookbooks_1_4&amp;link=/checklists/cookbooks.html%23item_1_4&amp;title=Nomadic Warrior's Cookbook [4]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="cookbooks_1_5" id="item_1_5">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="cookbooks_1_5" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_1_5">5. Sold by Nomadic Merchant Northwest of Fort Haight in the southeast section of the forest in east Limgrave</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_1_5&amp;id=cookbooks_1_5&amp;link=/checklists/cookbooks.html%23item_1_5&amp;title=Nomadic Warrior's Cookbook [5]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_1_5&amp;id=cookbooks_1_5&amp;link=/checklists/cookbooks.html%23item_1_5&amp;title=Nomadic Warrior's Cookbook [5]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="cookbooks_1_6" id="item_1_6">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="cookbooks_1_6" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_1_6">6. Fort Haight in the southeast section of the forest in east Limgrave, in the room under the stairs</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_1_6&amp;id=cookbooks_1_6&amp;link=/checklists/cookbooks.html%23item_1_6&amp;title=Nomadic Warrior's Cookbook [6]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_1_6&amp;id=cookbooks_1_6&amp;link=/checklists/cookbooks.html%23item_1_6&amp;title=Nomadic Warrior's Cookbook [6]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="cookbooks_1_7" id="item_1_7">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="cookbooks_1_7" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_1_7">7. North of Stormhill Shack at the edge of the broken bridge past the Finger Reader Crone</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_1_7&amp;id=cookbooks_1_7&amp;link=/checklists/cookbooks.html%23item_1_7&amp;title=Nomadic Warrior's Cookbook [7]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_1_7&amp;id=cookbooks_1_7&amp;link=/checklists/cookbooks.html%23item_1_7&amp;title=Nomadic Warrior's Cookbook [7]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="cookbooks_1_8" id="item_1_8">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="cookbooks_1_8" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_1_8">8. Tombsward Cave, southeast of Fourth Church of Marika in northwest Weeping Peninsula</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_1_8&amp;id=cookbooks_1_8&amp;link=/checklists/cookbooks.html%23item_1_8&amp;title=Nomadic Warrior's Cookbook [8]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_1_8&amp;id=cookbooks_1_8&amp;link=/checklists/cookbooks.html%23item_1_8&amp;title=Nomadic Warrior's Cookbook [8]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="cookbooks_1_9" id="item_1_9">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="cookbooks_1_9" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_1_9">9. Tombsward Catacombs, south of Church of the Pilgrimage in north Weeping Peninsula.</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_1_9&amp;id=cookbooks_1_9&amp;link=/checklists/cookbooks.html%23item_1_9&amp;title=Nomadic Warrior's Cookbook [9]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_1_9&amp;id=cookbooks_1_9&amp;link=/checklists/cookbooks.html%23item_1_9&amp;title=Nomadic Warrior's Cookbook [9]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="cookbooks_1_10" id="item_1_10">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="cookbooks_1_10" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_1_10">10. In Stormveil Castle, from Rampart Tower Grace, go through the north door and jump to the roof in the east. Keep going this way and you'll find it.</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_1_10&amp;id=cookbooks_1_10&amp;link=/checklists/cookbooks.html%23item_1_10&amp;title=Nomadic Warrior's Cookbook [10]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_1_10&amp;id=cookbooks_1_10&amp;link=/checklists/cookbooks.html%23item_1_10&amp;title=Nomadic Warrior's Cookbook [10]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="cookbooks_1_11" id="item_1_11">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="cookbooks_1_11" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_1_11">11. Sold by Nomadic Merchant at the Liurnia Lake Shore Grace</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_1_11&amp;id=cookbooks_1_11&amp;link=/checklists/cookbooks.html%23item_1_11&amp;title=Nomadic Warrior's Cookbook [11]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_1_11&amp;id=cookbooks_1_11&amp;link=/checklists/cookbooks.html%23item_1_11&amp;title=Nomadic Warrior's Cookbook [11]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="cookbooks_1_12" id="item_1_12">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="cookbooks_1_12" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_1_12">12. Rose Church, southwest of Raya Lucaria</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_1_12&amp;id=cookbooks_1_12&amp;link=/checklists/cookbooks.html%23item_1_12&amp;title=Nomadic Warrior's Cookbook [12]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_1_12&amp;id=cookbooks_1_12&amp;link=/checklists/cookbooks.html%23item_1_12&amp;title=Nomadic Warrior's Cookbook [12]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="cookbooks_1_13" id="item_1_13">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="cookbooks_1_13" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_1_13">13. Sold by Nomadic Merchant north of Bellum Church in northeast Liurnia of the Lakes</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_1_13&amp;id=cookbooks_1_13&amp;link=/checklists/cookbooks.html%23item_1_13&amp;title=Nomadic Warrior's Cookbook [13]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_1_13&amp;id=cookbooks_1_13&amp;link=/checklists/cookbooks.html%23item_1_13&amp;title=Nomadic Warrior's Cookbook [13]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="cookbooks_1_14" id="item_1_14">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="cookbooks_1_14" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_1_14">14. Smoldering Church, northeast Limgrave/northwest Caelid</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_1_14&amp;id=cookbooks_1_14&amp;link=/checklists/cookbooks.html%23item_1_14&amp;title=Nomadic Warrior's Cookbook [14]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_1_14&amp;id=cookbooks_1_14&amp;link=/checklists/cookbooks.html%23item_1_14&amp;title=Nomadic Warrior's Cookbook [14]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="cookbooks_1_15" id="item_1_15">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="cookbooks_1_15" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_1_15">15. Sold by Nomadic Merchant south of Caelid swamp at fork in the road.</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_1_15&amp;id=cookbooks_1_15&amp;link=/checklists/cookbooks.html%23item_1_15&amp;title=Nomadic Warrior's Cookbook [15]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_1_15&amp;id=cookbooks_1_15&amp;link=/checklists/cookbooks.html%23item_1_15&amp;title=Nomadic Warrior's Cookbook [15]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="cookbooks_1_16" id="item_1_16">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="cookbooks_1_16" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_1_16">16. Sold by Hermit Merchant in south/central of Ainsel River.</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_1_16&amp;id=cookbooks_1_16&amp;link=/checklists/cookbooks.html%23item_1_16&amp;title=Nomadic Warrior's Cookbook [16]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_1_16&amp;id=cookbooks_1_16&amp;link=/checklists/cookbooks.html%23item_1_16&amp;title=Nomadic Warrior's Cookbook [16]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="cookbooks_1_17" id="item_1_17">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="cookbooks_1_17" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_1_17">17. Sold by Abandoned Merchant in center of Siofra River on top of wooden house.</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_1_17&amp;id=cookbooks_1_17&amp;link=/checklists/cookbooks.html%23item_1_17&amp;title=Nomadic Warrior's Cookbook [17]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_1_17&amp;id=cookbooks_1_17&amp;link=/checklists/cookbooks.html%23item_1_17&amp;title=Nomadic Warrior's Cookbook [17]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="cookbooks_1_18" id="item_1_18">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="cookbooks_1_18" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_1_18">18. Sold by Abandoned Merchant in center of Siofra River on top of wooden house.</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_1_18&amp;id=cookbooks_1_18&amp;link=/checklists/cookbooks.html%23item_1_18&amp;title=Nomadic Warrior's Cookbook [18]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_1_18&amp;id=cookbooks_1_18&amp;link=/checklists/cookbooks.html%23item_1_18&amp;title=Nomadic Warrior's Cookbook [18]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="cookbooks_1_19" id="item_1_19">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="cookbooks_1_19" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_1_19">19. Woodfolk Ruins, east of the Minor Erdtree in north Altus Plateau</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_1_19&amp;id=cookbooks_1_19&amp;link=/checklists/cookbooks.html%23item_1_19&amp;title=Nomadic Warrior's Cookbook [19]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_1_19&amp;id=cookbooks_1_19&amp;link=/checklists/cookbooks.html%23item_1_19&amp;title=Nomadic Warrior's Cookbook [19]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="cookbooks_1_20" id="item_1_20">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="cookbooks_1_20" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_1_20">20. Sold by Nomadic Merchant in north Mt. Gelmir, northeast of Volcano Manor</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_1_20&amp;id=cookbooks_1_20&amp;link=/checklists/cookbooks.html%23item_1_20&amp;title=Nomadic Warrior's Cookbook [20]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_1_20&amp;id=cookbooks_1_20&amp;link=/checklists/cookbooks.html%23item_1_20&amp;title=Nomadic Warrior's Cookbook [20]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="cookbooks_1_21" id="item_1_21">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="cookbooks_1_21" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_1_21">21. Volcano Manor in the area hidden behind the Illusory Wall in one of the hallway rooms.</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_1_21&amp;id=cookbooks_1_21&amp;link=/checklists/cookbooks.html%23item_1_21&amp;title=Nomadic Warrior's Cookbook [21]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_1_21&amp;id=cookbooks_1_21&amp;link=/checklists/cookbooks.html%23item_1_21&amp;title=Nomadic Warrior's Cookbook [21]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="cookbooks_1_22" id="item_1_22">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="cookbooks_1_22" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_1_22">22. Chest in west Lake of Rot, west of Ainsel River underground. May require Ranni's questline.</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_1_22&amp;id=cookbooks_1_22&amp;link=/checklists/cookbooks.html%23item_1_22&amp;title=Nomadic Warrior's Cookbook [22]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_1_22&amp;id=cookbooks_1_22&amp;link=/checklists/cookbooks.html%23item_1_22&amp;title=Nomadic Warrior's Cookbook [22]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="cookbooks_1_23" id="item_1_23">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="cookbooks_1_23" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_1_23">23. Consecrated Snowfield, north of the first Grace. Requires Haligtree Medallion</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_1_23&amp;id=cookbooks_1_23&amp;link=/checklists/cookbooks.html%23item_1_23&amp;title=Nomadic Warrior's Cookbook [23]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_1_23&amp;id=cookbooks_1_23&amp;link=/checklists/cookbooks.html%23item_1_23&amp;title=Nomadic Warrior's Cookbook [23]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="cookbooks_1_24" id="item_1_24">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="cookbooks_1_24" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_1_24">24. Mohgwyn Palace on the edge of the cliffs past the swamp. Requires Haligtree Medallion or completion of White-Faced Varré's Questline.</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_1_24&amp;id=cookbooks_1_24&amp;link=/checklists/cookbooks.html%23item_1_24&amp;title=Nomadic Warrior's Cookbook [24]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_1_24&amp;id=cookbooks_1_24&amp;link=/checklists/cookbooks.html%23item_1_24&amp;title=Nomadic Warrior's Cookbook [24]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -536,9 +476,7 @@
         <div class="card shadow-sm mb-3" id="cookbooks_section_1">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#cookbooks_1Col" data-bs-toggle="collapse" href="#cookbooks_1Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#cookbooks_1Col" data-bs-toggle="collapse" href="#cookbooks_1Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <img class="me-1" data-src="/img/icons/keys/cookbooks/edited/03120.png" loading="lazy" style="height: 70px; width: 70px">
               <span class="d-print-inline">Armorer's Cookbooks</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="cookbooks_totals_1"></span>
@@ -549,63 +487,49 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="cookbooks_3_1" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_3_1">1. In camp northeast of north Agheel Lake Grace</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_3_1&amp;id=cookbooks_3_1&amp;link=/checklists/cookbooks.html%23item_3_1&amp;title=Armorer's Cookbook [1]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_3_1&amp;id=cookbooks_3_1&amp;link=/checklists/cookbooks.html%23item_3_1&amp;title=Armorer's Cookbook [1]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="cookbooks_3_2" id="item_3_2">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="cookbooks_3_2" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_3_2">2. Sold by Nomadic Merchant by Coastal Cave in southwest Limgrave</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_3_2&amp;id=cookbooks_3_2&amp;link=/checklists/cookbooks.html%23item_3_2&amp;title=Armorer's Cookbook [2]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_3_2&amp;id=cookbooks_3_2&amp;link=/checklists/cookbooks.html%23item_3_2&amp;title=Armorer's Cookbook [2]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="cookbooks_3_3" id="item_3_3">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="cookbooks_3_3" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_3_3">3. Sold by Nomadic Merchant Northwest of Fort Haight in the southeast section of the forest in east Limgrave</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_3_3&amp;id=cookbooks_3_3&amp;link=/checklists/cookbooks.html%23item_3_3&amp;title=Armorer's Cookbook [3]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_3_3&amp;id=cookbooks_3_3&amp;link=/checklists/cookbooks.html%23item_3_3&amp;title=Armorer's Cookbook [3]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="cookbooks_3_4" id="item_3_4">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="cookbooks_3_4" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_3_4">4. Castle Redmane in southeast Caelid in the northwest gatehouse</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_3_4&amp;id=cookbooks_3_4&amp;link=/checklists/cookbooks.html%23item_3_4&amp;title=Armorer's Cookbook [4]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_3_4&amp;id=cookbooks_3_4&amp;link=/checklists/cookbooks.html%23item_3_4&amp;title=Armorer's Cookbook [4]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="cookbooks_3_5" id="item_3_5">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="cookbooks_3_5" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_3_5">5. Castle Redmane in southeast Caelid. Follow the path going through the door in the southwest.</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_3_5&amp;id=cookbooks_3_5&amp;link=/checklists/cookbooks.html%23item_3_5&amp;title=Armorer's Cookbook [5]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_3_5&amp;id=cookbooks_3_5&amp;link=/checklists/cookbooks.html%23item_3_5&amp;title=Armorer's Cookbook [5]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="cookbooks_3_6" id="item_3_6">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="cookbooks_3_6" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_3_6">6. Siofra River. west of the Siofra River Bank Grace</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_3_6&amp;id=cookbooks_3_6&amp;link=/checklists/cookbooks.html%23item_3_6&amp;title=Armorer's Cookbook [6]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_3_6&amp;id=cookbooks_3_6&amp;link=/checklists/cookbooks.html%23item_3_6&amp;title=Armorer's Cookbook [6]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="cookbooks_3_7" id="item_3_7">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="cookbooks_3_7" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_3_7">7. Fort Laiedd in west Mt. Gelmir. west of Volcano Manor.</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_3_7&amp;id=cookbooks_3_7&amp;link=/checklists/cookbooks.html%23item_3_7&amp;title=Armorer's Cookbook [7]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_3_7&amp;id=cookbooks_3_7&amp;link=/checklists/cookbooks.html%23item_3_7&amp;title=Armorer's Cookbook [7]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -615,9 +539,7 @@
         <div class="card shadow-sm mb-3" id="cookbooks_section_2">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#cookbooks_2Col" data-bs-toggle="collapse" href="#cookbooks_2Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#cookbooks_2Col" data-bs-toggle="collapse" href="#cookbooks_2Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <img class="me-1" data-src="/img/icons/keys/cookbooks/edited/03121.png" loading="lazy" style="height: 70px; width: 70px">
               <span class="d-print-inline">Glintstone Craftsman's Cookbooks</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="cookbooks_totals_2"></span>
@@ -628,72 +550,56 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="2" id="cookbooks_5_1" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_5_1">1. In outpost south of Liurnia Lake Shore Grace</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_5_1&amp;id=cookbooks_5_1&amp;link=/checklists/cookbooks.html%23item_5_1&amp;title=Glintstone Craftsman's Cookbook [1]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_5_1&amp;id=cookbooks_5_1&amp;link=/checklists/cookbooks.html%23item_5_1&amp;title=Glintstone Craftsman's Cookbook [1]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="cookbooks_5_2" id="item_5_2">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="2" id="cookbooks_5_2" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_5_2">2. Directly next to the Laskyar Ruins Grace in southeast Liurnia of the Lakes</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_5_2&amp;id=cookbooks_5_2&amp;link=/checklists/cookbooks.html%23item_5_2&amp;title=Glintstone Craftsman's Cookbook [2]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_5_2&amp;id=cookbooks_5_2&amp;link=/checklists/cookbooks.html%23item_5_2&amp;title=Glintstone Craftsman's Cookbook [2]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="cookbooks_5_3" id="item_5_3">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="2" id="cookbooks_5_3" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_5_3">3. Highway Lookout Tower in east Liurnia of the Lakes, northwest of Liurnia Highway North Grace</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_5_3&amp;id=cookbooks_5_3&amp;link=/checklists/cookbooks.html%23item_5_3&amp;title=Glintstone Craftsman's Cookbook [3]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_5_3&amp;id=cookbooks_5_3&amp;link=/checklists/cookbooks.html%23item_5_3&amp;title=Glintstone Craftsman's Cookbook [3]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="cookbooks_5_4" id="item_5_4">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="2" id="cookbooks_5_4" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_5_4">4. Academy Gate Town southeast of Raya Lucaria Academy. It's in a chest northwest of the Grace.</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_5_4&amp;id=cookbooks_5_4&amp;link=/checklists/cookbooks.html%23item_5_4&amp;title=Glintstone Craftsman's Cookbook [4]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_5_4&amp;id=cookbooks_5_4&amp;link=/checklists/cookbooks.html%23item_5_4&amp;title=Glintstone Craftsman's Cookbook [4]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="cookbooks_5_5" id="item_5_5">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="2" id="cookbooks_5_5" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_5_5">5. Academy of Raya Lucaria in a chest past the Schoolhouse Classroom Grace</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_5_5&amp;id=cookbooks_5_5&amp;link=/checklists/cookbooks.html%23item_5_5&amp;title=Glintstone Craftsman's Cookbook [5]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_5_5&amp;id=cookbooks_5_5&amp;link=/checklists/cookbooks.html%23item_5_5&amp;title=Glintstone Craftsman's Cookbook [5]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="cookbooks_5_6" id="item_5_6">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="2" id="cookbooks_5_6" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_5_6">6. Caria Manor in a room southeast of the courtyard.</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_5_6&amp;id=cookbooks_5_6&amp;link=/checklists/cookbooks.html%23item_5_6&amp;title=Glintstone Craftsman's Cookbook [6]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_5_6&amp;id=cookbooks_5_6&amp;link=/checklists/cookbooks.html%23item_5_6&amp;title=Glintstone Craftsman's Cookbook [6]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="cookbooks_5_7" id="item_5_7">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="2" id="cookbooks_5_7" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_5_7">7. Sold by Pidia in Caria Manor. Complete Caria Manor then go to Seluvis's Rise west of it and then go east and drop onto the rampart from the cliff.</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_5_7&amp;id=cookbooks_5_7&amp;link=/checklists/cookbooks.html%23item_5_7&amp;title=Glintstone Craftsman's Cookbook [7]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_5_7&amp;id=cookbooks_5_7&amp;link=/checklists/cookbooks.html%23item_5_7&amp;title=Glintstone Craftsman's Cookbook [7]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="cookbooks_5_8" id="item_5_8">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="2" id="cookbooks_5_8" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_5_8">8. Southwest of Albinaurics Rise in east Consecrated Snowfield. Requires Haligtree Medallion.</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_5_8&amp;id=cookbooks_5_8&amp;link=/checklists/cookbooks.html%23item_5_8&amp;title=Glintstone Craftsman's Cookbook [8]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_5_8&amp;id=cookbooks_5_8&amp;link=/checklists/cookbooks.html%23item_5_8&amp;title=Glintstone Craftsman's Cookbook [8]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -703,9 +609,7 @@
         <div class="card shadow-sm mb-3" id="cookbooks_section_3">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#cookbooks_3Col" data-bs-toggle="collapse" href="#cookbooks_3Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#cookbooks_3Col" data-bs-toggle="collapse" href="#cookbooks_3Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <img class="me-1" data-src="/img/icons/keys/cookbooks/edited/03122.png" loading="lazy" style="height: 70px; width: 70px">
               <span class="d-print-inline">Missionary's Cookbooks</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="cookbooks_totals_3"></span>
@@ -716,63 +620,49 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="cookbooks_2_1" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_2_1">1. Sold by Kalé in Church of Elleh</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_2_1&amp;id=cookbooks_2_1&amp;link=/checklists/cookbooks.html%23item_2_1&amp;title=Missionary's Cookbook [1]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_2_1&amp;id=cookbooks_2_1&amp;link=/checklists/cookbooks.html%23item_2_1&amp;title=Missionary's Cookbook [1]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="cookbooks_2_2" id="item_2_2">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="cookbooks_2_2" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_2_2">2. Sold by Patches in Murkwater Cave located in the river going north from the lake in Limgrave.</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_2_2&amp;id=cookbooks_2_2&amp;link=/checklists/cookbooks.html%23item_2_2&amp;title=Missionary's Cookbook [2]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_2_2&amp;id=cookbooks_2_2&amp;link=/checklists/cookbooks.html%23item_2_2&amp;title=Missionary's Cookbook [2]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="cookbooks_2_3" id="item_2_3">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="cookbooks_2_3" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_2_3">3. Smoldering Church in northeast Limgrave/northwest Caelid</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_2_3&amp;id=cookbooks_2_3&amp;link=/checklists/cookbooks.html%23item_2_3&amp;title=Missionary's Cookbook [3]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_2_3&amp;id=cookbooks_2_3&amp;link=/checklists/cookbooks.html%23item_2_3&amp;title=Missionary's Cookbook [3]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="cookbooks_2_4" id="item_2_4">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="cookbooks_2_4" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_2_4">4. Minor Erdtree Church in southwest Capital Outskirts.</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_2_4&amp;id=cookbooks_2_4&amp;link=/checklists/cookbooks.html%23item_2_4&amp;title=Missionary's Cookbook [4]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_2_4&amp;id=cookbooks_2_4&amp;link=/checklists/cookbooks.html%23item_2_4&amp;title=Missionary's Cookbook [4]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="cookbooks_2_5" id="item_2_5">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="cookbooks_2_5" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_2_5">5. Siofra Aqueduct (accessed from Nokron), northeast of the Aqueduct-Facing Cliffs Grace. Drop onto the beam and into the room at the end, then exit to the west. It's in the room past the bridge with a Crucible Knight.</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_2_5&amp;id=cookbooks_2_5&amp;link=/checklists/cookbooks.html%23item_2_5&amp;title=Missionary's Cookbook [5]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_2_5&amp;id=cookbooks_2_5&amp;link=/checklists/cookbooks.html%23item_2_5&amp;title=Missionary's Cookbook [5]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="cookbooks_2_6" id="item_2_6">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="cookbooks_2_6" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_2_6">6. Volcano Manor, from Temple of Eiglay Grace, go up the elevator and hop down into the lava. Go through the window guarded by an Iron Maiden, down a ladder, and down the stairs. It's in a small cell in the room at the bottom.</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_2_6&amp;id=cookbooks_2_6&amp;link=/checklists/cookbooks.html%23item_2_6&amp;title=Missionary's Cookbook [6]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_2_6&amp;id=cookbooks_2_6&amp;link=/checklists/cookbooks.html%23item_2_6&amp;title=Missionary's Cookbook [6]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="cookbooks_2_7" id="item_2_7">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="cookbooks_2_7" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_2_7">7. Sold by Hermit Merchant in Mountaintops of the Giants, near the Ancient Snow Valley Ruins Grace.</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_2_7&amp;id=cookbooks_2_7&amp;link=/checklists/cookbooks.html%23item_2_7&amp;title=Missionary's Cookbook [7]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_2_7&amp;id=cookbooks_2_7&amp;link=/checklists/cookbooks.html%23item_2_7&amp;title=Missionary's Cookbook [7]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -782,9 +672,7 @@
         <div class="card shadow-sm mb-3" id="cookbooks_section_4">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#cookbooks_4Col" data-bs-toggle="collapse" href="#cookbooks_4Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#cookbooks_4Col" data-bs-toggle="collapse" href="#cookbooks_4Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <img class="me-1" data-src="/img/icons/keys/cookbooks/edited/03124.png" loading="lazy" style="height: 70px; width: 70px">
               <span class="d-print-inline">Ancient Dragon Apostle's Cookbooks</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="cookbooks_totals_4"></span>
@@ -795,36 +683,28 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="4" id="cookbooks_8_1" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_8_1">1. Wyndham Catacombs in west Altus Plateau. southeast of Volcano Manor. Under the spike trap, guarded by giant crabs</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_8_1&amp;id=cookbooks_8_1&amp;link=/checklists/cookbooks.html%23item_8_1&amp;title=Ancient Dragon Apostle's Cookbook [1]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_8_1&amp;id=cookbooks_8_1&amp;link=/checklists/cookbooks.html%23item_8_1&amp;title=Ancient Dragon Apostle's Cookbook [1]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="cookbooks_8_2" id="item_8_2">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="4" id="cookbooks_8_2" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_8_2">2. Sold by Nomadic Merchant just north of the Forest-Spanning Greatbridge Grace on the south side of the broken bridge in north/central Altus Plateau.</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_8_2&amp;id=cookbooks_8_2&amp;link=/checklists/cookbooks.html%23item_8_2&amp;title=Ancient Dragon Apostle's Cookbook [2]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_8_2&amp;id=cookbooks_8_2&amp;link=/checklists/cookbooks.html%23item_8_2&amp;title=Ancient Dragon Apostle's Cookbook [2]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="cookbooks_8_3" id="item_8_3">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="4" id="cookbooks_8_3" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_8_3">3. Cathedral of Dragon Communion in south Caelid, west of Castle Redmane.</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_8_3&amp;id=cookbooks_8_3&amp;link=/checklists/cookbooks.html%23item_8_3&amp;title=Ancient Dragon Apostle's Cookbook [3]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_8_3&amp;id=cookbooks_8_3&amp;link=/checklists/cookbooks.html%23item_8_3&amp;title=Ancient Dragon Apostle's Cookbook [3]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="cookbooks_8_4" id="item_8_4">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="4" id="cookbooks_8_4" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_8_4">4. Crumbling Farum Azula on a roof in the southwest section past a dragon.</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_8_4&amp;id=cookbooks_8_4&amp;link=/checklists/cookbooks.html%23item_8_4&amp;title=Ancient Dragon Apostle's Cookbook [4]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_8_4&amp;id=cookbooks_8_4&amp;link=/checklists/cookbooks.html%23item_8_4&amp;title=Ancient Dragon Apostle's Cookbook [4]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -834,9 +714,7 @@
         <div class="card shadow-sm mb-3" id="cookbooks_section_5">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#cookbooks_5Col" data-bs-toggle="collapse" href="#cookbooks_5Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#cookbooks_5Col" data-bs-toggle="collapse" href="#cookbooks_5Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <img class="me-1" data-src="/img/icons/keys/cookbooks/edited/03123.png" loading="lazy" style="height: 70px; width: 70px">
               <span class="d-print-inline">Perfumer's Cookbooks</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="cookbooks_totals_5"></span>
@@ -847,36 +725,28 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="cookbooks_7_1" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_7_1">1. Perfumer's Ruins, northwest of Abandoned Coffin Grace in Altus Plateau, found by going through the "Coward's" path past the Magma Wyrm.</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_7_1&amp;id=cookbooks_7_1&amp;link=/checklists/cookbooks.html%23item_7_1&amp;title=Perfumer's Cookbook [1]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_7_1&amp;id=cookbooks_7_1&amp;link=/checklists/cookbooks.html%23item_7_1&amp;title=Perfumer's Cookbook [1]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="cookbooks_7_2" id="item_7_2">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="cookbooks_7_2" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_7_2">2. Rooftops of Shaded Castle in north Altus Plateau</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_7_2&amp;id=cookbooks_7_2&amp;link=/checklists/cookbooks.html%23item_7_2&amp;title=Perfumer's Cookbook [2]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_7_2&amp;id=cookbooks_7_2&amp;link=/checklists/cookbooks.html%23item_7_2&amp;title=Perfumer's Cookbook [2]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="cookbooks_7_3" id="item_7_3">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="cookbooks_7_3" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_7_3">3. Auriza Side Tomb northeast of Leyndell. Open the chest in the room with a lot of benches.</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_7_3&amp;id=cookbooks_7_3&amp;link=/checklists/cookbooks.html%23item_7_3&amp;title=Perfumer's Cookbook [3]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_7_3&amp;id=cookbooks_7_3&amp;link=/checklists/cookbooks.html%23item_7_3&amp;title=Perfumer's Cookbook [3]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="cookbooks_7_4" id="item_7_4">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="cookbooks_7_4" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_7_4">4. Sold by Hermit Merchant in south/central Ainsel River</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_7_4&amp;id=cookbooks_7_4&amp;link=/checklists/cookbooks.html%23item_7_4&amp;title=Perfumer's Cookbook [4]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_7_4&amp;id=cookbooks_7_4&amp;link=/checklists/cookbooks.html%23item_7_4&amp;title=Perfumer's Cookbook [4]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -886,9 +756,7 @@
         <div class="card shadow-sm mb-3" id="cookbooks_section_6">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#cookbooks_6Col" data-bs-toggle="collapse" href="#cookbooks_6Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#cookbooks_6Col" data-bs-toggle="collapse" href="#cookbooks_6Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <img class="me-1" data-src="/img/icons/keys/cookbooks/edited/03125.png" loading="lazy" style="height: 70px; width: 70px">
               <span class="d-print-inline">Fevor's Cookbooks</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="cookbooks_totals_6"></span>
@@ -899,27 +767,21 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="cookbooks_4_1" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_4_1">1. On a stone tomb south of Summonwater Village in northeast Limgrave</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_4_1&amp;id=cookbooks_4_1&amp;link=/checklists/cookbooks.html%23item_4_1&amp;title=Fevor's Cookbook [1]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_4_1&amp;id=cookbooks_4_1&amp;link=/checklists/cookbooks.html%23item_4_1&amp;title=Fevor's Cookbook [1]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="cookbooks_4_2" id="item_4_2">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="cookbooks_4_2" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_4_2">2. Sold by Isolated Merchant east of Main Academy Gate Grace. Requires Glintstone Key gotten next to the Dragon west of Raya Lucaria.</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_4_2&amp;id=cookbooks_4_2&amp;link=/checklists/cookbooks.html%23item_4_2&amp;title=Fevor's Cookbook [2]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_4_2&amp;id=cookbooks_4_2&amp;link=/checklists/cookbooks.html%23item_4_2&amp;title=Fevor's Cookbook [2]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="cookbooks_4_3" id="item_4_3">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="cookbooks_4_3" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_4_3">3. Reward from Gideon Ofnir for information on Mohgwyn Dynasty Medallion. Requires either Haligtree Medallion or finishing White-Faced Varré's Questline.</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_4_3&amp;id=cookbooks_4_3&amp;link=/checklists/cookbooks.html%23item_4_3&amp;title=Fevor's Cookbook [3]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_4_3&amp;id=cookbooks_4_3&amp;link=/checklists/cookbooks.html%23item_4_3&amp;title=Fevor's Cookbook [3]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -929,9 +791,7 @@
         <div class="card shadow-sm mb-3" id="cookbooks_section_7">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#cookbooks_7Col" data-bs-toggle="collapse" href="#cookbooks_7Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#cookbooks_7Col" data-bs-toggle="collapse" href="#cookbooks_7Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <img class="me-1" data-src="/img/icons/keys/cookbooks/edited/03126.png" loading="lazy" style="height: 70px; width: 70px">
               <span class="d-print-inline">Frenzied's Cookbooks</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="cookbooks_totals_7"></span>
@@ -942,18 +802,14 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="7" id="cookbooks_6_1" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_6_1">1. Frenzied Flame Village in northeast Liurnia of the Lakes</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_6_1&amp;id=cookbooks_6_1&amp;link=/checklists/cookbooks.html%23item_6_1&amp;title=Frenzied's Cookbook [1]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_6_1&amp;id=cookbooks_6_1&amp;link=/checklists/cookbooks.html%23item_6_1&amp;title=Frenzied's Cookbook [1]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="cookbooks_6_2" id="item_6_2">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="7" id="cookbooks_6_2" type="checkbox" value="">
                     <label class="form-check-label item_content" for="cookbooks_6_2">2. On the path down to the Frenzied Flame.</label>
-                    <a class="ms-2" href="/map.html?target=cookbooks_6_2&amp;id=cookbooks_6_2&amp;link=/checklists/cookbooks.html%23item_6_2&amp;title=Frenzied's Cookbook [2]">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=cookbooks_6_2&amp;id=cookbooks_6_2&amp;link=/checklists/cookbooks.html%23item_6_2&amp;title=Frenzied's Cookbook [2]"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -963,9 +819,7 @@
         <div class="card shadow-sm mb-3" id="cookbooks_section_8">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#cookbooks_8Col" data-bs-toggle="collapse" href="#cookbooks_8Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#cookbooks_8Col" data-bs-toggle="collapse" href="#cookbooks_8Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <img class="me-1" data-src="/img/icons/keys/cookbooks/edited/03855.png" loading="lazy" style="height: 70px; width: 70px">
               <span class="d-print-inline">Forager Brood Cookbook</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="cookbooks_totals_8"></span>
@@ -1021,9 +875,7 @@
         <div class="card shadow-sm mb-3" id="cookbooks_section_9">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#cookbooks_9Col" data-bs-toggle="collapse" href="#cookbooks_9Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#cookbooks_9Col" data-bs-toggle="collapse" href="#cookbooks_9Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <img class="me-1" data-src="/img/icons/keys/cookbooks/edited/03840.png" loading="lazy" style="height: 70px; width: 70px">
               <span class="d-print-inline">Igon's Cookbook</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="cookbooks_totals_9"></span>
@@ -1049,9 +901,7 @@
         <div class="card shadow-sm mb-3" id="cookbooks_section_10">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#cookbooks_10Col" data-bs-toggle="collapse" href="#cookbooks_10Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#cookbooks_10Col" data-bs-toggle="collapse" href="#cookbooks_10Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <img class="me-1" data-src="/img/icons/keys/cookbooks/edited/01384.png" loading="lazy" style="height: 70px; width: 70px">
               <span class="d-print-inline">Finger-Weaver's Cookbook</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="cookbooks_totals_10"></span>
@@ -1077,9 +927,7 @@
         <div class="card shadow-sm mb-3" id="cookbooks_section_11">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#cookbooks_11Col" data-bs-toggle="collapse" href="#cookbooks_11Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#cookbooks_11Col" data-bs-toggle="collapse" href="#cookbooks_11Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <img class="me-1" data-src="/img/icons/keys/cookbooks/edited/03842.png" loading="lazy" style="height: 70px; width: 70px">
               <span class="d-print-inline">Greater Potentate's Cookbook</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="cookbooks_totals_11"></span>
@@ -1177,9 +1025,7 @@
         <div class="card shadow-sm mb-3" id="cookbooks_section_12">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#cookbooks_12Col" data-bs-toggle="collapse" href="#cookbooks_12Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#cookbooks_12Col" data-bs-toggle="collapse" href="#cookbooks_12Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <img class="me-1" data-src="/img/icons/keys/cookbooks/edited/03837.png" loading="lazy" style="height: 70px; width: 70px">
               <span class="d-print-inline">Ancient Dragon Knight's Cookbook</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="cookbooks_totals_12"></span>
@@ -1205,9 +1051,7 @@
         <div class="card shadow-sm mb-3" id="cookbooks_section_13">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#cookbooks_13Col" data-bs-toggle="collapse" href="#cookbooks_13Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#cookbooks_13Col" data-bs-toggle="collapse" href="#cookbooks_13Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <img class="me-1" data-src="/img/icons/keys/cookbooks/edited/03843.png" loading="lazy" style="height: 70px; width: 70px">
               <span class="d-print-inline">Mad Craftsman's Cookbook</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="cookbooks_totals_13"></span>
@@ -1239,9 +1083,7 @@
         <div class="card shadow-sm mb-3" id="cookbooks_section_14">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#cookbooks_14Col" data-bs-toggle="collapse" href="#cookbooks_14Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#cookbooks_14Col" data-bs-toggle="collapse" href="#cookbooks_14Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <img class="me-1" data-src="/img/icons/keys/cookbooks/edited/03841.png" loading="lazy" style="height: 70px; width: 70px">
               <span class="d-print-inline">St. Trina Disciple's Cookbook</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="cookbooks_totals_14"></span>
@@ -1273,9 +1115,7 @@
         <div class="card shadow-sm mb-3" id="cookbooks_section_15">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#cookbooks_15Col" data-bs-toggle="collapse" href="#cookbooks_15Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#cookbooks_15Col" data-bs-toggle="collapse" href="#cookbooks_15Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <img class="me-1" data-src="/img/icons/keys/cookbooks/edited/03836.png" loading="lazy" style="height: 70px; width: 70px">
               <span class="d-print-inline">Fire Knight's Cookbook</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="cookbooks_totals_15"></span>
@@ -1301,9 +1141,7 @@
         <div class="card shadow-sm mb-3" id="cookbooks_section_16">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#cookbooks_16Col" data-bs-toggle="collapse" href="#cookbooks_16Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#cookbooks_16Col" data-bs-toggle="collapse" href="#cookbooks_16Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <img class="me-1" data-src="/img/icons/keys/cookbooks/edited/03838.png" loading="lazy" style="height: 70px; width: 70px">
               <span class="d-print-inline">Loyal Knight's Cookbook</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="cookbooks_totals_16"></span>
@@ -1323,9 +1161,7 @@
         <div class="card shadow-sm mb-3" id="cookbooks_section_17">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#cookbooks_17Col" data-bs-toggle="collapse" href="#cookbooks_17Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#cookbooks_17Col" data-bs-toggle="collapse" href="#cookbooks_17Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <img class="me-1" data-src="/img/icons/keys/cookbooks/edited/03839.png" loading="lazy" style="height: 70px; width: 70px">
               <span class="d-print-inline">Battlefield Priest's Cookbook</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="cookbooks_totals_17"></span>
@@ -1363,9 +1199,7 @@
         <div class="card shadow-sm mb-3" id="cookbooks_section_18">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#cookbooks_18Col" data-bs-toggle="collapse" href="#cookbooks_18Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#cookbooks_18Col" data-bs-toggle="collapse" href="#cookbooks_18Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <img class="me-1" data-src="/img/icons/keys/cookbooks/edited/03844.png" loading="lazy" style="height: 70px; width: 70px">
               <span class="d-print-inline">Grave Keeper's Cookbook</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="cookbooks_totals_18"></span>
@@ -1391,9 +1225,7 @@
         <div class="card shadow-sm mb-3" id="cookbooks_section_19">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#cookbooks_19Col" data-bs-toggle="collapse" href="#cookbooks_19Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#cookbooks_19Col" data-bs-toggle="collapse" href="#cookbooks_19Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <img class="me-1" data-src="/img/icons/keys/cookbooks/edited/03845.png" loading="lazy" style="height: 70px; width: 70px">
               <span class="d-print-inline">Antiquity Scholar's Cookbook</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="cookbooks_totals_19"></span>
@@ -1419,9 +1251,7 @@
         <div class="card shadow-sm mb-3" id="cookbooks_section_20">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#cookbooks_20Col" data-bs-toggle="collapse" href="#cookbooks_20Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#cookbooks_20Col" data-bs-toggle="collapse" href="#cookbooks_20Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <img class="me-1" data-src="/img/icons/keys/cookbooks/edited/03852.png" loading="lazy" style="height: 70px; width: 70px">
               <span class="d-print-inline">Tibia's Cookbook</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="cookbooks_totals_20"></span>

--- a/docs/checklists/dlc_walkthrough.html
+++ b/docs/checklists/dlc_walkthrough.html
@@ -27,14 +27,10 @@
         <a class="navbar-brand me-auto ms-2" href="/index.html">Roundtable Guides</a>
         <form class="d-none d-sm-flex order-2 order-xl-3">
           <input aria-label="search" class="form-control me-2" name="search" placeholder="Search" type="search">
-          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit">
-            <i class="bi bi-search"></i>
-          </button>
+          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit"><i class="bi bi-search"></i></button>
         </form>
         <div class="d-sm-none order-2">
-          <a class="nav-link me-0" href="/search.html">
-            <i class="bi bi-search sb-icon-search"></i>
-          </a>
+          <a class="nav-link me-0" href="/search.html"><i class="bi bi-search sb-icon-search"></i></a>
         </div>
         <div class="collapse navbar-collapse order-3 order-xl-2 ms-xl-2" id="nav-collapse">
           <ul class="nav navbar-nav navbar-nav-scroll mr-auto">
@@ -179,14 +175,10 @@
               </ul>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/map.html">
-                <i class="bi bi-map"></i> Map
-              </a>
+              <a class="nav-link hide-buttons" href="/map.html"><i class="bi bi-map"></i> Map</a>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/options.html">
-                <i class="bi bi-gear-fill"></i> Options
-              </a>
+              <a class="nav-link hide-buttons" href="/options.html"><i class="bi bi-gear-fill"></i> Options</a>
             </li>
           </ul>
         </div>
@@ -206,9 +198,7 @@
       </div>
       <nav class="text-muted toc d-print-none">
         <strong class="d-block h5">
-          <a class="toc-button" data-bs-toggle="collapse" href="#toc_dlc_playthrough" role="button">
-            <i class="bi bi-plus-lg"></i>Table Of Contents
-          </a>
+          <a class="toc-button" data-bs-toggle="collapse" href="#toc_dlc_playthrough" role="button"><i class="bi bi-plus-lg"></i>Table Of Contents</a>
         </strong>
         <ul class="toc_page collapse" id="toc_dlc_playthrough">
           <li>
@@ -280,9 +270,7 @@
         <div class="card shadow-sm mb-3" id="dlc_playthrough_section_0">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#dlc_playthrough_0Col" data-bs-toggle="collapse" href="#dlc_playthrough_0Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#dlc_playthrough_0Col" data-bs-toggle="collapse" href="#dlc_playthrough_0Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Starting Out</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="dlc_playthrough_totals_0"></span>
             </h4>
@@ -349,9 +337,7 @@
         <div class="card shadow-sm mb-3" id="dlc_playthrough_section_1">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#dlc_playthrough_1Col" data-bs-toggle="collapse" href="#dlc_playthrough_1Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#dlc_playthrough_1Col" data-bs-toggle="collapse" href="#dlc_playthrough_1Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Belurat, Tower Settlement</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="dlc_playthrough_totals_1"></span>
             </h4>
@@ -478,9 +464,7 @@
         <div class="card shadow-sm mb-3" id="dlc_playthrough_section_2">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#dlc_playthrough_2Col" data-bs-toggle="collapse" href="#dlc_playthrough_2Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#dlc_playthrough_2Col" data-bs-toggle="collapse" href="#dlc_playthrough_2Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Gravesite Plains and Southern Shore</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="dlc_playthrough_totals_2"></span>
             </h4>
@@ -631,9 +615,7 @@
         <div class="card shadow-sm mb-3" id="dlc_playthrough_section_3">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#dlc_playthrough_3Col" data-bs-toggle="collapse" href="#dlc_playthrough_3Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#dlc_playthrough_3Col" data-bs-toggle="collapse" href="#dlc_playthrough_3Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Scadu Altus</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="dlc_playthrough_totals_3"></span>
             </h4>
@@ -820,9 +802,7 @@
         <div class="card shadow-sm mb-3" id="dlc_playthrough_section_4">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#dlc_playthrough_4Col" data-bs-toggle="collapse" href="#dlc_playthrough_4Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#dlc_playthrough_4Col" data-bs-toggle="collapse" href="#dlc_playthrough_4Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Progressing Questlines</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="dlc_playthrough_totals_4"></span>
             </h4>
@@ -879,9 +859,7 @@
         <div class="card shadow-sm mb-3" id="dlc_playthrough_section_5">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#dlc_playthrough_5Col" data-bs-toggle="collapse" href="#dlc_playthrough_5Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#dlc_playthrough_5Col" data-bs-toggle="collapse" href="#dlc_playthrough_5Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Starting &quot;The Count's&quot; Questline</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="dlc_playthrough_totals_5"></span>
             </h4>
@@ -936,9 +914,7 @@
         <div class="card shadow-sm mb-3" id="dlc_playthrough_section_6">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#dlc_playthrough_6Col" data-bs-toggle="collapse" href="#dlc_playthrough_6Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#dlc_playthrough_6Col" data-bs-toggle="collapse" href="#dlc_playthrough_6Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Starting &quot;The Saint's&quot; Questline</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="dlc_playthrough_totals_6"></span>
             </h4>
@@ -1035,9 +1011,7 @@
         <div class="card shadow-sm mb-3" id="dlc_playthrough_section_7">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#dlc_playthrough_7Col" data-bs-toggle="collapse" href="#dlc_playthrough_7Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#dlc_playthrough_7Col" data-bs-toggle="collapse" href="#dlc_playthrough_7Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Shadow Keep</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="dlc_playthrough_totals_7"></span>
             </h4>
@@ -1200,9 +1174,7 @@
         <div class="card shadow-sm mb-3" id="dlc_playthrough_section_8">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#dlc_playthrough_8Col" data-bs-toggle="collapse" href="#dlc_playthrough_8Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#dlc_playthrough_8Col" data-bs-toggle="collapse" href="#dlc_playthrough_8Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Complicated Quest Choices</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="dlc_playthrough_totals_8"></span>
             </h4>
@@ -1282,9 +1254,7 @@
         <div class="card shadow-sm mb-3" id="dlc_playthrough_section_9">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#dlc_playthrough_9Col" data-bs-toggle="collapse" href="#dlc_playthrough_9Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#dlc_playthrough_9Col" data-bs-toggle="collapse" href="#dlc_playthrough_9Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Finishing the Shadow Keep</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="dlc_playthrough_totals_9"></span>
             </h4>
@@ -1394,9 +1364,7 @@
         <div class="card shadow-sm mb-3" id="dlc_playthrough_section_10">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#dlc_playthrough_10Col" data-bs-toggle="collapse" href="#dlc_playthrough_10Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#dlc_playthrough_10Col" data-bs-toggle="collapse" href="#dlc_playthrough_10Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Finishing &quot;The Counts&quot; Questline</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="dlc_playthrough_totals_10"></span>
             </h4>
@@ -1523,9 +1491,7 @@
         <div class="card shadow-sm mb-3" id="dlc_playthrough_section_11">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#dlc_playthrough_11Col" data-bs-toggle="collapse" href="#dlc_playthrough_11Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#dlc_playthrough_11Col" data-bs-toggle="collapse" href="#dlc_playthrough_11Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Finishing &quot;The Lord's&quot; &quot;Quest&quot;</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="dlc_playthrough_totals_11"></span>
             </h4>
@@ -1676,9 +1642,7 @@
         <div class="card shadow-sm mb-3" id="dlc_playthrough_section_12">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#dlc_playthrough_12Col" data-bs-toggle="collapse" href="#dlc_playthrough_12Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#dlc_playthrough_12Col" data-bs-toggle="collapse" href="#dlc_playthrough_12Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Finishing Igon's Questline</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="dlc_playthrough_totals_12"></span>
             </h4>
@@ -1817,9 +1781,7 @@
         <div class="card shadow-sm mb-3" id="dlc_playthrough_section_13">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#dlc_playthrough_13Col" data-bs-toggle="collapse" href="#dlc_playthrough_13Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#dlc_playthrough_13Col" data-bs-toggle="collapse" href="#dlc_playthrough_13Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Continuing the Main Story</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="dlc_playthrough_totals_13"></span>
             </h4>
@@ -1898,9 +1860,7 @@
         <div class="card shadow-sm mb-3" id="dlc_playthrough_section_14">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#dlc_playthrough_14Col" data-bs-toggle="collapse" href="#dlc_playthrough_14Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#dlc_playthrough_14Col" data-bs-toggle="collapse" href="#dlc_playthrough_14Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">The Final Stretch</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="dlc_playthrough_totals_14"></span>
             </h4>

--- a/docs/checklists/dragon_hearts_deathroots.html
+++ b/docs/checklists/dragon_hearts_deathroots.html
@@ -27,14 +27,10 @@
         <a class="navbar-brand me-auto ms-2" href="/index.html">Roundtable Guides</a>
         <form class="d-none d-sm-flex order-2 order-xl-3">
           <input aria-label="search" class="form-control me-2" name="search" placeholder="Search" type="search">
-          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit">
-            <i class="bi bi-search"></i>
-          </button>
+          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit"><i class="bi bi-search"></i></button>
         </form>
         <div class="d-sm-none order-2">
-          <a class="nav-link me-0" href="/search.html">
-            <i class="bi bi-search sb-icon-search"></i>
-          </a>
+          <a class="nav-link me-0" href="/search.html"><i class="bi bi-search sb-icon-search"></i></a>
         </div>
         <div class="collapse navbar-collapse order-3 order-xl-2 ms-xl-2" id="nav-collapse">
           <ul class="nav navbar-nav navbar-nav-scroll mr-auto">
@@ -179,14 +175,10 @@
               </ul>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/map.html">
-                <i class="bi bi-map"></i> Map
-              </a>
+              <a class="nav-link hide-buttons" href="/map.html"><i class="bi bi-map"></i> Map</a>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/options.html">
-                <i class="bi bi-gear-fill"></i> Options
-              </a>
+              <a class="nav-link hide-buttons" href="/options.html"><i class="bi bi-gear-fill"></i> Options</a>
             </li>
           </ul>
         </div>
@@ -206,9 +198,7 @@
       </div>
       <nav class="text-muted toc d-print-none">
         <strong class="d-block h5">
-          <a class="toc-button" data-bs-toggle="collapse" href="#toc_dragon_hearts_death_roots" role="button">
-            <i class="bi bi-plus-lg"></i>Table Of Contents
-          </a>
+          <a class="toc-button" data-bs-toggle="collapse" href="#toc_dragon_hearts_death_roots" role="button"><i class="bi bi-plus-lg"></i>Table Of Contents</a>
         </strong>
         <ul class="toc_page collapse" id="toc_dragon_hearts_death_roots">
           <li>
@@ -228,9 +218,7 @@
         <div class="card shadow-sm mb-3" id="dragon_hearts_death_roots_section_0">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#dragon_hearts_death_roots_0Col" data-bs-toggle="collapse" href="#dragon_hearts_death_roots_0Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#dragon_hearts_death_roots_0Col" data-bs-toggle="collapse" href="#dragon_hearts_death_roots_0Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <img class="me-1" data-src="/img/icons/keys/edited/03230.png" loading="lazy" style="height: 70px; width: 70px">
               <span class="d-print-inline">Dragon Hearts</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="dragon_hearts_death_roots_totals_0"></span>
@@ -242,9 +230,7 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="dragon_hearts_death_roots_0_1" type="checkbox" value="">
                     <label class="form-check-label item_content" for="dragon_hearts_death_roots_0_1">Defeat Flying Dragon Agheel in Agheel Lake (x1)</label>
-                    <a class="ms-2" href="/map.html?target=dragon_hearts_death_roots_0_1&amp;id=dragon_hearts_death_roots_0_1&amp;link=/checklists/dragon_hearts_deathroots.html%23item_0_1&amp;title=Dragon Heart">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=dragon_hearts_death_roots_0_1&amp;id=dragon_hearts_death_roots_0_1&amp;link=/checklists/dragon_hearts_deathroots.html%23item_0_1&amp;title=Dragon Heart"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -254,36 +240,28 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="dragon_hearts_death_roots_0_3" type="checkbox" value="">
                     <label class="form-check-label item_content" for="dragon_hearts_death_roots_0_3">Defeat Glintstone Dragon Smarag, west of Raya Lucaria Academy (x1)</label>
-                    <a class="ms-2" href="/map.html?target=dragon_hearts_death_roots_0_3&amp;id=dragon_hearts_death_roots_0_3&amp;link=/checklists/dragon_hearts_deathroots.html%23item_0_3&amp;title=Dragon Heart">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=dragon_hearts_death_roots_0_3&amp;id=dragon_hearts_death_roots_0_3&amp;link=/checklists/dragon_hearts_deathroots.html%23item_0_3&amp;title=Dragon Heart"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="dragon_hearts_death_roots_0_4" id="item_0_4">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="dragon_hearts_death_roots_0_4" type="checkbox" value="">
                     <label class="form-check-label item_content" for="dragon_hearts_death_roots_0_4">Defeat Magma Wyrm Makar in Ruin-Strewn Precipice (x1)</label>
-                    <a class="ms-2" href="/map.html?target=dragon_hearts_death_roots_0_4&amp;id=dragon_hearts_death_roots_0_4&amp;link=/checklists/dragon_hearts_deathroots.html%23item_0_4&amp;title=Dragon Heart">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=dragon_hearts_death_roots_0_4&amp;id=dragon_hearts_death_roots_0_4&amp;link=/checklists/dragon_hearts_deathroots.html%23item_0_4&amp;title=Dragon Heart"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="dragon_hearts_death_roots_0_5" id="item_0_5">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="dragon_hearts_death_roots_0_5" type="checkbox" value="">
                     <label class="form-check-label item_content" for="dragon_hearts_death_roots_0_5">Defeat the three dragons in Moonlight Altar (x3)</label>
-                    <a class="ms-2" href="/map.html?target=dragon_hearts_death_roots_0_5&amp;id=dragon_hearts_death_roots_0_5&amp;link=/checklists/dragon_hearts_deathroots.html%23item_0_5&amp;title=Dragon Heart x3">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=dragon_hearts_death_roots_0_5&amp;id=dragon_hearts_death_roots_0_5&amp;link=/checklists/dragon_hearts_deathroots.html%23item_0_5&amp;title=Dragon Heart x3"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="dragon_hearts_death_roots_0_2" id="item_0_2">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="dragon_hearts_death_roots_0_2" type="checkbox" value="">
                     <label class="form-check-label item_content" for="dragon_hearts_death_roots_0_2">Defeat Glintstone Dragon Adula in front of the Cathedral of Manus Celes (x3)</label>
-                    <a class="ms-2" href="/map.html?target=dragon_hearts_death_roots_0_2&amp;id=dragon_hearts_death_roots_0_2&amp;link=/checklists/dragon_hearts_deathroots.html%23item_0_2&amp;title=Dragon Heart x3">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=dragon_hearts_death_roots_0_2&amp;id=dragon_hearts_death_roots_0_2&amp;link=/checklists/dragon_hearts_deathroots.html%23item_0_2&amp;title=Dragon Heart x3"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -293,36 +271,28 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="dragon_hearts_death_roots_0_6" type="checkbox" value="">
                     <label class="form-check-label item_content" for="dragon_hearts_death_roots_0_6">Defeat Decaying Ekzykes, northwest of the Cathedral of Dragon Communion (x1)</label>
-                    <a class="ms-2" href="/map.html?target=dragon_hearts_death_roots_0_6&amp;id=dragon_hearts_death_roots_0_6&amp;link=/checklists/dragon_hearts_deathroots.html%23item_0_6&amp;title=Dragon Heart">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=dragon_hearts_death_roots_0_6&amp;id=dragon_hearts_death_roots_0_6&amp;link=/checklists/dragon_hearts_deathroots.html%23item_0_6&amp;title=Dragon Heart"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="dragon_hearts_death_roots_0_7" id="item_0_7">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="dragon_hearts_death_roots_0_7" type="checkbox" value="">
                     <label class="form-check-label item_content" for="dragon_hearts_death_roots_0_7">Defeat Flying Dragon Greyll in the northeast of Caelid on the Farum Greatbridge (x1)</label>
-                    <a class="ms-2" href="/map.html?target=dragon_hearts_death_roots_0_7&amp;id=dragon_hearts_death_roots_0_7&amp;link=/checklists/dragon_hearts_deathroots.html%23item_0_7&amp;title=Dragon Heart">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=dragon_hearts_death_roots_0_7&amp;id=dragon_hearts_death_roots_0_7&amp;link=/checklists/dragon_hearts_deathroots.html%23item_0_7&amp;title=Dragon Heart"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="dragon_hearts_death_roots_0_8" id="item_0_8">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="dragon_hearts_death_roots_0_8" type="checkbox" value="">
                     <label class="form-check-label item_content" for="dragon_hearts_death_roots_0_8">Defeat Elder Dragon Greyoll in front of Fort Faroth (x5)</label>
-                    <a class="ms-2" href="/map.html?target=dragon_hearts_death_roots_0_8&amp;id=dragon_hearts_death_roots_0_8&amp;link=/checklists/dragon_hearts_deathroots.html%23item_0_8&amp;title=Dragon Heart x5">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=dragon_hearts_death_roots_0_8&amp;id=dragon_hearts_death_roots_0_8&amp;link=/checklists/dragon_hearts_deathroots.html%23item_0_8&amp;title=Dragon Heart x5"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="dragon_hearts_death_roots_0_9" id="item_0_9">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="dragon_hearts_death_roots_0_9" type="checkbox" value="">
                     <label class="form-check-label item_content" for="dragon_hearts_death_roots_0_9">Defeat the Magma Wyrm in Gael Tunnel bordering Limgrave (x1)</label>
-                    <a class="ms-2" href="/map.html?target=dragon_hearts_death_roots_0_9&amp;id=dragon_hearts_death_roots_0_9&amp;link=/checklists/dragon_hearts_deathroots.html%23item_0_9&amp;title=Dragon Heart">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=dragon_hearts_death_roots_0_9&amp;id=dragon_hearts_death_roots_0_9&amp;link=/checklists/dragon_hearts_deathroots.html%23item_0_9&amp;title=Dragon Heart"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -332,18 +302,14 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="dragon_hearts_death_roots_0_10" type="checkbox" value="">
                     <label class="form-check-label item_content" for="dragon_hearts_death_roots_0_10">Defeat the Magma Wyrm in Volcano Manor (x1)</label>
-                    <a class="ms-2" href="/map.html?target=dragon_hearts_death_roots_0_10&amp;id=dragon_hearts_death_roots_0_10&amp;link=/checklists/dragon_hearts_deathroots.html%23item_0_10&amp;title=Dragon Heart">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=dragon_hearts_death_roots_0_10&amp;id=dragon_hearts_death_roots_0_10&amp;link=/checklists/dragon_hearts_deathroots.html%23item_0_10&amp;title=Dragon Heart"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="dragon_hearts_death_roots_0_11" id="item_0_11">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="dragon_hearts_death_roots_0_11" type="checkbox" value="">
                     <label class="form-check-label item_content" for="dragon_hearts_death_roots_0_11">Defeat the Magma Wyrm near Seethwater Terminus to the west of Mt. Gelmir (x1)</label>
-                    <a class="ms-2" href="/map.html?target=dragon_hearts_death_roots_0_11&amp;id=dragon_hearts_death_roots_0_11&amp;link=/checklists/dragon_hearts_deathroots.html%23item_0_11&amp;title=Dragon Heart">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=dragon_hearts_death_roots_0_11&amp;id=dragon_hearts_death_roots_0_11&amp;link=/checklists/dragon_hearts_deathroots.html%23item_0_11&amp;title=Dragon Heart"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -353,9 +319,7 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="dragon_hearts_death_roots_0_12" type="checkbox" value="">
                     <label class="form-check-label item_content" for="dragon_hearts_death_roots_0_12">Defeat Borealis, the Freezing Fog in the frozen lake in the northeast (x1)</label>
-                    <a class="ms-2" href="/map.html?target=dragon_hearts_death_roots_0_12&amp;id=dragon_hearts_death_roots_0_12&amp;link=/checklists/dragon_hearts_deathroots.html%23item_0_12&amp;title=Dragon Heart">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=dragon_hearts_death_roots_0_12&amp;id=dragon_hearts_death_roots_0_12&amp;link=/checklists/dragon_hearts_deathroots.html%23item_0_12&amp;title=Dragon Heart"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -365,9 +329,7 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="dragon_hearts_death_roots_0_13" type="checkbox" value="">
                     <label class="form-check-label item_content" for="dragon_hearts_death_roots_0_13">Defeat Great Wyrm Theodorix, north of Albinauric Rise (x3)</label>
-                    <a class="ms-2" href="/map.html?target=dragon_hearts_death_roots_0_13&amp;id=dragon_hearts_death_roots_0_13&amp;link=/checklists/dragon_hearts_deathroots.html%23item_0_13&amp;title=Dragon Heart x3">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=dragon_hearts_death_roots_0_13&amp;id=dragon_hearts_death_roots_0_13&amp;link=/checklists/dragon_hearts_deathroots.html%23item_0_13&amp;title=Dragon Heart x3"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -416,9 +378,7 @@
         <div class="card shadow-sm mb-3" id="dragon_hearts_death_roots_section_1">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#dragon_hearts_death_roots_1Col" data-bs-toggle="collapse" href="#dragon_hearts_death_roots_1Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#dragon_hearts_death_roots_1Col" data-bs-toggle="collapse" href="#dragon_hearts_death_roots_1Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <img class="me-1" data-src="/img/icons/keys/edited/00557.png" loading="lazy" style="width: 70px; height: 69px">
               <span class="d-print-inline">Deathroots</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="dragon_hearts_death_roots_totals_1"></span>
@@ -430,18 +390,14 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="dragon_hearts_death_roots_1_1" type="checkbox" value="">
                     <label class="form-check-label item_content" for="dragon_hearts_death_roots_1_1">Defeat the Tibia Mariner in northeast Limgrave in Summonwater Village</label>
-                    <a class="ms-2" href="/map.html?target=dragon_hearts_death_roots_1_1&amp;id=dragon_hearts_death_roots_1_1&amp;link=/checklists/dragon_hearts_deathroots.html%23item_1_1&amp;title=Deathroot">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=dragon_hearts_death_roots_1_1&amp;id=dragon_hearts_death_roots_1_1&amp;link=/checklists/dragon_hearts_deathroots.html%23item_1_1&amp;title=Deathroot"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="dragon_hearts_death_roots_1_2" id="item_1_2">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="dragon_hearts_death_roots_1_2" type="checkbox" value="">
                     <label class="form-check-label item_content" for="dragon_hearts_death_roots_1_2">In a chest in the boss room of the Deathtouched Catacombs</label>
-                    <a class="ms-2" href="/map.html?target=dragon_hearts_death_roots_1_2&amp;id=dragon_hearts_death_roots_1_2&amp;link=/checklists/dragon_hearts_deathroots.html%23item_1_2&amp;title=Deathroot">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=dragon_hearts_death_roots_1_2&amp;id=dragon_hearts_death_roots_1_2&amp;link=/checklists/dragon_hearts_deathroots.html%23item_1_2&amp;title=Deathroot"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -451,18 +407,14 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="dragon_hearts_death_roots_1_3" type="checkbox" value="">
                     <label class="form-check-label item_content" for="dragon_hearts_death_roots_1_3">In a chest in the main boss room of the Black Knife Catacombs</label>
-                    <a class="ms-2" href="/map.html?target=dragon_hearts_death_roots_1_3&amp;id=dragon_hearts_death_roots_1_3&amp;link=/checklists/dragon_hearts_deathroots.html%23item_1_3&amp;title=Deathroot">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=dragon_hearts_death_roots_1_3&amp;id=dragon_hearts_death_roots_1_3&amp;link=/checklists/dragon_hearts_deathroots.html%23item_1_3&amp;title=Deathroot"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="dragon_hearts_death_roots_1_4" id="item_1_4">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="dragon_hearts_death_roots_1_4" type="checkbox" value="">
                     <label class="form-check-label item_content" for="dragon_hearts_death_roots_1_4">Defeat the Tibia Mariner southwest of Carian Study Hall in east Liurnia of the Lakes</label>
-                    <a class="ms-2" href="/map.html?target=dragon_hearts_death_roots_1_4&amp;id=dragon_hearts_death_roots_1_4&amp;link=/checklists/dragon_hearts_deathroots.html%23item_1_4&amp;title=Deathroot">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=dragon_hearts_death_roots_1_4&amp;id=dragon_hearts_death_roots_1_4&amp;link=/checklists/dragon_hearts_deathroots.html%23item_1_4&amp;title=Deathroot"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -472,18 +424,14 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="dragon_hearts_death_roots_1_5" type="checkbox" value="">
                     <label class="form-check-label item_content" for="dragon_hearts_death_roots_1_5">Defeat the Tibia Mariner in the Wyndham Ruins</label>
-                    <a class="ms-2" href="/map.html?target=dragon_hearts_death_roots_1_5&amp;id=dragon_hearts_death_roots_1_5&amp;link=/checklists/dragon_hearts_deathroots.html%23item_1_5&amp;title=Deathroot">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=dragon_hearts_death_roots_1_5&amp;id=dragon_hearts_death_roots_1_5&amp;link=/checklists/dragon_hearts_deathroots.html%23item_1_5&amp;title=Deathroot"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="dragon_hearts_death_roots_1_6" id="item_1_6">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="dragon_hearts_death_roots_1_6" type="checkbox" value="">
                     <label class="form-check-label item_content" for="dragon_hearts_death_roots_1_6">In a chest in the boss room of the Gelmir Hero's Grave</label>
-                    <a class="ms-2" href="/map.html?target=dragon_hearts_death_roots_1_6&amp;id=dragon_hearts_death_roots_1_6&amp;link=/checklists/dragon_hearts_deathroots.html%23item_1_6&amp;title=Deathroot">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=dragon_hearts_death_roots_1_6&amp;id=dragon_hearts_death_roots_1_6&amp;link=/checklists/dragon_hearts_deathroots.html%23item_1_6&amp;title=Deathroot"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -493,18 +441,14 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="dragon_hearts_death_roots_1_7" type="checkbox" value="">
                     <label class="form-check-label item_content" for="dragon_hearts_death_roots_1_7">In a chest in the boss room of the Giants' Mountaintop Catacombs</label>
-                    <a class="ms-2" href="/map.html?target=dragon_hearts_death_roots_1_7&amp;id=dragon_hearts_death_roots_1_7&amp;link=/checklists/dragon_hearts_deathroots.html%23item_1_7&amp;title=Deathroot">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=dragon_hearts_death_roots_1_7&amp;id=dragon_hearts_death_roots_1_7&amp;link=/checklists/dragon_hearts_deathroots.html%23item_1_7&amp;title=Deathroot"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="dragon_hearts_death_roots_1_8" id="item_1_8">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="dragon_hearts_death_roots_1_8" type="checkbox" value="">
                     <label class="form-check-label item_content" for="dragon_hearts_death_roots_1_8">Defeat the Tibia Mariner south of Castle Sol, on a cliff edge</label>
-                    <a class="ms-2" href="/map.html?target=dragon_hearts_death_roots_1_8&amp;id=dragon_hearts_death_roots_1_8&amp;link=/checklists/dragon_hearts_deathroots.html%23item_1_8&amp;title=Deathroot">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=dragon_hearts_death_roots_1_8&amp;id=dragon_hearts_death_roots_1_8&amp;link=/checklists/dragon_hearts_deathroots.html%23item_1_8&amp;title=Deathroot"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -514,9 +458,7 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="dragon_hearts_death_roots_1_9" type="checkbox" value="">
                     <label class="form-check-label item_content" for="dragon_hearts_death_roots_1_9">In a chest in the boss room at the bottom of the Hidden Path to the Haligtree</label>
-                    <a class="ms-2" href="/map.html?target=dragon_hearts_death_roots_1_9&amp;id=dragon_hearts_death_roots_1_9&amp;link=/checklists/dragon_hearts_deathroots.html%23item_1_9&amp;title=Deathroot">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=dragon_hearts_death_roots_1_9&amp;id=dragon_hearts_death_roots_1_9&amp;link=/checklists/dragon_hearts_deathroots.html%23item_1_9&amp;title=Deathroot"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>

--- a/docs/checklists/flaskof_wondrous_physick.html
+++ b/docs/checklists/flaskof_wondrous_physick.html
@@ -27,14 +27,10 @@
         <a class="navbar-brand me-auto ms-2" href="/index.html">Roundtable Guides</a>
         <form class="d-none d-sm-flex order-2 order-xl-3">
           <input aria-label="search" class="form-control me-2" name="search" placeholder="Search" type="search">
-          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit">
-            <i class="bi bi-search"></i>
-          </button>
+          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit"><i class="bi bi-search"></i></button>
         </form>
         <div class="d-sm-none order-2">
-          <a class="nav-link me-0" href="/search.html">
-            <i class="bi bi-search sb-icon-search"></i>
-          </a>
+          <a class="nav-link me-0" href="/search.html"><i class="bi bi-search sb-icon-search"></i></a>
         </div>
         <div class="collapse navbar-collapse order-3 order-xl-2 ms-xl-2" id="nav-collapse">
           <ul class="nav navbar-nav navbar-nav-scroll mr-auto">
@@ -179,14 +175,10 @@
               </ul>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/map.html">
-                <i class="bi bi-map"></i> Map
-              </a>
+              <a class="nav-link hide-buttons" href="/map.html"><i class="bi bi-map"></i> Map</a>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/options.html">
-                <i class="bi bi-gear-fill"></i> Options
-              </a>
+              <a class="nav-link hide-buttons" href="/options.html"><i class="bi bi-gear-fill"></i> Options</a>
             </li>
           </ul>
         </div>
@@ -206,9 +198,7 @@
       </div>
       <nav class="text-muted toc d-print-none">
         <strong class="d-block h5">
-          <a class="toc-button" data-bs-toggle="collapse" href="#toc_crystal_tears" role="button">
-            <i class="bi bi-plus-lg"></i>Table Of Contents
-          </a>
+          <a class="toc-button" data-bs-toggle="collapse" href="#toc_crystal_tears" role="button"><i class="bi bi-plus-lg"></i>Table Of Contents</a>
         </strong>
         <ul class="toc_page collapse" id="toc_crystal_tears">
           <li>
@@ -260,9 +250,7 @@
         <div class="card shadow-sm mb-3" id="crystal_tears_section_0">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#crystal_tears_0Col" data-bs-toggle="collapse" href="#crystal_tears_0Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#crystal_tears_0Col" data-bs-toggle="collapse" href="#crystal_tears_0Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Limgrave</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="crystal_tears_totals_0"></span>
             </h4>
@@ -274,9 +262,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -305,9 +291,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="crystal_tears_1_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=crystal_tears_1_1&amp;id=crystal_tears_1_1&amp;link=/checklists/flaskof_wondrous_physick.html%23item_1_1&amp;title=Strength-Knot Crystal Tear">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=crystal_tears_1_1&amp;id=crystal_tears_1_1&amp;link=/checklists/flaskof_wondrous_physick.html%23item_1_1&amp;title=Strength-Knot Crystal Tear"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -340,9 +324,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="crystal_tears_1_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=crystal_tears_1_2&amp;id=crystal_tears_1_2&amp;link=/checklists/flaskof_wondrous_physick.html%23item_1_2&amp;title=Spiked Cracked Tear">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=crystal_tears_1_2&amp;id=crystal_tears_1_2&amp;link=/checklists/flaskof_wondrous_physick.html%23item_1_2&amp;title=Spiked Cracked Tear"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -375,9 +357,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="crystal_tears_1_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=crystal_tears_1_3&amp;id=crystal_tears_1_3&amp;link=/checklists/flaskof_wondrous_physick.html%23item_1_3&amp;title=Greenspill Crystal Tear">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=crystal_tears_1_3&amp;id=crystal_tears_1_3&amp;link=/checklists/flaskof_wondrous_physick.html%23item_1_3&amp;title=Greenspill Crystal Tear"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -410,9 +390,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="crystal_tears_1_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=crystal_tears_1_4&amp;id=crystal_tears_1_4&amp;link=/checklists/flaskof_wondrous_physick.html%23item_1_4&amp;title=Crimson Crystal Tear [1]">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=crystal_tears_1_4&amp;id=crystal_tears_1_4&amp;link=/checklists/flaskof_wondrous_physick.html%23item_1_4&amp;title=Crimson Crystal Tear [1]"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -446,9 +424,7 @@
         <div class="card shadow-sm mb-3" id="crystal_tears_section_1">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#crystal_tears_1Col" data-bs-toggle="collapse" href="#crystal_tears_1Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#crystal_tears_1Col" data-bs-toggle="collapse" href="#crystal_tears_1Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Weeping Peninsula</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="crystal_tears_totals_1"></span>
             </h4>
@@ -460,9 +436,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -491,9 +465,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="crystal_tears_0_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=crystal_tears_0_1&amp;id=crystal_tears_0_1&amp;link=/checklists/flaskof_wondrous_physick.html%23item_0_1&amp;title=Faith-Knot Crystal Tear">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=crystal_tears_0_1&amp;id=crystal_tears_0_1&amp;link=/checklists/flaskof_wondrous_physick.html%23item_0_1&amp;title=Faith-Knot Crystal Tear"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -526,9 +498,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="crystal_tears_0_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=crystal_tears_0_2&amp;id=crystal_tears_0_2&amp;link=/checklists/flaskof_wondrous_physick.html%23item_0_2&amp;title=Crimsonburst Crystal Tear">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=crystal_tears_0_2&amp;id=crystal_tears_0_2&amp;link=/checklists/flaskof_wondrous_physick.html%23item_0_2&amp;title=Crimsonburst Crystal Tear"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -561,9 +531,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="crystal_tears_0_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=crystal_tears_0_3&amp;id=crystal_tears_0_3&amp;link=/checklists/flaskof_wondrous_physick.html%23item_0_3&amp;title=Opaline Bubbletear">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=crystal_tears_0_3&amp;id=crystal_tears_0_3&amp;link=/checklists/flaskof_wondrous_physick.html%23item_0_3&amp;title=Opaline Bubbletear"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -597,9 +565,7 @@
         <div class="card shadow-sm mb-3" id="crystal_tears_section_2">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#crystal_tears_2Col" data-bs-toggle="collapse" href="#crystal_tears_2Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#crystal_tears_2Col" data-bs-toggle="collapse" href="#crystal_tears_2Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Liurnia of the Lakes</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="crystal_tears_totals_2"></span>
             </h4>
@@ -611,9 +577,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -642,9 +606,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="crystal_tears_2_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=crystal_tears_2_1&amp;id=crystal_tears_2_1&amp;link=/checklists/flaskof_wondrous_physick.html%23item_2_1&amp;title=Dexterity-Knot Crystal Tear">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=crystal_tears_2_1&amp;id=crystal_tears_2_1&amp;link=/checklists/flaskof_wondrous_physick.html%23item_2_1&amp;title=Dexterity-Knot Crystal Tear"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -677,9 +639,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="crystal_tears_2_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=crystal_tears_2_2&amp;id=crystal_tears_2_2&amp;link=/checklists/flaskof_wondrous_physick.html%23item_2_2&amp;title=Ruptured Crystal Tear [1]">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=crystal_tears_2_2&amp;id=crystal_tears_2_2&amp;link=/checklists/flaskof_wondrous_physick.html%23item_2_2&amp;title=Ruptured Crystal Tear [1]"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -712,9 +672,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="crystal_tears_2_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=crystal_tears_2_3&amp;id=crystal_tears_2_3&amp;link=/checklists/flaskof_wondrous_physick.html%23item_2_3&amp;title=Cerulean Crystal Tear [1]">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=crystal_tears_2_3&amp;id=crystal_tears_2_3&amp;link=/checklists/flaskof_wondrous_physick.html%23item_2_3&amp;title=Cerulean Crystal Tear [1]"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -747,9 +705,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="crystal_tears_2_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=crystal_tears_2_4&amp;id=crystal_tears_2_4&amp;link=/checklists/flaskof_wondrous_physick.html%23item_2_4&amp;title=Lightning-Shrouding Cracked Tear">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=crystal_tears_2_4&amp;id=crystal_tears_2_4&amp;link=/checklists/flaskof_wondrous_physick.html%23item_2_4&amp;title=Lightning-Shrouding Cracked Tear"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -782,9 +738,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="crystal_tears_2_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=crystal_tears_2_5&amp;id=crystal_tears_2_5&amp;link=/checklists/flaskof_wondrous_physick.html%23item_2_5&amp;title=Holy-Shrouding Cracked Tear">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=crystal_tears_2_5&amp;id=crystal_tears_2_5&amp;link=/checklists/flaskof_wondrous_physick.html%23item_2_5&amp;title=Holy-Shrouding Cracked Tear"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -817,9 +771,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="crystal_tears_2_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=crystal_tears_2_6&amp;id=crystal_tears_2_6&amp;link=/checklists/flaskof_wondrous_physick.html%23item_2_6&amp;title=Magic-Shrouding Cracked Tear">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=crystal_tears_2_6&amp;id=crystal_tears_2_6&amp;link=/checklists/flaskof_wondrous_physick.html%23item_2_6&amp;title=Magic-Shrouding Cracked Tear"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -852,9 +804,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="crystal_tears_2_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=crystal_tears_2_7&amp;id=crystal_tears_2_7&amp;link=/checklists/flaskof_wondrous_physick.html%23item_2_7&amp;title=Intelligence-Knot Crystal Tear">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=crystal_tears_2_7&amp;id=crystal_tears_2_7&amp;link=/checklists/flaskof_wondrous_physick.html%23item_2_7&amp;title=Intelligence-Knot Crystal Tear"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -888,9 +838,7 @@
         <div class="card shadow-sm mb-3" id="crystal_tears_section_3">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#crystal_tears_3Col" data-bs-toggle="collapse" href="#crystal_tears_3Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#crystal_tears_3Col" data-bs-toggle="collapse" href="#crystal_tears_3Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Caelid</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="crystal_tears_totals_3"></span>
             </h4>
@@ -902,9 +850,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -933,9 +879,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="crystal_tears_3_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=crystal_tears_3_1&amp;id=crystal_tears_3_1&amp;link=/checklists/flaskof_wondrous_physick.html%23item_3_1&amp;title=Flame-Shrouding Cracked Tear">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=crystal_tears_3_1&amp;id=crystal_tears_3_1&amp;link=/checklists/flaskof_wondrous_physick.html%23item_3_1&amp;title=Flame-Shrouding Cracked Tear"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -968,9 +912,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="crystal_tears_3_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=crystal_tears_3_2&amp;id=crystal_tears_3_2&amp;link=/checklists/flaskof_wondrous_physick.html%23item_3_2&amp;title=Greenburst Crystal Tear">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=crystal_tears_3_2&amp;id=crystal_tears_3_2&amp;link=/checklists/flaskof_wondrous_physick.html%23item_3_2&amp;title=Greenburst Crystal Tear"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1003,9 +945,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="crystal_tears_3_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=crystal_tears_3_3&amp;id=crystal_tears_3_3&amp;link=/checklists/flaskof_wondrous_physick.html%23item_3_3&amp;title=Opaline Hardtear">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=crystal_tears_3_3&amp;id=crystal_tears_3_3&amp;link=/checklists/flaskof_wondrous_physick.html%23item_3_3&amp;title=Opaline Hardtear"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1038,9 +978,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="crystal_tears_3_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=crystal_tears_3_4&amp;id=crystal_tears_3_4&amp;link=/checklists/flaskof_wondrous_physick.html%23item_3_4&amp;title=Stonebarb Cracked Tear">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=crystal_tears_3_4&amp;id=crystal_tears_3_4&amp;link=/checklists/flaskof_wondrous_physick.html%23item_3_4&amp;title=Stonebarb Cracked Tear"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1073,9 +1011,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="crystal_tears_3_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=crystal_tears_3_5&amp;id=crystal_tears_3_5&amp;link=/checklists/flaskof_wondrous_physick.html%23item_3_5&amp;title=Windy Crystal Tear">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=crystal_tears_3_5&amp;id=crystal_tears_3_5&amp;link=/checklists/flaskof_wondrous_physick.html%23item_3_5&amp;title=Windy Crystal Tear"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1109,9 +1045,7 @@
         <div class="card shadow-sm mb-3" id="crystal_tears_section_4">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#crystal_tears_4Col" data-bs-toggle="collapse" href="#crystal_tears_4Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#crystal_tears_4Col" data-bs-toggle="collapse" href="#crystal_tears_4Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Altus Plateau</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="crystal_tears_totals_4"></span>
             </h4>
@@ -1123,9 +1057,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -1154,9 +1086,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="crystal_tears_4_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=crystal_tears_4_1&amp;id=crystal_tears_4_1&amp;link=/checklists/flaskof_wondrous_physick.html%23item_4_1&amp;title=Purifying Crystal Tear">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=crystal_tears_4_1&amp;id=crystal_tears_4_1&amp;link=/checklists/flaskof_wondrous_physick.html%23item_4_1&amp;title=Purifying Crystal Tear"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1189,9 +1119,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="crystal_tears_4_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=crystal_tears_4_2&amp;id=crystal_tears_4_2&amp;link=/checklists/flaskof_wondrous_physick.html%23item_4_2&amp;title=Speckled Hardtear">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=crystal_tears_4_2&amp;id=crystal_tears_4_2&amp;link=/checklists/flaskof_wondrous_physick.html%23item_4_2&amp;title=Speckled Hardtear"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1224,9 +1152,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="crystal_tears_4_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=crystal_tears_4_3&amp;id=crystal_tears_4_3&amp;link=/checklists/flaskof_wondrous_physick.html%23item_4_3&amp;title=Crimsonspill Crystal Tear">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=crystal_tears_4_3&amp;id=crystal_tears_4_3&amp;link=/checklists/flaskof_wondrous_physick.html%23item_4_3&amp;title=Crimsonspill Crystal Tear"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1260,9 +1186,7 @@
         <div class="card shadow-sm mb-3" id="crystal_tears_section_5">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#crystal_tears_5Col" data-bs-toggle="collapse" href="#crystal_tears_5Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#crystal_tears_5Col" data-bs-toggle="collapse" href="#crystal_tears_5Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Mt. Gelmir</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="crystal_tears_totals_5"></span>
             </h4>
@@ -1274,9 +1198,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -1305,9 +1227,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="crystal_tears_5_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=crystal_tears_5_1&amp;id=crystal_tears_5_1&amp;link=/checklists/flaskof_wondrous_physick.html%23item_5_1&amp;title=Leaden Hardtear">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=crystal_tears_5_1&amp;id=crystal_tears_5_1&amp;link=/checklists/flaskof_wondrous_physick.html%23item_5_1&amp;title=Leaden Hardtear"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1340,9 +1260,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="crystal_tears_5_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=crystal_tears_5_2&amp;id=crystal_tears_5_2&amp;link=/checklists/flaskof_wondrous_physick.html%23item_5_2&amp;title=Cerulean Hidden Tear">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=crystal_tears_5_2&amp;id=crystal_tears_5_2&amp;link=/checklists/flaskof_wondrous_physick.html%23item_5_2&amp;title=Cerulean Hidden Tear"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1376,9 +1294,7 @@
         <div class="card shadow-sm mb-3" id="crystal_tears_section_6">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#crystal_tears_6Col" data-bs-toggle="collapse" href="#crystal_tears_6Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#crystal_tears_6Col" data-bs-toggle="collapse" href="#crystal_tears_6Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Leyndell, Royal Capital</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="crystal_tears_totals_6"></span>
             </h4>
@@ -1390,9 +1306,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -1421,9 +1335,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="crystal_tears_6_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=crystal_tears_6_1&amp;id=crystal_tears_6_1&amp;link=/checklists/flaskof_wondrous_physick.html%23item_6_1&amp;title=Winged Crystal Tear">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=crystal_tears_6_1&amp;id=crystal_tears_6_1&amp;link=/checklists/flaskof_wondrous_physick.html%23item_6_1&amp;title=Winged Crystal Tear"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1456,9 +1368,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="crystal_tears_6_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=crystal_tears_6_2&amp;id=crystal_tears_6_2&amp;link=/checklists/flaskof_wondrous_physick.html%23item_6_2&amp;title=Twiggy Cracked Tear">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=crystal_tears_6_2&amp;id=crystal_tears_6_2&amp;link=/checklists/flaskof_wondrous_physick.html%23item_6_2&amp;title=Twiggy Cracked Tear"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1491,9 +1401,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="crystal_tears_6_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=crystal_tears_6_3&amp;id=crystal_tears_6_3&amp;link=/checklists/flaskof_wondrous_physick.html%23item_6_3&amp;title=Crimson Crystal Tear [2]">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=crystal_tears_6_3&amp;id=crystal_tears_6_3&amp;link=/checklists/flaskof_wondrous_physick.html%23item_6_3&amp;title=Crimson Crystal Tear [2]"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1527,9 +1435,7 @@
         <div class="card shadow-sm mb-3" id="crystal_tears_section_7">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#crystal_tears_7Col" data-bs-toggle="collapse" href="#crystal_tears_7Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#crystal_tears_7Col" data-bs-toggle="collapse" href="#crystal_tears_7Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Mountaintops of the Giants</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="crystal_tears_totals_7"></span>
             </h4>
@@ -1541,9 +1447,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -1572,9 +1476,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="crystal_tears_7_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=crystal_tears_7_1&amp;id=crystal_tears_7_1&amp;link=/checklists/flaskof_wondrous_physick.html%23item_7_1&amp;title=Crimsonwhorl Bubbletear">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=crystal_tears_7_1&amp;id=crystal_tears_7_1&amp;link=/checklists/flaskof_wondrous_physick.html%23item_7_1&amp;title=Crimsonwhorl Bubbletear"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1607,9 +1509,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="crystal_tears_8_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=crystal_tears_8_1&amp;id=crystal_tears_8_1&amp;link=/checklists/flaskof_wondrous_physick.html%23item_8_1&amp;title=Cerulean Crystal Tear [2]">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=crystal_tears_8_1&amp;id=crystal_tears_8_1&amp;link=/checklists/flaskof_wondrous_physick.html%23item_8_1&amp;title=Cerulean Crystal Tear [2]"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1642,9 +1542,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="crystal_tears_8_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=crystal_tears_8_2&amp;id=crystal_tears_8_2&amp;link=/checklists/flaskof_wondrous_physick.html%23item_8_2&amp;title=Crimson Bubbletear">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=crystal_tears_8_2&amp;id=crystal_tears_8_2&amp;link=/checklists/flaskof_wondrous_physick.html%23item_8_2&amp;title=Crimson Bubbletear"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1678,9 +1576,7 @@
         <div class="card shadow-sm mb-3" id="crystal_tears_section_8">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#crystal_tears_8Col" data-bs-toggle="collapse" href="#crystal_tears_8Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#crystal_tears_8Col" data-bs-toggle="collapse" href="#crystal_tears_8Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Consecrated Snowfield</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="crystal_tears_totals_8"></span>
             </h4>
@@ -1692,9 +1588,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -1723,9 +1617,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="crystal_tears_8_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=crystal_tears_8_3&amp;id=crystal_tears_8_3&amp;link=/checklists/flaskof_wondrous_physick.html%23item_8_3&amp;title=Thorny Cracked Tear">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=crystal_tears_8_3&amp;id=crystal_tears_8_3&amp;link=/checklists/flaskof_wondrous_physick.html%23item_8_3&amp;title=Thorny Cracked Tear"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1758,9 +1650,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="crystal_tears_8_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=crystal_tears_8_4&amp;id=crystal_tears_8_4&amp;link=/checklists/flaskof_wondrous_physick.html%23item_8_4&amp;title=Ruptured Crystal Tear [2]">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=crystal_tears_8_4&amp;id=crystal_tears_8_4&amp;link=/checklists/flaskof_wondrous_physick.html%23item_8_4&amp;title=Ruptured Crystal Tear [2]"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1794,9 +1684,7 @@
         <div class="card shadow-sm mb-3" id="crystal_tears_section_9">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#crystal_tears_9Col" data-bs-toggle="collapse" href="#crystal_tears_9Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#crystal_tears_9Col" data-bs-toggle="collapse" href="#crystal_tears_9Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Realm of Shadow</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="crystal_tears_totals_9"></span>
             </h4>
@@ -1808,9 +1696,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -1839,9 +1725,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="crystal_tears_20_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=crystal_tears_20_1&amp;id=crystal_tears_20_1&amp;link=/checklists/flaskof_wondrous_physick.html%23item_20_1&amp;title=Viridian Hidden Tear">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=crystal_tears_20_1&amp;id=crystal_tears_20_1&amp;link=/checklists/flaskof_wondrous_physick.html%23item_20_1&amp;title=Viridian Hidden Tear"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1874,9 +1758,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="crystal_tears_20_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=crystal_tears_20_2&amp;id=crystal_tears_20_2&amp;link=/checklists/flaskof_wondrous_physick.html%23item_20_2&amp;title=Crimsonburst Dried Tear">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=crystal_tears_20_2&amp;id=crystal_tears_20_2&amp;link=/checklists/flaskof_wondrous_physick.html%23item_20_2&amp;title=Crimsonburst Dried Tear"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1909,9 +1791,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="crystal_tears_20_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=crystal_tears_20_3&amp;id=crystal_tears_20_3&amp;link=/checklists/flaskof_wondrous_physick.html%23item_20_3&amp;title=Crimson-Sapping Cracked Tear">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=crystal_tears_20_3&amp;id=crystal_tears_20_3&amp;link=/checklists/flaskof_wondrous_physick.html%23item_20_3&amp;title=Crimson-Sapping Cracked Tear"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1944,9 +1824,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="crystal_tears_20_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=crystal_tears_20_4&amp;id=crystal_tears_20_4&amp;link=/checklists/flaskof_wondrous_physick.html%23item_20_4&amp;title=Cerulean-Sapping Cracked Tear">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=crystal_tears_20_4&amp;id=crystal_tears_20_4&amp;link=/checklists/flaskof_wondrous_physick.html%23item_20_4&amp;title=Cerulean-Sapping Cracked Tear"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1979,9 +1857,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="crystal_tears_20_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=crystal_tears_20_5&amp;id=crystal_tears_20_5&amp;link=/checklists/flaskof_wondrous_physick.html%23item_20_5&amp;title=Oil-Soaked Tear">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=crystal_tears_20_5&amp;id=crystal_tears_20_5&amp;link=/checklists/flaskof_wondrous_physick.html%23item_20_5&amp;title=Oil-Soaked Tear"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2014,9 +1890,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="crystal_tears_20_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=crystal_tears_20_6&amp;id=crystal_tears_20_6&amp;link=/checklists/flaskof_wondrous_physick.html%23item_20_6&amp;title=Bloodsucking Cracked Tear">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=crystal_tears_20_6&amp;id=crystal_tears_20_6&amp;link=/checklists/flaskof_wondrous_physick.html%23item_20_6&amp;title=Bloodsucking Cracked Tear"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2049,9 +1923,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="crystal_tears_20_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=crystal_tears_20_7&amp;id=crystal_tears_20_7&amp;link=/checklists/flaskof_wondrous_physick.html%23item_20_7&amp;title=Glovewort Crystal Tear">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=crystal_tears_20_7&amp;id=crystal_tears_20_7&amp;link=/checklists/flaskof_wondrous_physick.html%23item_20_7&amp;title=Glovewort Crystal Tear"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2084,9 +1956,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="crystal_tears_20_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=crystal_tears_20_8&amp;id=crystal_tears_20_8&amp;link=/checklists/flaskof_wondrous_physick.html%23item_20_8&amp;title=Deflecting Hardtear">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=crystal_tears_20_8&amp;id=crystal_tears_20_8&amp;link=/checklists/flaskof_wondrous_physick.html%23item_20_8&amp;title=Deflecting Hardtear"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">

--- a/docs/checklists/gestures.html
+++ b/docs/checklists/gestures.html
@@ -27,14 +27,10 @@
         <a class="navbar-brand me-auto ms-2" href="/index.html">Roundtable Guides</a>
         <form class="d-none d-sm-flex order-2 order-xl-3">
           <input aria-label="search" class="form-control me-2" name="search" placeholder="Search" type="search">
-          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit">
-            <i class="bi bi-search"></i>
-          </button>
+          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit"><i class="bi bi-search"></i></button>
         </form>
         <div class="d-sm-none order-2">
-          <a class="nav-link me-0" href="/search.html">
-            <i class="bi bi-search sb-icon-search"></i>
-          </a>
+          <a class="nav-link me-0" href="/search.html"><i class="bi bi-search sb-icon-search"></i></a>
         </div>
         <div class="collapse navbar-collapse order-3 order-xl-2 ms-xl-2" id="nav-collapse">
           <ul class="nav navbar-nav navbar-nav-scroll mr-auto">
@@ -179,14 +175,10 @@
               </ul>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/map.html">
-                <i class="bi bi-map"></i> Map
-              </a>
+              <a class="nav-link hide-buttons" href="/map.html"><i class="bi bi-map"></i> Map</a>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/options.html">
-                <i class="bi bi-gear-fill"></i> Options
-              </a>
+              <a class="nav-link hide-buttons" href="/options.html"><i class="bi bi-gear-fill"></i> Options</a>
             </li>
           </ul>
         </div>
@@ -206,9 +198,7 @@
       </div>
       <nav class="text-muted toc d-print-none">
         <strong class="d-block h5">
-          <a class="toc-button" data-bs-toggle="collapse" href="#toc_gestures" role="button">
-            <i class="bi bi-plus-lg"></i>Table Of Contents
-          </a>
+          <a class="toc-button" data-bs-toggle="collapse" href="#toc_gestures" role="button"><i class="bi bi-plus-lg"></i>Table Of Contents</a>
         </strong>
         <ul class="toc_page collapse" id="toc_gestures">
           <li>
@@ -260,9 +250,7 @@
         <div class="card shadow-sm mb-3" id="gestures_section_0">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#gestures_0Col" data-bs-toggle="collapse" href="#gestures_0Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#gestures_0Col" data-bs-toggle="collapse" href="#gestures_0Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Starting Gestures</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="gestures_totals_0"></span>
             </h4>
@@ -371,9 +359,7 @@
         <div class="card shadow-sm mb-3" id="gestures_section_1">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#gestures_1Col" data-bs-toggle="collapse" href="#gestures_1Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#gestures_1Col" data-bs-toggle="collapse" href="#gestures_1Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Limgrave</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="gestures_totals_1"></span>
             </h4>
@@ -385,9 +371,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -421,9 +405,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="gestures_1_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=gestures_1_1&amp;id=gestures_1_1&amp;link=/checklists/gestures.html%23item_1_1&amp;title=Strength!">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=gestures_1_1&amp;id=gestures_1_1&amp;link=/checklists/gestures.html%23item_1_1&amp;title=Strength!"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -459,9 +441,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="gestures_1_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=gestures_1_2&amp;id=gestures_1_2&amp;link=/checklists/gestures.html%23item_1_2&amp;title=The Ring">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=gestures_1_2&amp;id=gestures_1_2&amp;link=/checklists/gestures.html%23item_1_2&amp;title=The Ring"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -497,9 +477,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="gestures_1_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=gestures_1_3&amp;id=gestures_1_3&amp;link=/checklists/gestures.html%23item_1_3&amp;title=Nod in Thought">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=gestures_1_3&amp;id=gestures_1_3&amp;link=/checklists/gestures.html%23item_1_3&amp;title=Nod in Thought"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -536,9 +514,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="gestures_1_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=gestures_1_4&amp;id=gestures_1_4&amp;link=/checklists/gestures.html%23item_1_4&amp;title=Grovel for Mercy">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=gestures_1_4&amp;id=gestures_1_4&amp;link=/checklists/gestures.html%23item_1_4&amp;title=Grovel for Mercy"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -575,9 +551,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="gestures_1_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=gestures_1_5&amp;id=gestures_1_5&amp;link=/checklists/gestures.html%23item_1_5&amp;title=Extreme Repentance">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=gestures_1_5&amp;id=gestures_1_5&amp;link=/checklists/gestures.html%23item_1_5&amp;title=Extreme Repentance"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -614,9 +588,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="gestures_1_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=gestures_1_6&amp;id=gestures_1_6&amp;link=/checklists/gestures.html%23item_1_6&amp;title=Calm Down!">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=gestures_1_6&amp;id=gestures_1_6&amp;link=/checklists/gestures.html%23item_1_6&amp;title=Calm Down!"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -653,9 +625,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="gestures_1_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=gestures_1_7&amp;id=gestures_1_7&amp;link=/checklists/gestures.html%23item_1_7&amp;title=Finger Snap">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=gestures_1_7&amp;id=gestures_1_7&amp;link=/checklists/gestures.html%23item_1_7&amp;title=Finger Snap"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -692,9 +662,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="gestures_1_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=gestures_1_8&amp;id=gestures_1_8&amp;link=/checklists/gestures.html%23item_1_8&amp;title=Triumphant Delight">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=gestures_1_8&amp;id=gestures_1_8&amp;link=/checklists/gestures.html%23item_1_8&amp;title=Triumphant Delight"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -731,9 +699,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="gestures_1_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=gestures_1_9&amp;id=gestures_1_9&amp;link=/checklists/gestures.html%23item_1_9&amp;title=Crossed Legs">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=gestures_1_9&amp;id=gestures_1_9&amp;link=/checklists/gestures.html%23item_1_9&amp;title=Crossed Legs"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -769,9 +735,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="gestures_1_10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=gestures_1_10&amp;id=gestures_1_10&amp;link=/checklists/gestures.html%23item_1_10&amp;title=Sitting Sideways">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=gestures_1_10&amp;id=gestures_1_10&amp;link=/checklists/gestures.html%23item_1_10&amp;title=Sitting Sideways"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -808,9 +772,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="gestures_1_11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=gestures_1_11&amp;id=gestures_1_11&amp;link=/checklists/gestures.html%23item_1_11&amp;title=Dozing Cross-Legged">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=gestures_1_11&amp;id=gestures_1_11&amp;link=/checklists/gestures.html%23item_1_11&amp;title=Dozing Cross-Legged"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -846,9 +808,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="gestures_1_12" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=gestures_1_12&amp;id=gestures_1_12&amp;link=/checklists/gestures.html%23item_1_12&amp;title=Bravo!">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=gestures_1_12&amp;id=gestures_1_12&amp;link=/checklists/gestures.html%23item_1_12&amp;title=Bravo!"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -884,9 +844,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="gestures_1_13" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=gestures_1_13&amp;id=gestures_1_13&amp;link=/checklists/gestures.html%23item_1_13&amp;title=Patches' Crouch">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=gestures_1_13&amp;id=gestures_1_13&amp;link=/checklists/gestures.html%23item_1_13&amp;title=Patches' Crouch"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -924,9 +882,7 @@
         <div class="card shadow-sm mb-3" id="gestures_section_2">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#gestures_2Col" data-bs-toggle="collapse" href="#gestures_2Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#gestures_2Col" data-bs-toggle="collapse" href="#gestures_2Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Roundtable Hold</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="gestures_totals_2"></span>
             </h4>
@@ -938,9 +894,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -974,9 +928,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="gestures_2_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=gestures_2_1&amp;id=gestures_2_1&amp;link=/checklists/gestures.html%23item_2_1&amp;title=Prayer">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=gestures_2_1&amp;id=gestures_2_1&amp;link=/checklists/gestures.html%23item_2_1&amp;title=Prayer"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1012,9 +964,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="gestures_2_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=gestures_2_2&amp;id=gestures_2_2&amp;link=/checklists/gestures.html%23item_2_2&amp;title=What Do You Want?">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=gestures_2_2&amp;id=gestures_2_2&amp;link=/checklists/gestures.html%23item_2_2&amp;title=What Do You Want?"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1050,9 +1000,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="gestures_2_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=gestures_2_3&amp;id=gestures_2_3&amp;link=/checklists/gestures.html%23item_2_3&amp;title=Reverential Bow">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=gestures_2_3&amp;id=gestures_2_3&amp;link=/checklists/gestures.html%23item_2_3&amp;title=Reverential Bow"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1087,9 +1035,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="gestures_2_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=gestures_2_4&amp;id=gestures_2_4&amp;link=/checklists/gestures.html%23item_2_4&amp;title=Curtsy">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=gestures_2_4&amp;id=gestures_2_4&amp;link=/checklists/gestures.html%23item_2_4&amp;title=Curtsy"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1125,9 +1071,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="gestures_2_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=gestures_2_5&amp;id=gestures_2_5&amp;link=/checklists/gestures.html%23item_2_5&amp;title=Rapture">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=gestures_2_5&amp;id=gestures_2_5&amp;link=/checklists/gestures.html%23item_2_5&amp;title=Rapture"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1163,9 +1107,7 @@
         <div class="card shadow-sm mb-3" id="gestures_section_3">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#gestures_3Col" data-bs-toggle="collapse" href="#gestures_3Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#gestures_3Col" data-bs-toggle="collapse" href="#gestures_3Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Liurnia of the Lakes</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="gestures_totals_3"></span>
             </h4>
@@ -1177,9 +1119,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -1213,9 +1153,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="gestures_3_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=gestures_3_1&amp;id=gestures_3_1&amp;link=/checklists/gestures.html%23item_3_1&amp;title=As You Wish">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=gestures_3_1&amp;id=gestures_3_1&amp;link=/checklists/gestures.html%23item_3_1&amp;title=As You Wish"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1251,9 +1189,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="gestures_3_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=gestures_3_2&amp;id=gestures_3_2&amp;link=/checklists/gestures.html%23item_3_2&amp;title=Fire Spur Me">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=gestures_3_2&amp;id=gestures_3_2&amp;link=/checklists/gestures.html%23item_3_2&amp;title=Fire Spur Me"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1288,9 +1224,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="gestures_3_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=gestures_3_3&amp;id=gestures_3_3&amp;link=/checklists/gestures.html%23item_3_3&amp;title=Spread Out">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=gestures_3_3&amp;id=gestures_3_3&amp;link=/checklists/gestures.html%23item_3_3&amp;title=Spread Out"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1327,9 +1261,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="gestures_3_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=gestures_3_4&amp;id=gestures_3_4&amp;link=/checklists/gestures.html%23item_3_4&amp;title=Erudition">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=gestures_3_4&amp;id=gestures_3_4&amp;link=/checklists/gestures.html%23item_3_4&amp;title=Erudition"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1366,9 +1298,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="gestures_3_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=gestures_3_5&amp;id=gestures_3_5&amp;link=/checklists/gestures.html%23item_3_5&amp;title=Balled Up">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=gestures_3_5&amp;id=gestures_3_5&amp;link=/checklists/gestures.html%23item_3_5&amp;title=Balled Up"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1404,9 +1334,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="gestures_3_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=gestures_3_6&amp;id=gestures_3_6&amp;link=/checklists/gestures.html%23item_3_6&amp;title=Casual Greeting (option 1)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=gestures_3_6&amp;id=gestures_3_6&amp;link=/checklists/gestures.html%23item_3_6&amp;title=Casual Greeting (option 1)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1443,9 +1371,7 @@
         <div class="card shadow-sm mb-3" id="gestures_section_4">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#gestures_4Col" data-bs-toggle="collapse" href="#gestures_4Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#gestures_4Col" data-bs-toggle="collapse" href="#gestures_4Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Caelid</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="gestures_totals_4"></span>
             </h4>
@@ -1457,9 +1383,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -1493,9 +1417,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="gestures_4_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=gestures_4_1&amp;id=gestures_4_1&amp;link=/checklists/gestures.html%23item_4_1&amp;title=Desperate Prayer">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=gestures_4_1&amp;id=gestures_4_1&amp;link=/checklists/gestures.html%23item_4_1&amp;title=Desperate Prayer"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1532,9 +1454,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="gestures_4_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=gestures_4_2&amp;id=gestures_4_2&amp;link=/checklists/gestures.html%23item_4_2&amp;title=Heartening Cry">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=gestures_4_2&amp;id=gestures_4_2&amp;link=/checklists/gestures.html%23item_4_2&amp;title=Heartening Cry"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1571,9 +1491,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="gestures_4_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=gestures_4_3&amp;id=gestures_4_3&amp;link=/checklists/gestures.html%23item_4_3&amp;title=Polite Bow">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=gestures_4_3&amp;id=gestures_4_3&amp;link=/checklists/gestures.html%23item_4_3&amp;title=Polite Bow"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1609,9 +1527,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="gestures_4_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=gestures_4_4&amp;id=gestures_4_4&amp;link=/checklists/gestures.html%23item_4_4&amp;title=Casual Greeting (option 2)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=gestures_4_4&amp;id=gestures_4_4&amp;link=/checklists/gestures.html%23item_4_4&amp;title=Casual Greeting (option 2)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1648,9 +1564,7 @@
         <div class="card shadow-sm mb-3" id="gestures_section_5">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#gestures_5Col" data-bs-toggle="collapse" href="#gestures_5Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#gestures_5Col" data-bs-toggle="collapse" href="#gestures_5Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Mt. Gelmir</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="gestures_totals_5"></span>
             </h4>
@@ -1662,9 +1576,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -1698,9 +1610,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="gestures_5_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=gestures_5_1&amp;id=gestures_5_1&amp;link=/checklists/gestures.html%23item_5_1&amp;title=My Thanks">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=gestures_5_1&amp;id=gestures_5_1&amp;link=/checklists/gestures.html%23item_5_1&amp;title=My Thanks"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1738,9 +1648,7 @@
         <div class="card shadow-sm mb-3" id="gestures_section_6">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#gestures_6Col" data-bs-toggle="collapse" href="#gestures_6Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#gestures_6Col" data-bs-toggle="collapse" href="#gestures_6Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Leyndell, Royal Capital</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="gestures_totals_6"></span>
             </h4>
@@ -1752,9 +1660,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -1788,9 +1694,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="gestures_6_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=gestures_6_1&amp;id=gestures_6_1&amp;link=/checklists/gestures.html%23item_6_1&amp;title=Outer Order">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=gestures_6_1&amp;id=gestures_6_1&amp;link=/checklists/gestures.html%23item_6_1&amp;title=Outer Order"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1827,9 +1731,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="gestures_6_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=gestures_6_2&amp;id=gestures_6_2&amp;link=/checklists/gestures.html%23item_6_2&amp;title=By My Sword">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=gestures_6_2&amp;id=gestures_6_2&amp;link=/checklists/gestures.html%23item_6_2&amp;title=By My Sword"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1865,9 +1767,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="gestures_6_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=gestures_6_3&amp;id=gestures_6_3&amp;link=/checklists/gestures.html%23item_6_3&amp;title=My Lord">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=gestures_6_3&amp;id=gestures_6_3&amp;link=/checklists/gestures.html%23item_6_3&amp;title=My Lord"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1904,9 +1804,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="gestures_6_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=gestures_6_4&amp;id=gestures_6_4&amp;link=/checklists/gestures.html%23item_6_4&amp;title=Golden Order Totality">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=gestures_6_4&amp;id=gestures_6_4&amp;link=/checklists/gestures.html%23item_6_4&amp;title=Golden Order Totality"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1943,9 +1841,7 @@
         <div class="card shadow-sm mb-3" id="gestures_section_7">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#gestures_7Col" data-bs-toggle="collapse" href="#gestures_7Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#gestures_7Col" data-bs-toggle="collapse" href="#gestures_7Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Mountaintops of the Giants</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="gestures_totals_7"></span>
             </h4>
@@ -1957,9 +1853,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -1993,9 +1887,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="gestures_7_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=gestures_7_1&amp;id=gestures_7_1&amp;link=/checklists/gestures.html%23item_7_1&amp;title=Fancy Spin">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=gestures_7_1&amp;id=gestures_7_1&amp;link=/checklists/gestures.html%23item_7_1&amp;title=Fancy Spin"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2032,9 +1924,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="gestures_7_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=gestures_7_2&amp;id=gestures_7_2&amp;link=/checklists/gestures.html%23item_7_2&amp;title=Hoslow's Oath">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=gestures_7_2&amp;id=gestures_7_2&amp;link=/checklists/gestures.html%23item_7_2&amp;title=Hoslow's Oath"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2072,9 +1962,7 @@
         <div class="card shadow-sm mb-3" id="gestures_section_8">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#gestures_8Col" data-bs-toggle="collapse" href="#gestures_8Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#gestures_8Col" data-bs-toggle="collapse" href="#gestures_8Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Nokron, Eternal City</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="gestures_totals_8"></span>
             </h4>
@@ -2086,9 +1974,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -2122,9 +2008,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="gestures_8_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=gestures_8_1&amp;id=gestures_8_1&amp;link=/checklists/gestures.html%23item_8_1&amp;title=Inner Order">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=gestures_8_1&amp;id=gestures_8_1&amp;link=/checklists/gestures.html%23item_8_1&amp;title=Inner Order"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2162,9 +2046,7 @@
         <div class="card shadow-sm mb-3" id="gestures_section_9">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#gestures_9Col" data-bs-toggle="collapse" href="#gestures_9Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#gestures_9Col" data-bs-toggle="collapse" href="#gestures_9Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Real of Shadow</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="gestures_totals_9"></span>
             </h4>
@@ -2176,9 +2058,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -2212,9 +2092,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="gestures_11_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=gestures_11_1&amp;id=gestures_11_1&amp;link=/checklists/gestures.html%23item_11_1&amp;title=Ring of Miquella">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=gestures_11_1&amp;id=gestures_11_1&amp;link=/checklists/gestures.html%23item_11_1&amp;title=Ring of Miquella"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2249,9 +2127,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="gestures_11_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=gestures_11_2&amp;id=gestures_11_2&amp;link=/checklists/gestures.html%23item_11_2&amp;title=May the Best Win">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=gestures_11_2&amp;id=gestures_11_2&amp;link=/checklists/gestures.html%23item_11_2&amp;title=May the Best Win"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2288,9 +2164,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="gestures_11_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=gestures_11_3&amp;id=gestures_11_3&amp;link=/checklists/gestures.html%23item_11_3&amp;title=The Two Fingers">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=gestures_11_3&amp;id=gestures_11_3&amp;link=/checklists/gestures.html%23item_11_3&amp;title=The Two Fingers"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2326,9 +2200,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="gestures_11_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=gestures_11_4&amp;id=gestures_11_4&amp;link=/checklists/gestures.html%23item_11_4&amp;title=Let Us Go Together">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=gestures_11_4&amp;id=gestures_11_4&amp;link=/checklists/gestures.html%23item_11_4&amp;title=Let Us Go Together"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2364,9 +2236,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="gestures_11_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=gestures_11_5&amp;id=gestures_11_5&amp;link=/checklists/gestures.html%23item_11_5&amp;title=O Mother">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=gestures_11_5&amp;id=gestures_11_5&amp;link=/checklists/gestures.html%23item_11_5&amp;title=O Mother"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">

--- a/docs/checklists/golden_seeds_sacred_tears.html
+++ b/docs/checklists/golden_seeds_sacred_tears.html
@@ -27,14 +27,10 @@
         <a class="navbar-brand me-auto ms-2" href="/index.html">Roundtable Guides</a>
         <form class="d-none d-sm-flex order-2 order-xl-3">
           <input aria-label="search" class="form-control me-2" name="search" placeholder="Search" type="search">
-          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit">
-            <i class="bi bi-search"></i>
-          </button>
+          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit"><i class="bi bi-search"></i></button>
         </form>
         <div class="d-sm-none order-2">
-          <a class="nav-link me-0" href="/search.html">
-            <i class="bi bi-search sb-icon-search"></i>
-          </a>
+          <a class="nav-link me-0" href="/search.html"><i class="bi bi-search sb-icon-search"></i></a>
         </div>
         <div class="collapse navbar-collapse order-3 order-xl-2 ms-xl-2" id="nav-collapse">
           <ul class="nav navbar-nav navbar-nav-scroll mr-auto">
@@ -179,14 +175,10 @@
               </ul>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/map.html">
-                <i class="bi bi-map"></i> Map
-              </a>
+              <a class="nav-link hide-buttons" href="/map.html"><i class="bi bi-map"></i> Map</a>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/options.html">
-                <i class="bi bi-gear-fill"></i> Options
-              </a>
+              <a class="nav-link hide-buttons" href="/options.html"><i class="bi bi-gear-fill"></i> Options</a>
             </li>
           </ul>
         </div>
@@ -206,9 +198,7 @@
       </div>
       <nav class="text-muted toc d-print-none">
         <strong class="d-block h5">
-          <a class="toc-button" data-bs-toggle="collapse" href="#toc_flasks" role="button">
-            <i class="bi bi-plus-lg"></i>Table Of Contents
-          </a>
+          <a class="toc-button" data-bs-toggle="collapse" href="#toc_flasks" role="button"><i class="bi bi-plus-lg"></i>Table Of Contents</a>
         </strong>
         <ul class="toc_page collapse" id="toc_flasks">
           <li>
@@ -228,9 +218,7 @@
         <div class="card shadow-sm mb-3" id="flasks_section_0">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#flasks_0Col" data-bs-toggle="collapse" href="#flasks_0Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#flasks_0Col" data-bs-toggle="collapse" href="#flasks_0Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <img class="me-1" data-src="/img/icons/bolstering/edited/00383.png" loading="lazy" style="height: 70px; width: 68px">
               <span class="d-print-inline">Golden Seeds</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="flasks_totals_0"></span>
@@ -248,63 +236,49 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="flasks_1_3" type="checkbox" value="">
                     <label class="form-check-label item_content" for="flasks_1_3">Under a Golden Tree on the path to Stormveil Castle</label>
-                    <a class="ms-2" href="/map.html?target=flasks_1_3&amp;id=flasks_1_3&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_3&amp;title=Golden Seed">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=flasks_1_3&amp;id=flasks_1_3&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_3&amp;title=Golden Seed"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="flasks_1_4" id="item_1_4">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="flasks_1_4" type="checkbox" value="">
                     <label class="form-check-label item_content" for="flasks_1_4">Reward for finishing Roderika's quest, can otherwise be found at her shack</label>
-                    <a class="ms-2" href="/map.html?target=flasks_1_4&amp;id=flasks_1_4&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_4&amp;title=Golden Seed">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=flasks_1_4&amp;id=flasks_1_4&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_4&amp;title=Golden Seed"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="flasks_1_5" id="item_1_5">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="flasks_1_5" type="checkbox" value="">
                     <label class="form-check-label item_content" for="flasks_1_5">Under Golden Tree in front of Fort Haight</label>
-                    <a class="ms-2" href="/map.html?target=flasks_1_5&amp;id=flasks_1_5&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_5&amp;title=Golden Seed">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=flasks_1_5&amp;id=flasks_1_5&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_5&amp;title=Golden Seed"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="flasks_1_6" id="item_1_6">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="flasks_1_6" type="checkbox" value="">
                     <label class="form-check-label item_content" for="flasks_1_6">Drops from Kenneth Haight if killed</label>
-                    <a class="ms-2" href="/map.html?target=flasks_1_6&amp;id=flasks_1_6&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_6&amp;title=Golden Seed">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=flasks_1_6&amp;id=flasks_1_6&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_6&amp;title=Golden Seed"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="flasks_1_7" id="item_1_7">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="flasks_1_7" type="checkbox" value="">
                     <label class="form-check-label item_content" for="flasks_1_7">Reward for defeating Ulcerated Tree Spirit in Fringefolk Hero's Grave</label>
-                    <a class="ms-2" href="/map.html?target=flasks_1_7&amp;id=flasks_1_7&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_7&amp;title=Golden Seed">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=flasks_1_7&amp;id=flasks_1_7&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_7&amp;title=Golden Seed"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="flasks_1_43" id="item_1_43">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="flasks_1_43" type="checkbox" value="">
                     <label class="form-check-label item_content" for="flasks_1_43">Under a Golden Tree inside Stormveil, near the Secluded Cell Grace</label>
-                    <a class="ms-2" href="/map.html?target=flasks_1_43&amp;id=flasks_1_43&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_43&amp;title=Golden Seed">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=flasks_1_43&amp;id=flasks_1_43&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_43&amp;title=Golden Seed"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="flasks_1_8" id="item_1_8">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="flasks_1_8" type="checkbox" value="">
                     <label class="form-check-label item_content" for="flasks_1_8">Reward for defeating hidden Ulcerated Tree Spirit in Stormveil Castle</label>
-                    <a class="ms-2" href="/map.html?target=flasks_1_8&amp;id=flasks_1_8&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_8&amp;title=Golden Seed">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=flasks_1_8&amp;id=flasks_1_8&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_8&amp;title=Golden Seed"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -314,9 +288,7 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="flasks_1_1" type="checkbox" value="">
                     <label class="form-check-label item_content" for="flasks_1_1">Under a Golden Tree south of Castle Morne Rampart Grace</label>
-                    <a class="ms-2" href="/map.html?target=flasks_1_1&amp;id=flasks_1_1&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_1&amp;title=Golden Seed">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=flasks_1_1&amp;id=flasks_1_1&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_1&amp;title=Golden Seed"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -326,45 +298,35 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="flasks_1_9" type="checkbox" value="">
                     <label class="form-check-label item_content" for="flasks_1_9">Under a Golden Tree in Academy Gate Town</label>
-                    <a class="ms-2" href="/map.html?target=flasks_1_9&amp;id=flasks_1_9&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_9&amp;title=Golden Seed">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=flasks_1_9&amp;id=flasks_1_9&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_9&amp;title=Golden Seed"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="flasks_1_10" id="item_1_10">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="flasks_1_10" type="checkbox" value="">
                     <label class="form-check-label item_content" for="flasks_1_10">Under a Golden Tree north of Main Academy Gate Grace, at the end of the bridge</label>
-                    <a class="ms-2" href="/map.html?target=flasks_1_10&amp;id=flasks_1_10&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_10&amp;title=Golden Seed">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=flasks_1_10&amp;id=flasks_1_10&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_10&amp;title=Golden Seed"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="flasks_1_11" id="item_1_11">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="flasks_1_11" type="checkbox" value="">
                     <label class="form-check-label item_content" for="flasks_1_11">Under a Golden Tree west side of Raya Lucaria Academy courtyard</label>
-                    <a class="ms-2" href="/map.html?target=flasks_1_11&amp;id=flasks_1_11&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_11&amp;title=Golden Seed">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=flasks_1_11&amp;id=flasks_1_11&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_11&amp;title=Golden Seed"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="flasks_1_12" id="item_1_12">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="flasks_1_12" type="checkbox" value="">
                     <label class="form-check-label item_content" for="flasks_1_12">Under a Golden Tree in Caria Manor's upper level.</label>
-                    <a class="ms-2" href="/map.html?target=flasks_1_12&amp;id=flasks_1_12&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_12&amp;title=Golden Seed">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=flasks_1_12&amp;id=flasks_1_12&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_12&amp;title=Golden Seed"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="flasks_1_13" id="item_1_13">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="flasks_1_13" type="checkbox" value="">
                     <label class="form-check-label item_content" for="flasks_1_13">Under a Golden Tree at the north end of the lake, near the Ruin-Strewn Precipice</label>
-                    <a class="ms-2" href="/map.html?target=flasks_1_13&amp;id=flasks_1_13&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_13&amp;title=Golden Seed">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=flasks_1_13&amp;id=flasks_1_13&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_13&amp;title=Golden Seed"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -374,36 +336,28 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="flasks_1_14" type="checkbox" value="">
                     <label class="form-check-label item_content" for="flasks_1_14">under a Golden Tree near the three way crossroad leading to Castle Redmane</label>
-                    <a class="ms-2" href="/map.html?target=flasks_1_14&amp;id=flasks_1_14&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_14&amp;title=Golden Seed">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=flasks_1_14&amp;id=flasks_1_14&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_14&amp;title=Golden Seed"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="flasks_1_15" id="item_1_15">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="flasks_1_15" type="checkbox" value="">
                     <label class="form-check-label item_content" for="flasks_1_15">under a Golden Tree in the upper area of Sellia, Town of Sorcery</label>
-                    <a class="ms-2" href="/map.html?target=flasks_1_15&amp;id=flasks_1_15&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_15&amp;title=Golden Seed">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=flasks_1_15&amp;id=flasks_1_15&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_15&amp;title=Golden Seed"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="flasks_1_16" id="item_1_16">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="flasks_1_16" type="checkbox" value="">
                     <label class="form-check-label item_content" for="flasks_1_16">under a Golden Tree, south of Bestial Sanctum</label>
-                    <a class="ms-2" href="/map.html?target=flasks_1_16&amp;id=flasks_1_16&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_16&amp;title=Golden Seed">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=flasks_1_16&amp;id=flasks_1_16&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_16&amp;title=Golden Seed"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="flasks_1_17" id="item_1_17">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="flasks_1_17" type="checkbox" value="">
                     <label class="form-check-label item_content" for="flasks_1_17">reward for defeating Putrid Tree Spirit in War-Dead Catacombs (after Radahn)</label>
-                    <a class="ms-2" href="/map.html?target=flasks_1_17&amp;id=flasks_1_17&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_17&amp;title=Golden Seed">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=flasks_1_17&amp;id=flasks_1_17&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_17&amp;title=Golden Seed"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -413,36 +367,28 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="flasks_1_18" type="checkbox" value="">
                     <label class="form-check-label item_content" for="flasks_1_18">under a Golden Tree near Erdtree-Grazing Hill Grace</label>
-                    <a class="ms-2" href="/map.html?target=flasks_1_18&amp;id=flasks_1_18&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_18&amp;title=Golden Seed">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=flasks_1_18&amp;id=flasks_1_18&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_18&amp;title=Golden Seed"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="flasks_1_19" id="item_1_19">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="flasks_1_19" type="checkbox" value="">
                     <label class="form-check-label item_content" for="flasks_1_19">under a Golden Tree north of Altus Highway Junction</label>
-                    <a class="ms-2" href="/map.html?target=flasks_1_19&amp;id=flasks_1_19&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_19&amp;title=Golden Seed">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=flasks_1_19&amp;id=flasks_1_19&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_19&amp;title=Golden Seed"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="flasks_1_20" id="item_1_20">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="flasks_1_20" type="checkbox" value="">
                     <label class="form-check-label item_content" for="flasks_1_20">under a Golden Tree near the Minor Erdtree</label>
-                    <a class="ms-2" href="/map.html?target=flasks_1_20&amp;id=flasks_1_20&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_20&amp;title=Golden Seed">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=flasks_1_20&amp;id=flasks_1_20&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_20&amp;title=Golden Seed"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="flasks_1_21" id="item_1_21">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="flasks_1_21" type="checkbox" value="">
                     <label class="form-check-label item_content" for="flasks_1_21">under a Golden Tree, southeast of Windmill Village, near Highway Lookout Tower</label>
-                    <a class="ms-2" href="/map.html?target=flasks_1_21&amp;id=flasks_1_21&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_21&amp;title=Golden Seed">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=flasks_1_21&amp;id=flasks_1_21&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_21&amp;title=Golden Seed"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -452,18 +398,14 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="flasks_1_29" type="checkbox" value="">
                     <label class="form-check-label item_content" for="flasks_1_29">under a Golden Tree in the ravine, south of Seethewater Cave</label>
-                    <a class="ms-2" href="/map.html?target=flasks_1_29&amp;id=flasks_1_29&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_29&amp;title=Golden Seed">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=flasks_1_29&amp;id=flasks_1_29&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_29&amp;title=Golden Seed"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="flasks_1_30" id="item_1_30">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="flasks_1_30" type="checkbox" value="">
                     <label class="form-check-label item_content" for="flasks_1_30">under a Golden Tree, northwest of Road of Iniquity</label>
-                    <a class="ms-2" href="/map.html?target=flasks_1_30&amp;id=flasks_1_30&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_30&amp;title=Golden Seed">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=flasks_1_30&amp;id=flasks_1_30&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_30&amp;title=Golden Seed"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -473,45 +415,35 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="flasks_1_22" type="checkbox" value="">
                     <label class="form-check-label item_content" for="flasks_1_22">under a large Golden Tree near the Outer Wall Phantom Tree Grace</label>
-                    <a class="ms-2" href="/map.html?target=flasks_1_22&amp;id=flasks_1_22&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_22&amp;title=Golden Seed x2">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=flasks_1_22&amp;id=flasks_1_22&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_22&amp;title=Golden Seed x2"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="flasks_1_23" id="item_1_23">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="flasks_1_23" type="checkbox" value="">
                     <label class="form-check-label item_content" for="flasks_1_23">under the same Golden Tree mentioned above</label>
-                    <a class="ms-2" href="/map.html?x=3670&amp;y=3491&amp;id=flasks_1_23&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_23&amp;title=Golden Seed">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3670&amp;y=3491&amp;id=flasks_1_23&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_23&amp;title=Golden Seed"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="flasks_1_24" id="item_1_24">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="flasks_1_24" type="checkbox" value="">
                     <label class="form-check-label item_content" for="flasks_1_24">under a large Golden Tree north of the Outer Wall Phantom Tree Grace</label>
-                    <a class="ms-2" href="/map.html?target=flasks_1_24&amp;id=flasks_1_24&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_24&amp;title=Golden Seed x2">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=flasks_1_24&amp;id=flasks_1_24&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_24&amp;title=Golden Seed x2"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="flasks_1_25" id="item_1_25">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="flasks_1_25" type="checkbox" value="">
                     <label class="form-check-label item_content" for="flasks_1_25">under the same Golden Tree mentioned above</label>
-                    <a class="ms-2" href="/map.html?x=3842&amp;y=3233&amp;id=flasks_1_25&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_25&amp;title=Golden Seed">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3842&amp;y=3233&amp;id=flasks_1_25&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_25&amp;title=Golden Seed"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="flasks_1_26" id="item_1_26">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="flasks_1_26" type="checkbox" value="">
                     <label class="form-check-label item_content" for="flasks_1_26">reward for defeating Ulcerated Tree Spirit south of Outer Wall Phantom Tree Grace</label>
-                    <a class="ms-2" href="/map.html?target=flasks_1_26&amp;id=flasks_1_26&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_26&amp;title=Golden Seed">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=flasks_1_26&amp;id=flasks_1_26&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_26&amp;title=Golden Seed"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -521,18 +453,14 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="flasks_1_27" type="checkbox" value="">
                     <label class="form-check-label item_content" for="flasks_1_27">under a Golden Tree south of the West Capital Rampart Grace</label>
-                    <a class="ms-2" href="/map.html?target=flasks_1_27&amp;id=flasks_1_27&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_27&amp;title=Golden Seed">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=flasks_1_27&amp;id=flasks_1_27&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_27&amp;title=Golden Seed"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="flasks_1_28" id="item_1_28">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="flasks_1_28" type="checkbox" value="">
                     <label class="form-check-label item_content" for="flasks_1_28">reward for defeating Ulcerated Tree Spirit west of Avenue Balcony Grace</label>
-                    <a class="ms-2" href="/map.html?target=flasks_1_28&amp;id=flasks_1_28&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_28&amp;title=Golden Seed">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=flasks_1_28&amp;id=flasks_1_28&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_28&amp;title=Golden Seed"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -542,36 +470,28 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="flasks_1_31" type="checkbox" value="">
                     <label class="form-check-label item_content" for="flasks_1_31">under a Golden Tree in the Forbidden Lands</label>
-                    <a class="ms-2" href="/map.html?target=flasks_1_31&amp;id=flasks_1_31&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_31&amp;title=Golden Seed">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=flasks_1_31&amp;id=flasks_1_31&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_31&amp;title=Golden Seed"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="flasks_1_32" id="item_1_32">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="flasks_1_32" type="checkbox" value="">
                     <label class="form-check-label item_content" for="flasks_1_32">reward for defeating Ulcerated Tree Spirit in the Giants' Mountaintop Catacombs</label>
-                    <a class="ms-2" href="/map.html?target=flasks_1_32&amp;id=flasks_1_32&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_32&amp;title=Golden Seed">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=flasks_1_32&amp;id=flasks_1_32&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_32&amp;title=Golden Seed"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="flasks_1_33" id="item_1_33">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="flasks_1_33" type="checkbox" value="">
                     <label class="form-check-label item_content" for="flasks_1_33">under a Golden Tree, northeast of the Foot of the Forge Grace</label>
-                    <a class="ms-2" href="/map.html?target=flasks_1_33&amp;id=flasks_1_33&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_33&amp;title=Golden Seed">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=flasks_1_33&amp;id=flasks_1_33&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_33&amp;title=Golden Seed"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="flasks_1_34" id="item_1_34">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="flasks_1_34" type="checkbox" value="">
                     <label class="form-check-label item_content" for="flasks_1_34">under a Golden Tree, in the ravine between the Minor Erdtree and Heretical Rise, guarded by a Giant Golem</label>
-                    <a class="ms-2" href="/map.html?target=flasks_1_34&amp;id=flasks_1_34&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_34&amp;title=Golden Seed">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=flasks_1_34&amp;id=flasks_1_34&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_34&amp;title=Golden Seed"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -581,18 +501,14 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="flasks_1_35" type="checkbox" value="">
                     <label class="form-check-label item_content" for="flasks_1_35">under a Golden Tree, south of Inner Consecrated Snowfield Grace</label>
-                    <a class="ms-2" href="/map.html?target=flasks_1_35&amp;id=flasks_1_35&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_35&amp;title=Golden Seed">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=flasks_1_35&amp;id=flasks_1_35&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_35&amp;title=Golden Seed"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="flasks_1_36" id="item_1_36">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="flasks_1_36" type="checkbox" value="">
                     <label class="form-check-label item_content" for="flasks_1_36">under a Golden Tree, west of Ordina, Liturgical Town</label>
-                    <a class="ms-2" href="/map.html?target=flasks_1_36&amp;id=flasks_1_36&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_36&amp;title=Golden Seed">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=flasks_1_36&amp;id=flasks_1_36&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_36&amp;title=Golden Seed"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -602,18 +518,14 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="flasks_1_37" type="checkbox" value="">
                     <label class="form-check-label item_content" for="flasks_1_37">under a Golden Tree in the middle of the Dragon Temple</label>
-                    <a class="ms-2" href="/map.html?target=flasks_1_37&amp;id=flasks_1_37&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_37&amp;title=Golden Seed">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=flasks_1_37&amp;id=flasks_1_37&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_37&amp;title=Golden Seed"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="flasks_1_38" id="item_1_38">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="flasks_1_38" type="checkbox" value="">
                     <label class="form-check-label item_content" for="flasks_1_38">under a Golden Tree, southeast of Dragon Temple Rooftop Grace</label>
-                    <a class="ms-2" href="/map.html?target=flasks_1_38&amp;id=flasks_1_38&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_38&amp;title=Golden Seed">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=flasks_1_38&amp;id=flasks_1_38&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_38&amp;title=Golden Seed"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -623,9 +535,7 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="flasks_1_39" type="checkbox" value="">
                     <label class="form-check-label item_content" for="flasks_1_39">under a Golden Tree accessible by crossing a stone bridge southwest of the Below the Well Site of Grace</label>
-                    <a class="ms-2" href="/map.html?target=flasks_1_39&amp;id=flasks_1_39&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_39&amp;title=Golden Seed">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=flasks_1_39&amp;id=flasks_1_39&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_39&amp;title=Golden Seed"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -635,9 +545,7 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="flasks_1_40" type="checkbox" value="">
                     <label class="form-check-label item_content" for="flasks_1_40">under a Golden Tree in the middle of the lake, surrounded by giant birds</label>
-                    <a class="ms-2" href="/map.html?target=flasks_1_40&amp;id=flasks_1_40&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_40&amp;title=Golden Seed">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=flasks_1_40&amp;id=flasks_1_40&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_40&amp;title=Golden Seed"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -647,18 +555,14 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="flasks_1_41" type="checkbox" value="">
                     <label class="form-check-label item_content" for="flasks_1_41">under a Golden Tree in the northwest of Nokstella; climb every staircase to the absolute top of the city, exit the topmost building (with the Moon of Nokstella talisman) to the left, and go down the elevator past it, to see the tree as you emerge back at the bottom</label>
-                    <a class="ms-2" href="/map.html?target=flasks_1_41&amp;id=flasks_1_41&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_41&amp;title=Golden Seed">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=flasks_1_41&amp;id=flasks_1_41&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_41&amp;title=Golden Seed"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="flasks_1_42" id="item_1_42">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="flasks_1_42" type="checkbox" value="">
                     <label class="form-check-label item_content" for="flasks_1_42">reward for defeating Putrid Tree Spirit in Lake of Rot</label>
-                    <a class="ms-2" href="/map.html?target=flasks_1_42&amp;id=flasks_1_42&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_42&amp;title=Golden Seed">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=flasks_1_42&amp;id=flasks_1_42&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_1_42&amp;title=Golden Seed"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -668,9 +572,7 @@
         <div class="card shadow-sm mb-3" id="flasks_section_1">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#flasks_1Col" data-bs-toggle="collapse" href="#flasks_1Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#flasks_1Col" data-bs-toggle="collapse" href="#flasks_1Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <img class="me-1" data-src="/img/icons/bolstering/edited/00384.png" loading="lazy" style="height: 70px; width: 70px">
               <span class="d-print-inline">Sacred Tears</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="flasks_totals_1"></span>
@@ -682,9 +584,7 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="flasks_2_4" type="checkbox" value="">
                     <label class="form-check-label item_content" for="flasks_2_4">Third Church of Marika, in East Limgrave</label>
-                    <a class="ms-2" href="/map.html?target=flasks_2_4&amp;id=flasks_2_4&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_2_4&amp;title=Sacred Tear">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=flasks_2_4&amp;id=flasks_2_4&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_2_4&amp;title=Sacred Tear"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -694,27 +594,21 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="flasks_2_1" type="checkbox" value="">
                     <label class="form-check-label item_content" for="flasks_2_1">Callu Baptismal Church, in the middle of the Weeping Peninsula</label>
-                    <a class="ms-2" href="/map.html?target=flasks_2_1&amp;id=flasks_2_1&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_2_1&amp;title=Sacred Tear">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=flasks_2_1&amp;id=flasks_2_1&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_2_1&amp;title=Sacred Tear"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="flasks_2_2" id="item_2_2">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="flasks_2_2" type="checkbox" value="">
                     <label class="form-check-label item_content" for="flasks_2_2">Church of Pilgrimage, north of Weeping Peninsula</label>
-                    <a class="ms-2" href="/map.html?target=flasks_2_2&amp;id=flasks_2_2&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_2_2&amp;title=Sacred Tear">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=flasks_2_2&amp;id=flasks_2_2&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_2_2&amp;title=Sacred Tear"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="flasks_2_3" id="item_2_3">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="flasks_2_3" type="checkbox" value="">
                     <label class="form-check-label item_content" for="flasks_2_3">Fourth Church of Marika, west of Weeping Peninsula</label>
-                    <a class="ms-2" href="/map.html?target=flasks_2_3&amp;id=flasks_2_3&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_2_3&amp;title=Sacred Tear">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=flasks_2_3&amp;id=flasks_2_3&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_2_3&amp;title=Sacred Tear"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -724,27 +618,21 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="flasks_2_5" type="checkbox" value="">
                     <label class="form-check-label item_content" for="flasks_2_5">Church of Irith, southern part of Liurnia of the Lakes</label>
-                    <a class="ms-2" href="/map.html?target=flasks_2_5&amp;id=flasks_2_5&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_2_5&amp;title=Sacred Tear">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=flasks_2_5&amp;id=flasks_2_5&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_2_5&amp;title=Sacred Tear"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="flasks_2_6" id="item_2_6">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="flasks_2_6" type="checkbox" value="">
                     <label class="form-check-label item_content" for="flasks_2_6">Bellum Church, on the way to the Grand Lift of Dectus</label>
-                    <a class="ms-2" href="/map.html?target=flasks_2_6&amp;id=flasks_2_6&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_2_6&amp;title=Sacred Tear">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=flasks_2_6&amp;id=flasks_2_6&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_2_6&amp;title=Sacred Tear"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="flasks_2_7" id="item_2_7">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="flasks_2_7" type="checkbox" value="">
                     <label class="form-check-label item_content" for="flasks_2_7">Church of Inhibition, northeast of Bellum Highway Forest</label>
-                    <a class="ms-2" href="/map.html?target=flasks_2_7&amp;id=flasks_2_7&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_2_7&amp;title=Sacred Tear">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=flasks_2_7&amp;id=flasks_2_7&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_2_7&amp;title=Sacred Tear"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -754,9 +642,7 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="flasks_2_8" type="checkbox" value="">
                     <label class="form-check-label item_content" for="flasks_2_8">Church of Plague, accessible through Sellia, Town of Sorcery</label>
-                    <a class="ms-2" href="/map.html?target=flasks_2_8&amp;id=flasks_2_8&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_2_8&amp;title=Sacred Tear">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=flasks_2_8&amp;id=flasks_2_8&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_2_8&amp;title=Sacred Tear"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -766,18 +652,14 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="flasks_2_9" type="checkbox" value="">
                     <label class="form-check-label item_content" for="flasks_2_9">Second Church of Marika, north of Altus Highway Junction Grace</label>
-                    <a class="ms-2" href="/map.html?target=flasks_2_9&amp;id=flasks_2_9&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_2_9&amp;title=Sacred Tear">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=flasks_2_9&amp;id=flasks_2_9&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_2_9&amp;title=Sacred Tear"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="flasks_2_10" id="item_2_10">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="flasks_2_10" type="checkbox" value="">
                     <label class="form-check-label item_content" for="flasks_2_10">Stormcaller Church, west of Rampartside Path Grace</label>
-                    <a class="ms-2" href="/map.html?target=flasks_2_10&amp;id=flasks_2_10&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_2_10&amp;title=Sacred Tear">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=flasks_2_10&amp;id=flasks_2_10&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_2_10&amp;title=Sacred Tear"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -787,18 +669,14 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="flasks_2_11" type="checkbox" value="">
                     <label class="form-check-label item_content" for="flasks_2_11">Church of Repose, east of Grand Lift of Rold</label>
-                    <a class="ms-2" href="/map.html?target=flasks_2_11&amp;id=flasks_2_11&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_2_11&amp;title=Sacred Tear">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=flasks_2_11&amp;id=flasks_2_11&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_2_11&amp;title=Sacred Tear"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="flasks_2_12" id="item_2_12">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="flasks_2_12" type="checkbox" value="">
                     <label class="form-check-label item_content" for="flasks_2_12">First Church of Marika, southeastern most part of Mountaintops of the Giants</label>
-                    <a class="ms-2" href="/map.html?target=flasks_2_12&amp;id=flasks_2_12&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_2_12&amp;title=Sacred Tear">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=flasks_2_12&amp;id=flasks_2_12&amp;link=/checklists/golden_seeds_sacred_tears.html%23item_2_12&amp;title=Sacred Tear"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>

--- a/docs/checklists/great_runes.html
+++ b/docs/checklists/great_runes.html
@@ -27,14 +27,10 @@
         <a class="navbar-brand me-auto ms-2" href="/index.html">Roundtable Guides</a>
         <form class="d-none d-sm-flex order-2 order-xl-3">
           <input aria-label="search" class="form-control me-2" name="search" placeholder="Search" type="search">
-          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit">
-            <i class="bi bi-search"></i>
-          </button>
+          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit"><i class="bi bi-search"></i></button>
         </form>
         <div class="d-sm-none order-2">
-          <a class="nav-link me-0" href="/search.html">
-            <i class="bi bi-search sb-icon-search"></i>
-          </a>
+          <a class="nav-link me-0" href="/search.html"><i class="bi bi-search sb-icon-search"></i></a>
         </div>
         <div class="collapse navbar-collapse order-3 order-xl-2 ms-xl-2" id="nav-collapse">
           <ul class="nav navbar-nav navbar-nav-scroll mr-auto">
@@ -179,14 +175,10 @@
               </ul>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/map.html">
-                <i class="bi bi-map"></i> Map
-              </a>
+              <a class="nav-link hide-buttons" href="/map.html"><i class="bi bi-map"></i> Map</a>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/options.html">
-                <i class="bi bi-gear-fill"></i> Options
-              </a>
+              <a class="nav-link hide-buttons" href="/options.html"><i class="bi bi-gear-fill"></i> Options</a>
             </li>
           </ul>
         </div>
@@ -206,9 +198,7 @@
       </div>
       <nav class="text-muted toc d-print-none">
         <strong class="d-block h5">
-          <a class="toc-button" data-bs-toggle="collapse" href="#toc_great_runes" role="button">
-            <i class="bi bi-plus-lg"></i>Table Of Contents
-          </a>
+          <a class="toc-button" data-bs-toggle="collapse" href="#toc_great_runes" role="button"><i class="bi bi-plus-lg"></i>Table Of Contents</a>
         </strong>
         <ul class="toc_page collapse" id="toc_great_runes">
           <li>
@@ -232,9 +222,7 @@
         <div class="card shadow-sm mb-3" id="great_runes_section_0">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#great_runes_0Col" data-bs-toggle="collapse" href="#great_runes_0Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#great_runes_0Col" data-bs-toggle="collapse" href="#great_runes_0Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Great Runes</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="great_runes_totals_0"></span>
             </h4>
@@ -246,9 +234,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -277,9 +263,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="great_runes_1_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=great_runes_1_1&amp;id=great_runes_1_1&amp;link=/checklists/great_runes.html%23item_1_1&amp;title=Godrick's Great Rune (unactivated)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=great_runes_1_1&amp;id=great_runes_1_1&amp;link=/checklists/great_runes.html%23item_1_1&amp;title=Godrick's Great Rune (unactivated)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -312,9 +296,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="great_runes_1_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=great_runes_1_2&amp;id=great_runes_1_2&amp;link=/checklists/great_runes.html%23item_1_2&amp;title=Great Rune of the Unborn">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=great_runes_1_2&amp;id=great_runes_1_2&amp;link=/checklists/great_runes.html%23item_1_2&amp;title=Great Rune of the Unborn"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -347,9 +329,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="great_runes_1_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=great_runes_1_3&amp;id=great_runes_1_3&amp;link=/checklists/great_runes.html%23item_1_3&amp;title=Radahn's Great Rune (unactivated)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=great_runes_1_3&amp;id=great_runes_1_3&amp;link=/checklists/great_runes.html%23item_1_3&amp;title=Radahn's Great Rune (unactivated)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -382,9 +362,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="great_runes_1_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=great_runes_1_4&amp;id=great_runes_1_4&amp;link=/checklists/great_runes.html%23item_1_4&amp;title=Morgott's Great Rune (unactivated)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=great_runes_1_4&amp;id=great_runes_1_4&amp;link=/checklists/great_runes.html%23item_1_4&amp;title=Morgott's Great Rune (unactivated)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -417,9 +395,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="great_runes_1_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=great_runes_1_5&amp;id=great_runes_1_5&amp;link=/checklists/great_runes.html%23item_1_5&amp;title=Rykard's Great Rune (unactivated)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=great_runes_1_5&amp;id=great_runes_1_5&amp;link=/checklists/great_runes.html%23item_1_5&amp;title=Rykard's Great Rune (unactivated)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -452,9 +428,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="great_runes_1_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=great_runes_1_7&amp;id=great_runes_1_7&amp;link=/checklists/great_runes.html%23item_1_7&amp;title=Mohg's Great Rune (unactivated)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=great_runes_1_7&amp;id=great_runes_1_7&amp;link=/checklists/great_runes.html%23item_1_7&amp;title=Mohg's Great Rune (unactivated)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -487,9 +461,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="great_runes_1_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=great_runes_1_6&amp;id=great_runes_1_6&amp;link=/checklists/great_runes.html%23item_1_6&amp;title=Malenia's Great Rune (unactivated)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=great_runes_1_6&amp;id=great_runes_1_6&amp;link=/checklists/great_runes.html%23item_1_6&amp;title=Malenia's Great Rune (unactivated)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -522,9 +494,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="great_runes_1_11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=great_runes_1_11&amp;id=great_runes_1_11&amp;link=/checklists/great_runes.html%23item_1_11&amp;title=Miquella's Great Rune">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=great_runes_1_11&amp;id=great_runes_1_11&amp;link=/checklists/great_runes.html%23item_1_11&amp;title=Miquella's Great Rune"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -558,9 +528,7 @@
         <div class="card shadow-sm mb-3" id="great_runes_section_1">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#great_runes_1Col" data-bs-toggle="collapse" href="#great_runes_1Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#great_runes_1Col" data-bs-toggle="collapse" href="#great_runes_1Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Great Rune restoration</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="great_runes_totals_1"></span>
             </h4>
@@ -572,9 +540,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -603,9 +569,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="great_runes_1_1r" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=great_runes_1_1r&amp;id=great_runes_1_1r&amp;link=/checklists/great_runes.html%23item_1_1r&amp;title=Godrick's Great Rune restoration">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=great_runes_1_1r&amp;id=great_runes_1_1r&amp;link=/checklists/great_runes.html%23item_1_1r&amp;title=Godrick's Great Rune restoration"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -638,9 +602,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="great_runes_1_3r" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=great_runes_1_3r&amp;id=great_runes_1_3r&amp;link=/checklists/great_runes.html%23item_1_3r&amp;title=Radahn's Great Rune restoration">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=great_runes_1_3r&amp;id=great_runes_1_3r&amp;link=/checklists/great_runes.html%23item_1_3r&amp;title=Radahn's Great Rune restoration"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -673,9 +635,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="great_runes_1_5r" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=great_runes_1_5r&amp;id=great_runes_1_5r&amp;link=/checklists/great_runes.html%23item_1_5r&amp;title=Rykard's Great Rune restoration">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=great_runes_1_5r&amp;id=great_runes_1_5r&amp;link=/checklists/great_runes.html%23item_1_5r&amp;title=Rykard's Great Rune restoration"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -708,9 +668,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="great_runes_1_6r" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=great_runes_1_6r&amp;id=great_runes_1_6r&amp;link=/checklists/great_runes.html%23item_1_6r&amp;title=Malenia's Great Rune restoration">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=great_runes_1_6r&amp;id=great_runes_1_6r&amp;link=/checklists/great_runes.html%23item_1_6r&amp;title=Malenia's Great Rune restoration"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -743,9 +701,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="great_runes_1_4r" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=great_runes_1_4r&amp;id=great_runes_1_4r&amp;link=/checklists/great_runes.html%23item_1_4r&amp;title=Morgott's Great Rune restoration">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=great_runes_1_4r&amp;id=great_runes_1_4r&amp;link=/checklists/great_runes.html%23item_1_4r&amp;title=Morgott's Great Rune restoration"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -778,9 +734,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="great_runes_1_7r" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=great_runes_1_7r&amp;id=great_runes_1_7r&amp;link=/checklists/great_runes.html%23item_1_7r&amp;title=Mohg's Great Rune restoration">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=great_runes_1_7r&amp;id=great_runes_1_7r&amp;link=/checklists/great_runes.html%23item_1_7r&amp;title=Mohg's Great Rune restoration"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -814,9 +768,7 @@
         <div class="card shadow-sm mb-3" id="great_runes_section_2">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#great_runes_2Col" data-bs-toggle="collapse" href="#great_runes_2Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#great_runes_2Col" data-bs-toggle="collapse" href="#great_runes_2Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Other Important Runes</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="great_runes_totals_2"></span>
             </h4>
@@ -828,9 +780,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -859,9 +809,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="great_runes_2_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=great_runes_2_1&amp;id=great_runes_2_1&amp;link=/checklists/great_runes.html%23item_2_1&amp;title=Phantom Great Rune">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=great_runes_2_1&amp;id=great_runes_2_1&amp;link=/checklists/great_runes.html%23item_2_1&amp;title=Phantom Great Rune"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -894,9 +842,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="great_runes_2_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=great_runes_2_2&amp;id=great_runes_2_2&amp;link=/checklists/great_runes.html%23item_2_2&amp;title=Mending Rune of the Death-Prince">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=great_runes_2_2&amp;id=great_runes_2_2&amp;link=/checklists/great_runes.html%23item_2_2&amp;title=Mending Rune of the Death-Prince"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -929,9 +875,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="great_runes_2_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=great_runes_2_3&amp;id=great_runes_2_3&amp;link=/checklists/great_runes.html%23item_2_3&amp;title=Mending Rune of the Fell Curse">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=great_runes_2_3&amp;id=great_runes_2_3&amp;link=/checklists/great_runes.html%23item_2_3&amp;title=Mending Rune of the Fell Curse"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -964,9 +908,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="great_runes_2_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=great_runes_2_4&amp;id=great_runes_2_4&amp;link=/checklists/great_runes.html%23item_2_4&amp;title=Mending Rune of Perfect Order">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=great_runes_2_4&amp;id=great_runes_2_4&amp;link=/checklists/great_runes.html%23item_2_4&amp;title=Mending Rune of Perfect Order"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">

--- a/docs/checklists/illusory_walls_invisible_paths.html
+++ b/docs/checklists/illusory_walls_invisible_paths.html
@@ -27,14 +27,10 @@
         <a class="navbar-brand me-auto ms-2" href="/index.html">Roundtable Guides</a>
         <form class="d-none d-sm-flex order-2 order-xl-3">
           <input aria-label="search" class="form-control me-2" name="search" placeholder="Search" type="search">
-          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit">
-            <i class="bi bi-search"></i>
-          </button>
+          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit"><i class="bi bi-search"></i></button>
         </form>
         <div class="d-sm-none order-2">
-          <a class="nav-link me-0" href="/search.html">
-            <i class="bi bi-search sb-icon-search"></i>
-          </a>
+          <a class="nav-link me-0" href="/search.html"><i class="bi bi-search sb-icon-search"></i></a>
         </div>
         <div class="collapse navbar-collapse order-3 order-xl-2 ms-xl-2" id="nav-collapse">
           <ul class="nav navbar-nav navbar-nav-scroll mr-auto">
@@ -179,14 +175,10 @@
               </ul>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/map.html">
-                <i class="bi bi-map"></i> Map
-              </a>
+              <a class="nav-link hide-buttons" href="/map.html"><i class="bi bi-map"></i> Map</a>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/options.html">
-                <i class="bi bi-gear-fill"></i> Options
-              </a>
+              <a class="nav-link hide-buttons" href="/options.html"><i class="bi bi-gear-fill"></i> Options</a>
             </li>
           </ul>
         </div>
@@ -206,9 +198,7 @@
       </div>
       <nav class="text-muted toc d-print-none">
         <strong class="d-block h5">
-          <a class="toc-button" data-bs-toggle="collapse" href="#toc_illusory_walls" role="button">
-            <i class="bi bi-plus-lg"></i>Table Of Contents
-          </a>
+          <a class="toc-button" data-bs-toggle="collapse" href="#toc_illusory_walls" role="button"><i class="bi bi-plus-lg"></i>Table Of Contents</a>
         </strong>
         <ul class="toc_page collapse" id="toc_illusory_walls">
           <li>
@@ -248,9 +238,7 @@
         <div class="card shadow-sm mb-3" id="illusory_walls_section_0">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#illusory_walls_0Col" data-bs-toggle="collapse" href="#illusory_walls_0Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#illusory_walls_0Col" data-bs-toggle="collapse" href="#illusory_walls_0Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Liurnia+of+the+Lakes">Liurnia of the Lakes</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="illusory_walls_totals_0"></span>
             </h4>
@@ -262,9 +250,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -293,9 +279,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="illusory_walls_1_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=illusory_walls_1_1&amp;id=illusory_walls_1_1&amp;link=/checklists/illusory_walls_invisible_paths.html%23item_1_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Academy+Crystal+Cave&quot;&gt;Academy Crystal Cave&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=illusory_walls_1_1&amp;id=illusory_walls_1_1&amp;link=/checklists/illusory_walls_invisible_paths.html%23item_1_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Academy+Crystal+Cave&quot;&gt;Academy Crystal Cave&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -325,9 +309,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="illusory_walls_1_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=illusory_walls_1_2&amp;id=illusory_walls_1_2&amp;link=/checklists/illusory_walls_invisible_paths.html%23item_1_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Academy+of+Raya+Lucaria&quot;&gt;Academy of Raya Lucaria&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=illusory_walls_1_2&amp;id=illusory_walls_1_2&amp;link=/checklists/illusory_walls_invisible_paths.html%23item_1_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Academy+of+Raya+Lucaria&quot;&gt;Academy of Raya Lucaria&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -357,9 +339,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="illusory_walls_1_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=illusory_walls_1_3&amp;id=illusory_walls_1_3&amp;link=/checklists/illusory_walls_invisible_paths.html%23item_1_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Academy+of+Raya+Lucaria&quot;&gt;Academy of Raya Lucaria&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=illusory_walls_1_3&amp;id=illusory_walls_1_3&amp;link=/checklists/illusory_walls_invisible_paths.html%23item_1_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Academy+of+Raya+Lucaria&quot;&gt;Academy of Raya Lucaria&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -389,9 +369,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="illusory_walls_1_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=illusory_walls_1_4&amp;id=illusory_walls_1_4&amp;link=/checklists/illusory_walls_invisible_paths.html%23item_1_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Academy+of+Raya+Lucaria&quot;&gt;Academy of Raya Lucaria&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=illusory_walls_1_4&amp;id=illusory_walls_1_4&amp;link=/checklists/illusory_walls_invisible_paths.html%23item_1_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Academy+of+Raya+Lucaria&quot;&gt;Academy of Raya Lucaria&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -421,9 +399,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="illusory_walls_1_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=illusory_walls_1_5&amp;id=illusory_walls_1_5&amp;link=/checklists/illusory_walls_invisible_paths.html%23item_1_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Black+Knife+Catacombs&quot;&gt;Black Knife Catacombs&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=illusory_walls_1_5&amp;id=illusory_walls_1_5&amp;link=/checklists/illusory_walls_invisible_paths.html%23item_1_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Black+Knife+Catacombs&quot;&gt;Black Knife Catacombs&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -453,9 +429,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="illusory_walls_1_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=illusory_walls_1_6&amp;id=illusory_walls_1_6&amp;link=/checklists/illusory_walls_invisible_paths.html%23item_1_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Kingsrealm+Ruins&quot;&gt;Kingsrealm Ruins&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=illusory_walls_1_6&amp;id=illusory_walls_1_6&amp;link=/checklists/illusory_walls_invisible_paths.html%23item_1_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Kingsrealm+Ruins&quot;&gt;Kingsrealm Ruins&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -485,9 +459,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="illusory_walls_1_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=illusory_walls_1_7&amp;id=illusory_walls_1_7&amp;link=/checklists/illusory_walls_invisible_paths.html%23item_1_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Kingsrealm+Ruins&quot;&gt;Kingsrealm Ruins&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=illusory_walls_1_7&amp;id=illusory_walls_1_7&amp;link=/checklists/illusory_walls_invisible_paths.html%23item_1_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Kingsrealm+Ruins&quot;&gt;Kingsrealm Ruins&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -517,9 +489,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="illusory_walls_1_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=illusory_walls_1_8&amp;id=illusory_walls_1_8&amp;link=/checklists/illusory_walls_invisible_paths.html%23item_1_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Moonfolk+Ruins&quot;&gt;Moonfolk Ruins&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=illusory_walls_1_8&amp;id=illusory_walls_1_8&amp;link=/checklists/illusory_walls_invisible_paths.html%23item_1_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Moonfolk+Ruins&quot;&gt;Moonfolk Ruins&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -549,9 +519,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="illusory_walls_1_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=illusory_walls_1_9&amp;id=illusory_walls_1_9&amp;link=/checklists/illusory_walls_invisible_paths.html%23item_1_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Road's+End+Catacombs&quot;&gt;Road's End Catacomb&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=illusory_walls_1_9&amp;id=illusory_walls_1_9&amp;link=/checklists/illusory_walls_invisible_paths.html%23item_1_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Road's+End+Catacombs&quot;&gt;Road's End Catacomb&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -581,9 +549,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="illusory_walls_1_10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=illusory_walls_1_10&amp;id=illusory_walls_1_10&amp;link=/checklists/illusory_walls_invisible_paths.html%23item_1_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Three+Sisters&quot;&gt;Three Sisters&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=illusory_walls_1_10&amp;id=illusory_walls_1_10&amp;link=/checklists/illusory_walls_invisible_paths.html%23item_1_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Three+Sisters&quot;&gt;Three Sisters&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -614,9 +580,7 @@
         <div class="card shadow-sm mb-3" id="illusory_walls_section_1">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#illusory_walls_1Col" data-bs-toggle="collapse" href="#illusory_walls_1Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#illusory_walls_1Col" data-bs-toggle="collapse" href="#illusory_walls_1Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Caelid">Caelid</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="illusory_walls_totals_1"></span>
             </h4>
@@ -628,9 +592,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -659,9 +621,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="illusory_walls_2_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=illusory_walls_2_1&amp;id=illusory_walls_2_1&amp;link=/checklists/illusory_walls_invisible_paths.html%23item_2_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Caelid+Catacombs&quot;&gt;Caelid Catacombs&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=illusory_walls_2_1&amp;id=illusory_walls_2_1&amp;link=/checklists/illusory_walls_invisible_paths.html%23item_2_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Caelid+Catacombs&quot;&gt;Caelid Catacombs&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -691,9 +651,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="illusory_walls_2_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=illusory_walls_2_2&amp;id=illusory_walls_2_2&amp;link=/checklists/illusory_walls_invisible_paths.html%23item_2_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Sellia+Hideaway&quot;&gt;Sellia Hideaway&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=illusory_walls_2_2&amp;id=illusory_walls_2_2&amp;link=/checklists/illusory_walls_invisible_paths.html%23item_2_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Sellia+Hideaway&quot;&gt;Sellia Hideaway&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -724,9 +682,7 @@
         <div class="card shadow-sm mb-3" id="illusory_walls_section_2">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#illusory_walls_2Col" data-bs-toggle="collapse" href="#illusory_walls_2Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#illusory_walls_2Col" data-bs-toggle="collapse" href="#illusory_walls_2Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Altus+Plateau">Altus Plateau</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="illusory_walls_totals_2"></span>
             </h4>
@@ -738,9 +694,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -769,9 +723,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="illusory_walls_3_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=illusory_walls_3_1&amp;id=illusory_walls_3_1&amp;link=/checklists/illusory_walls_invisible_paths.html%23item_3_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Auriza+Side+Tomb&quot;&gt;Auriza Side Tomb&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=illusory_walls_3_1&amp;id=illusory_walls_3_1&amp;link=/checklists/illusory_walls_invisible_paths.html%23item_3_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Auriza+Side+Tomb&quot;&gt;Auriza Side Tomb&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -801,9 +753,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="illusory_walls_3_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=illusory_walls_3_2&amp;id=illusory_walls_3_2&amp;link=/checklists/illusory_walls_invisible_paths.html%23item_3_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Mirage+Rise&quot;&gt;Mirage Rise&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=illusory_walls_3_2&amp;id=illusory_walls_3_2&amp;link=/checklists/illusory_walls_invisible_paths.html%23item_3_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Mirage+Rise&quot;&gt;Mirage Rise&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -833,9 +783,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="illusory_walls_3_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=illusory_walls_3_3&amp;id=illusory_walls_3_3&amp;link=/checklists/illusory_walls_invisible_paths.html%23item_3_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Sage's+Cave&quot;&gt;Sage's Cave&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=illusory_walls_3_3&amp;id=illusory_walls_3_3&amp;link=/checklists/illusory_walls_invisible_paths.html%23item_3_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Sage's+Cave&quot;&gt;Sage's Cave&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -865,9 +813,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="illusory_walls_3_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=illusory_walls_3_4&amp;id=illusory_walls_3_4&amp;link=/checklists/illusory_walls_invisible_paths.html%23item_3_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Sainted+Hero's+Grave&quot;&gt;Sainted Hero's Grave&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=illusory_walls_3_4&amp;id=illusory_walls_3_4&amp;link=/checklists/illusory_walls_invisible_paths.html%23item_3_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Sainted+Hero's+Grave&quot;&gt;Sainted Hero's Grave&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -897,9 +843,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="illusory_walls_3_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=illusory_walls_3_5&amp;id=illusory_walls_3_5&amp;link=/checklists/illusory_walls_invisible_paths.html%23item_3_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Sealed+Tunnel&quot;&gt;Sealed Tunnel&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=illusory_walls_3_5&amp;id=illusory_walls_3_5&amp;link=/checklists/illusory_walls_invisible_paths.html%23item_3_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Sealed+Tunnel&quot;&gt;Sealed Tunnel&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -929,9 +873,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="illusory_walls_3_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=illusory_walls_3_6&amp;id=illusory_walls_3_6&amp;link=/checklists/illusory_walls_invisible_paths.html%23item_3_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Sealed+Tunnel&quot;&gt;Sealed Tunnel&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=illusory_walls_3_6&amp;id=illusory_walls_3_6&amp;link=/checklists/illusory_walls_invisible_paths.html%23item_3_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Sealed+Tunnel&quot;&gt;Sealed Tunnel&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -962,9 +904,7 @@
         <div class="card shadow-sm mb-3" id="illusory_walls_section_3">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#illusory_walls_3Col" data-bs-toggle="collapse" href="#illusory_walls_3Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#illusory_walls_3Col" data-bs-toggle="collapse" href="#illusory_walls_3Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Subterranean+Shunning-Grounds">Subterranean Shunning-Grounds</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="illusory_walls_totals_3"></span>
             </h4>
@@ -976,9 +916,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -1007,9 +945,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="illusory_walls_4_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=illusory_walls_4_1&amp;id=illusory_walls_4_1&amp;link=/checklists/illusory_walls_invisible_paths.html%23item_4_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Frenzied+Flame+Proscription&quot;&gt;Frenzied Flame Proscription&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=illusory_walls_4_1&amp;id=illusory_walls_4_1&amp;link=/checklists/illusory_walls_invisible_paths.html%23item_4_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Frenzied+Flame+Proscription&quot;&gt;Frenzied Flame Proscription&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1039,9 +975,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="illusory_walls_4_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=illusory_walls_4_2&amp;id=illusory_walls_4_2&amp;link=/checklists/illusory_walls_invisible_paths.html%23item_4_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Leyndell+Catacombs&quot;&gt;Leyndell Catacombs&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=illusory_walls_4_2&amp;id=illusory_walls_4_2&amp;link=/checklists/illusory_walls_invisible_paths.html%23item_4_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Leyndell+Catacombs&quot;&gt;Leyndell Catacombs&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1072,9 +1006,7 @@
         <div class="card shadow-sm mb-3" id="illusory_walls_section_4">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#illusory_walls_4Col" data-bs-toggle="collapse" href="#illusory_walls_4Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#illusory_walls_4Col" data-bs-toggle="collapse" href="#illusory_walls_4Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Forbidden+Lands">Forbidden Lands</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="illusory_walls_totals_4"></span>
             </h4>
@@ -1086,9 +1018,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -1117,9 +1047,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="illusory_walls_5_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=illusory_walls_5_1&amp;id=illusory_walls_5_1&amp;link=/checklists/illusory_walls_invisible_paths.html%23item_5_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Hidden+Path+to+the+Haligtree&quot;&gt;Hidden Path to the Haligtree&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=illusory_walls_5_1&amp;id=illusory_walls_5_1&amp;link=/checklists/illusory_walls_invisible_paths.html%23item_5_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Hidden+Path+to+the+Haligtree&quot;&gt;Hidden Path to the Haligtree&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1150,9 +1078,7 @@
         <div class="card shadow-sm mb-3" id="illusory_walls_section_5">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#illusory_walls_5Col" data-bs-toggle="collapse" href="#illusory_walls_5Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#illusory_walls_5Col" data-bs-toggle="collapse" href="#illusory_walls_5Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Mountaintops+of+the+Giants">Mountaintops of the Giants</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="illusory_walls_totals_5"></span>
             </h4>
@@ -1164,9 +1090,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -1195,9 +1119,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="illusory_walls_6_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=illusory_walls_6_1&amp;id=illusory_walls_6_1&amp;link=/checklists/illusory_walls_invisible_paths.html%23item_6_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Giant-Conquering+Hero's+Grave&quot;&gt;Giant-Conquering Hero's Grave&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=illusory_walls_6_1&amp;id=illusory_walls_6_1&amp;link=/checklists/illusory_walls_invisible_paths.html%23item_6_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Giant-Conquering+Hero's+Grave&quot;&gt;Giant-Conquering Hero's Grave&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1227,9 +1149,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="illusory_walls_6_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=illusory_walls_6_2&amp;id=illusory_walls_6_2&amp;link=/checklists/illusory_walls_invisible_paths.html%23item_6_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Giants'+Mountaintop+Catacombs&quot;&gt;Giants' Mountaintop Catacombs&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=illusory_walls_6_2&amp;id=illusory_walls_6_2&amp;link=/checklists/illusory_walls_invisible_paths.html%23item_6_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Giants'+Mountaintop+Catacombs&quot;&gt;Giants' Mountaintop Catacombs&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1259,9 +1179,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="illusory_walls_6_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=illusory_walls_6_3&amp;id=illusory_walls_6_3&amp;link=/checklists/illusory_walls_invisible_paths.html%23item_6_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Heretical+Rise&quot;&gt;Heretical Rise&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=illusory_walls_6_3&amp;id=illusory_walls_6_3&amp;link=/checklists/illusory_walls_invisible_paths.html%23item_6_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Heretical+Rise&quot;&gt;Heretical Rise&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1292,9 +1210,7 @@
         <div class="card shadow-sm mb-3" id="illusory_walls_section_6">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#illusory_walls_6Col" data-bs-toggle="collapse" href="#illusory_walls_6Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#illusory_walls_6Col" data-bs-toggle="collapse" href="#illusory_walls_6Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Mt+Gelmir">Mt. Gelmir</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="illusory_walls_totals_6"></span>
             </h4>
@@ -1306,9 +1222,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -1337,9 +1251,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="illusory_walls_7_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=illusory_walls_7_1&amp;id=illusory_walls_7_1&amp;link=/checklists/illusory_walls_invisible_paths.html%23item_7_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Volcano+Manor&quot;&gt;Volcano Manor&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=illusory_walls_7_1&amp;id=illusory_walls_7_1&amp;link=/checklists/illusory_walls_invisible_paths.html%23item_7_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Volcano+Manor&quot;&gt;Volcano Manor&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1369,9 +1281,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="illusory_walls_7_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=illusory_walls_7_2&amp;id=illusory_walls_7_2&amp;link=/checklists/illusory_walls_invisible_paths.html%23item_7_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Volcano+Manor&quot;&gt;Volcano Manor&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=illusory_walls_7_2&amp;id=illusory_walls_7_2&amp;link=/checklists/illusory_walls_invisible_paths.html%23item_7_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Volcano+Manor&quot;&gt;Volcano Manor&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">

--- a/docs/checklists/incantations.html
+++ b/docs/checklists/incantations.html
@@ -27,14 +27,10 @@
         <a class="navbar-brand me-auto ms-2" href="/index.html">Roundtable Guides</a>
         <form class="d-none d-sm-flex order-2 order-xl-3">
           <input aria-label="search" class="form-control me-2" name="search" placeholder="Search" type="search">
-          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit">
-            <i class="bi bi-search"></i>
-          </button>
+          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit"><i class="bi bi-search"></i></button>
         </form>
         <div class="d-sm-none order-2">
-          <a class="nav-link me-0" href="/search.html">
-            <i class="bi bi-search sb-icon-search"></i>
-          </a>
+          <a class="nav-link me-0" href="/search.html"><i class="bi bi-search sb-icon-search"></i></a>
         </div>
         <div class="collapse navbar-collapse order-3 order-xl-2 ms-xl-2" id="nav-collapse">
           <ul class="nav navbar-nav navbar-nav-scroll mr-auto">
@@ -179,14 +175,10 @@
               </ul>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/map.html">
-                <i class="bi bi-map"></i> Map
-              </a>
+              <a class="nav-link hide-buttons" href="/map.html"><i class="bi bi-map"></i> Map</a>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/options.html">
-                <i class="bi bi-gear-fill"></i> Options
-              </a>
+              <a class="nav-link hide-buttons" href="/options.html"><i class="bi bi-gear-fill"></i> Options</a>
             </li>
           </ul>
         </div>
@@ -206,9 +198,7 @@
       </div>
       <nav class="text-muted toc d-print-none">
         <strong class="d-block h5">
-          <a class="toc-button" data-bs-toggle="collapse" href="#toc_incantations" role="button">
-            <i class="bi bi-plus-lg"></i>Table Of Contents
-          </a>
+          <a class="toc-button" data-bs-toggle="collapse" href="#toc_incantations" role="button"><i class="bi bi-plus-lg"></i>Table Of Contents</a>
         </strong>
         <ul class="toc_page collapse" id="toc_incantations">
           <li>
@@ -282,9 +272,7 @@
         <div class="card shadow-sm mb-3" id="incantations_section_0">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#incantations_0Col" data-bs-toggle="collapse" href="#incantations_0Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#incantations_0Col" data-bs-toggle="collapse" href="#incantations_0Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Bestial Incantations</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="incantations_totals_0"></span>
             </h4>
@@ -296,9 +284,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -327,9 +313,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="incantations_1_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_1_1&amp;id=incantations_1_1&amp;link=/checklists/incantations.html%23item_1_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Beast+Claw&quot;&gt;Beast Claw&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_1_1&amp;id=incantations_1_1&amp;link=/checklists/incantations.html%23item_1_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Beast+Claw&quot;&gt;Beast Claw&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -362,9 +346,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="incantations_1_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_1_2&amp;id=incantations_1_2&amp;link=/checklists/incantations.html%23item_1_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Bestial+Constitution&quot;&gt;Bestial Constitution&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_1_2&amp;id=incantations_1_2&amp;link=/checklists/incantations.html%23item_1_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Bestial+Constitution&quot;&gt;Bestial Constitution&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -397,9 +379,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="incantations_1_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_1_3&amp;id=incantations_1_3&amp;link=/checklists/incantations.html%23item_1_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Bestial+Sling&quot;&gt;Bestial Sling&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_1_3&amp;id=incantations_1_3&amp;link=/checklists/incantations.html%23item_1_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Bestial+Sling&quot;&gt;Bestial Sling&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -432,9 +412,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="incantations_1_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_1_4&amp;id=incantations_1_4&amp;link=/checklists/incantations.html%23item_1_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Bestial+Vitality&quot;&gt;Bestial Vitality&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_1_4&amp;id=incantations_1_4&amp;link=/checklists/incantations.html%23item_1_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Bestial+Vitality&quot;&gt;Bestial Vitality&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -467,9 +445,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="incantations_1_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_1_5&amp;id=incantations_1_5&amp;link=/checklists/incantations.html%23item_1_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gurranq's+Beast+Claw&quot;&gt;Gurrang's Beast Claw&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_1_5&amp;id=incantations_1_5&amp;link=/checklists/incantations.html%23item_1_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gurranq's+Beast+Claw&quot;&gt;Gurrang's Beast Claw&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -502,9 +478,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="incantations_1_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_1_6&amp;id=incantations_1_6&amp;link=/checklists/incantations.html%23item_1_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Stone+of+Gurranq&quot;&gt;Stone of Gurranq&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_1_6&amp;id=incantations_1_6&amp;link=/checklists/incantations.html%23item_1_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Stone+of+Gurranq&quot;&gt;Stone of Gurranq&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -538,9 +512,7 @@
         <div class="card shadow-sm mb-3" id="incantations_section_1">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#incantations_1Col" data-bs-toggle="collapse" href="#incantations_1Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#incantations_1Col" data-bs-toggle="collapse" href="#incantations_1Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Blood Incantations</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="incantations_totals_1"></span>
             </h4>
@@ -552,9 +524,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -583,9 +553,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="incantations_2_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_2_1&amp;id=incantations_2_1&amp;link=/checklists/incantations.html%23item_2_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Bloodboon&quot;&gt;Bloodboon&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_2_1&amp;id=incantations_2_1&amp;link=/checklists/incantations.html%23item_2_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Bloodboon&quot;&gt;Bloodboon&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -618,9 +586,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="incantations_2_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_2_2&amp;id=incantations_2_2&amp;link=/checklists/incantations.html%23item_2_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Bloodflame+Blade&quot;&gt;Bloodflame Blade&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_2_2&amp;id=incantations_2_2&amp;link=/checklists/incantations.html%23item_2_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Bloodflame+Blade&quot;&gt;Bloodflame Blade&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -653,9 +619,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="incantations_2_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_2_3&amp;id=incantations_2_3&amp;link=/checklists/incantations.html%23item_2_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Bloodflame+Talons&quot;&gt;Bloodflame Talons&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_2_3&amp;id=incantations_2_3&amp;link=/checklists/incantations.html%23item_2_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Bloodflame+Talons&quot;&gt;Bloodflame Talons&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -688,9 +652,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="incantations_2_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_2_4&amp;id=incantations_2_4&amp;link=/checklists/incantations.html%23item_2_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Swarm+of+Flies&quot;&gt;Swarm Of Flies&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_2_4&amp;id=incantations_2_4&amp;link=/checklists/incantations.html%23item_2_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Swarm+of+Flies&quot;&gt;Swarm Of Flies&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -724,9 +686,7 @@
         <div class="card shadow-sm mb-3" id="incantations_section_2">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#incantations_2Col" data-bs-toggle="collapse" href="#incantations_2Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#incantations_2Col" data-bs-toggle="collapse" href="#incantations_2Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Dragon Communion Incantations</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="incantations_totals_2"></span>
             </h4>
@@ -738,9 +698,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -769,9 +727,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="incantations_3_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_3_1&amp;id=incantations_3_1&amp;link=/checklists/incantations.html%23item_3_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Agheel's+Flame&quot;&gt;Agheel's Flame&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_3_1&amp;id=incantations_3_1&amp;link=/checklists/incantations.html%23item_3_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Agheel's+Flame&quot;&gt;Agheel's Flame&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -804,9 +760,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="incantations_3_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_3_2&amp;id=incantations_3_2&amp;link=/checklists/incantations.html%23item_3_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Borealis's+Mist&quot;&gt;Borealis's Mist&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_3_2&amp;id=incantations_3_2&amp;link=/checklists/incantations.html%23item_3_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Borealis's+Mist&quot;&gt;Borealis's Mist&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -839,9 +793,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="incantations_3_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_3_3&amp;id=incantations_3_3&amp;link=/checklists/incantations.html%23item_3_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dragonclaw&quot;&gt;Dragonclaw&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_3_3&amp;id=incantations_3_3&amp;link=/checklists/incantations.html%23item_3_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dragonclaw&quot;&gt;Dragonclaw&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -874,9 +826,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="incantations_3_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_3_4&amp;id=incantations_3_4&amp;link=/checklists/incantations.html%23item_3_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dragonfire&quot;&gt;Dragonfire&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_3_4&amp;id=incantations_3_4&amp;link=/checklists/incantations.html%23item_3_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dragonfire&quot;&gt;Dragonfire&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -909,9 +859,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="incantations_3_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_3_5&amp;id=incantations_3_5&amp;link=/checklists/incantations.html%23item_3_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dragonice&quot;&gt;Dragonice&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_3_5&amp;id=incantations_3_5&amp;link=/checklists/incantations.html%23item_3_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dragonice&quot;&gt;Dragonice&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -944,9 +892,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="incantations_3_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_3_6&amp;id=incantations_3_6&amp;link=/checklists/incantations.html%23item_3_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dragonmaw&quot;&gt;Dragonmaw&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_3_6&amp;id=incantations_3_6&amp;link=/checklists/incantations.html%23item_3_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dragonmaw&quot;&gt;Dragonmaw&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -979,9 +925,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="incantations_3_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_3_7&amp;id=incantations_3_7&amp;link=/checklists/incantations.html%23item_3_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ekzykes's+Decay&quot;&gt;Ekzykes's Decay&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_3_7&amp;id=incantations_3_7&amp;link=/checklists/incantations.html%23item_3_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ekzykes's+Decay&quot;&gt;Ekzykes's Decay&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1014,9 +958,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="incantations_3_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_3_8&amp;id=incantations_3_8&amp;link=/checklists/incantations.html%23item_3_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Glintstone+Breath&quot;&gt;Glintstone Breath&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_3_8&amp;id=incantations_3_8&amp;link=/checklists/incantations.html%23item_3_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Glintstone+Breath&quot;&gt;Glintstone Breath&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1049,9 +991,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="incantations_3_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_3_9&amp;id=incantations_3_9&amp;link=/checklists/incantations.html%23item_3_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Greyoll's+Roar&quot;&gt;Greyoll's Roar&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_3_9&amp;id=incantations_3_9&amp;link=/checklists/incantations.html%23item_3_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Greyoll's+Roar&quot;&gt;Greyoll's Roar&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1084,9 +1024,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="incantations_3_10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_3_10&amp;id=incantations_3_10&amp;link=/checklists/incantations.html%23item_3_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Magma+Breath&quot;&gt;Magma Breath&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_3_10&amp;id=incantations_3_10&amp;link=/checklists/incantations.html%23item_3_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Magma+Breath&quot;&gt;Magma Breath&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1119,9 +1057,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="incantations_3_12" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_3_12&amp;id=incantations_3_12&amp;link=/checklists/incantations.html%23item_3_12&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Rotten+Breath&quot;&gt;Rotten Breath&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_3_12&amp;id=incantations_3_12&amp;link=/checklists/incantations.html%23item_3_12&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Rotten+Breath&quot;&gt;Rotten Breath&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1154,9 +1090,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="incantations_3_13" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_3_13&amp;id=incantations_3_13&amp;link=/checklists/incantations.html%23item_3_13&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Smarag's+Glintstone+Breath&quot;&gt;Smarag's Glintstone Breath&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_3_13&amp;id=incantations_3_13&amp;link=/checklists/incantations.html%23item_3_13&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Smarag's+Glintstone+Breath&quot;&gt;Smarag's Glintstone Breath&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1189,9 +1123,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="incantations_3_14" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_3_14&amp;id=incantations_3_14&amp;link=/checklists/incantations.html%23item_3_14&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Theodorix's+Magma&quot;&gt;Theodorix's Magma&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_3_14&amp;id=incantations_3_14&amp;link=/checklists/incantations.html%23item_3_14&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Theodorix's+Magma&quot;&gt;Theodorix's Magma&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1225,9 +1157,7 @@
         <div class="card shadow-sm mb-3" id="incantations_section_3">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#incantations_3Col" data-bs-toggle="collapse" href="#incantations_3Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#incantations_3Col" data-bs-toggle="collapse" href="#incantations_3Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Dragon Cult Incantations</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="incantations_totals_3"></span>
             </h4>
@@ -1239,9 +1169,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -1270,9 +1198,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="incantations_4_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_4_1&amp;id=incantations_4_1&amp;link=/checklists/incantations.html%23item_4_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ancient+Dragons'+Lightning+Spear&quot;&gt;Ancient Dragons' Lightning Spear&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_4_1&amp;id=incantations_4_1&amp;link=/checklists/incantations.html%23item_4_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ancient+Dragons'+Lightning+Spear&quot;&gt;Ancient Dragons' Lightning Spear&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1305,9 +1231,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="incantations_4_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_4_2&amp;id=incantations_4_2&amp;link=/checklists/incantations.html%23item_4_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ancient+Dragons'+Lightning+Strike&quot;&gt;Ancient Dragons' Lightning Strike&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_4_2&amp;id=incantations_4_2&amp;link=/checklists/incantations.html%23item_4_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ancient+Dragons'+Lightning+Strike&quot;&gt;Ancient Dragons' Lightning Strike&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1340,9 +1264,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="incantations_4_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_4_3&amp;id=incantations_4_3&amp;link=/checklists/incantations.html%23item_4_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Death+Lightning&quot;&gt;Death Lightning&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_4_3&amp;id=incantations_4_3&amp;link=/checklists/incantations.html%23item_4_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Death+Lightning&quot;&gt;Death Lightning&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1375,9 +1297,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="incantations_4_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_4_4&amp;id=incantations_4_4&amp;link=/checklists/incantations.html%23item_4_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dragonbolt+Blessing&quot;&gt;Dragonbolt Blessing&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_4_4&amp;id=incantations_4_4&amp;link=/checklists/incantations.html%23item_4_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dragonbolt+Blessing&quot;&gt;Dragonbolt Blessing&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1410,9 +1330,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="incantations_4_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_4_5&amp;id=incantations_4_5&amp;link=/checklists/incantations.html%23item_4_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Electrify+Armament&quot;&gt;Electrify Armament&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_4_5&amp;id=incantations_4_5&amp;link=/checklists/incantations.html%23item_4_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Electrify+Armament&quot;&gt;Electrify Armament&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1445,9 +1363,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="incantations_4_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_4_6&amp;id=incantations_4_6&amp;link=/checklists/incantations.html%23item_4_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Fortissax's+Lightning+Spear&quot;&gt;Fortissax's Lightning Spear&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_4_6&amp;id=incantations_4_6&amp;link=/checklists/incantations.html%23item_4_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Fortissax's+Lightning+Spear&quot;&gt;Fortissax's Lightning Spear&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1480,9 +1396,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="incantations_4_12" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_4_12&amp;id=incantations_4_12&amp;link=/checklists/incantations.html%23item_4_12&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Frozen+Lightning+Spear&quot;&gt;Frozen Lightning Spear&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_4_12&amp;id=incantations_4_12&amp;link=/checklists/incantations.html%23item_4_12&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Frozen+Lightning+Spear&quot;&gt;Frozen Lightning Spear&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1515,9 +1429,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="incantations_4_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_4_7&amp;id=incantations_4_7&amp;link=/checklists/incantations.html%23item_4_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Honed+Bolt&quot;&gt;Honed Bolt&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_4_7&amp;id=incantations_4_7&amp;link=/checklists/incantations.html%23item_4_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Honed+Bolt&quot;&gt;Honed Bolt&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1550,9 +1462,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="incantations_4_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_4_8&amp;id=incantations_4_8&amp;link=/checklists/incantations.html%23item_4_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Lansseax's+Glaive&quot;&gt;Lansseax's Glaive&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_4_8&amp;id=incantations_4_8&amp;link=/checklists/incantations.html%23item_4_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Lansseax's+Glaive&quot;&gt;Lansseax's Glaive&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1585,9 +1495,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="incantations_4_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_4_9&amp;id=incantations_4_9&amp;link=/checklists/incantations.html%23item_4_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Lightning+Spear&quot;&gt;Lightning Spear&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_4_9&amp;id=incantations_4_9&amp;link=/checklists/incantations.html%23item_4_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Lightning+Spear&quot;&gt;Lightning Spear&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1620,9 +1528,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="incantations_4_10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_4_10&amp;id=incantations_4_10&amp;link=/checklists/incantations.html%23item_4_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Lightning+Strike&quot;&gt;Lightning Strike&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_4_10&amp;id=incantations_4_10&amp;link=/checklists/incantations.html%23item_4_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Lightning+Strike&quot;&gt;Lightning Strike&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1655,9 +1561,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="incantations_3_11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_3_11&amp;id=incantations_3_11&amp;link=/checklists/incantations.html%23item_3_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Placidusax's+Ruin&quot;&gt;Placidusax's Ruin&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_3_11&amp;id=incantations_3_11&amp;link=/checklists/incantations.html%23item_3_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Placidusax's+Ruin&quot;&gt;Placidusax's Ruin&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1690,9 +1594,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="incantations_4_11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_4_11&amp;id=incantations_4_11&amp;link=/checklists/incantations.html%23item_4_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Vyke's+Dragonbolt&quot;&gt;Vyke's Dragonbolt&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_4_11&amp;id=incantations_4_11&amp;link=/checklists/incantations.html%23item_4_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Vyke's+Dragonbolt&quot;&gt;Vyke's Dragonbolt&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1726,9 +1628,7 @@
         <div class="card shadow-sm mb-3" id="incantations_section_4">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#incantations_4Col" data-bs-toggle="collapse" href="#incantations_4Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#incantations_4Col" data-bs-toggle="collapse" href="#incantations_4Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Erdtree Incantations</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="incantations_totals_4"></span>
             </h4>
@@ -1740,9 +1640,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -1771,9 +1669,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="incantations_5_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_5_1&amp;id=incantations_5_1&amp;link=/checklists/incantations.html%23item_5_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Aspects+of+the+Crucible:+Breath&quot;&gt;Aspect Of The Crucible: Breath&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_5_1&amp;id=incantations_5_1&amp;link=/checklists/incantations.html%23item_5_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Aspects+of+the+Crucible:+Breath&quot;&gt;Aspect Of The Crucible: Breath&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1806,9 +1702,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="incantations_5_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_5_2&amp;id=incantations_5_2&amp;link=/checklists/incantations.html%23item_5_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Aspects+of+the+Crucible:+Horns&quot;&gt;Aspect Of The Crucible Horns&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_5_2&amp;id=incantations_5_2&amp;link=/checklists/incantations.html%23item_5_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Aspects+of+the+Crucible:+Horns&quot;&gt;Aspect Of The Crucible Horns&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1841,9 +1735,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="incantations_5_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_5_3&amp;id=incantations_5_3&amp;link=/checklists/incantations.html%23item_5_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Aspects+of+the+Crucible:+Tail&quot;&gt;Aspects Of The Crucible: Tail&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_5_3&amp;id=incantations_5_3&amp;link=/checklists/incantations.html%23item_5_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Aspects+of+the+Crucible:+Tail&quot;&gt;Aspects Of The Crucible: Tail&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1876,9 +1768,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="incantations_5_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_5_4&amp;id=incantations_5_4&amp;link=/checklists/incantations.html%23item_5_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Barrier+of+Gold&quot;&gt;Barrier Of Gold&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_5_4&amp;id=incantations_5_4&amp;link=/checklists/incantations.html%23item_5_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Barrier+of+Gold&quot;&gt;Barrier Of Gold&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1911,9 +1801,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="incantations_5_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_5_5&amp;id=incantations_5_5&amp;link=/checklists/incantations.html%23item_5_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Black+Blade&quot;&gt;Black Blade&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_5_5&amp;id=incantations_5_5&amp;link=/checklists/incantations.html%23item_5_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Black+Blade&quot;&gt;Black Blade&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1946,9 +1834,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="incantations_5_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_5_6&amp;id=incantations_5_6&amp;link=/checklists/incantations.html%23item_5_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Blessing+of+the+Erdtree&quot;&gt;Blessing Of The Erdtree&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_5_6&amp;id=incantations_5_6&amp;link=/checklists/incantations.html%23item_5_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Blessing+of+the+Erdtree&quot;&gt;Blessing Of The Erdtree&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1981,9 +1867,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="incantations_5_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_5_7&amp;id=incantations_5_7&amp;link=/checklists/incantations.html%23item_5_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Blessing's+Boon&quot;&gt;Blessing's Boon&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_5_7&amp;id=incantations_5_7&amp;link=/checklists/incantations.html%23item_5_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Blessing's+Boon&quot;&gt;Blessing's Boon&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2016,9 +1900,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="incantations_5_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_5_8&amp;id=incantations_5_8&amp;link=/checklists/incantations.html%23item_5_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Elden+Stars&quot;&gt;Elden Stars&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_5_8&amp;id=incantations_5_8&amp;link=/checklists/incantations.html%23item_5_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Elden+Stars&quot;&gt;Elden Stars&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2051,9 +1933,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="incantations_5_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_5_9&amp;id=incantations_5_9&amp;link=/checklists/incantations.html%23item_5_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Erdtree+Heal&quot;&gt;Erdtree Heal&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_5_9&amp;id=incantations_5_9&amp;link=/checklists/incantations.html%23item_5_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Erdtree+Heal&quot;&gt;Erdtree Heal&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2086,9 +1966,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="incantations_5_10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_5_10&amp;id=incantations_5_10&amp;link=/checklists/incantations.html%23item_5_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Golden+Lightning+Fortification&quot;&gt;Golden Lightning Fortification&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_5_10&amp;id=incantations_5_10&amp;link=/checklists/incantations.html%23item_5_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Golden+Lightning+Fortification&quot;&gt;Golden Lightning Fortification&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2121,9 +1999,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="incantations_5_11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_5_11&amp;id=incantations_5_11&amp;link=/checklists/incantations.html%23item_5_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Golden+Vow+(Spell)&quot;&gt;Golden Vow&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_5_11&amp;id=incantations_5_11&amp;link=/checklists/incantations.html%23item_5_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Golden+Vow+(Spell)&quot;&gt;Golden Vow&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2156,9 +2032,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="incantations_5_12" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_5_12&amp;id=incantations_5_12&amp;link=/checklists/incantations.html%23item_5_12&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Protection+of+the+Erdtree&quot;&gt;Protection Of The Erdtree&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_5_12&amp;id=incantations_5_12&amp;link=/checklists/incantations.html%23item_5_12&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Protection+of+the+Erdtree&quot;&gt;Protection Of The Erdtree&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2191,9 +2065,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="incantations_5_13" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_5_13&amp;id=incantations_5_13&amp;link=/checklists/incantations.html%23item_5_13&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Wrath+of+Gold&quot;&gt;Wrath Of Gold&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_5_13&amp;id=incantations_5_13&amp;link=/checklists/incantations.html%23item_5_13&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Wrath+of+Gold&quot;&gt;Wrath Of Gold&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2227,9 +2099,7 @@
         <div class="card shadow-sm mb-3" id="incantations_section_5">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#incantations_5Col" data-bs-toggle="collapse" href="#incantations_5Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#incantations_5Col" data-bs-toggle="collapse" href="#incantations_5Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Fire Giant Incantations</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="incantations_totals_5"></span>
             </h4>
@@ -2241,9 +2111,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -2272,9 +2140,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="incantations_6_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_6_1&amp;id=incantations_6_1&amp;link=/checklists/incantations.html%23item_6_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Burn+O+Flame!&quot;&gt;Burn, O Flame&lt;/a&gt;!">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_6_1&amp;id=incantations_6_1&amp;link=/checklists/incantations.html%23item_6_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Burn+O+Flame!&quot;&gt;Burn, O Flame&lt;/a&gt;!"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2307,9 +2173,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="incantations_6_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_6_2&amp;id=incantations_6_2&amp;link=/checklists/incantations.html%23item_6_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Flame+of+the+Fell+God&quot;&gt;Flame Of The Fell God&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_6_2&amp;id=incantations_6_2&amp;link=/checklists/incantations.html%23item_6_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Flame+of+the+Fell+God&quot;&gt;Flame Of The Fell God&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2342,9 +2206,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="incantations_6_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_6_3&amp;id=incantations_6_3&amp;link=/checklists/incantations.html%23item_6_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Flame+Fall+Upon+Them&quot;&gt;Flame, Fall Upon Them&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_6_3&amp;id=incantations_6_3&amp;link=/checklists/incantations.html%23item_6_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Flame+Fall+Upon+Them&quot;&gt;Flame, Fall Upon Them&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2377,9 +2239,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="incantations_6_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_6_4&amp;id=incantations_6_4&amp;link=/checklists/incantations.html%23item_6_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Giantsflame+Take+Thee&quot;&gt;Giantsflame Take Thee&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_6_4&amp;id=incantations_6_4&amp;link=/checklists/incantations.html%23item_6_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Giantsflame+Take+Thee&quot;&gt;Giantsflame Take Thee&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2413,9 +2273,7 @@
         <div class="card shadow-sm mb-3" id="incantations_section_6">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#incantations_6Col" data-bs-toggle="collapse" href="#incantations_6Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#incantations_6Col" data-bs-toggle="collapse" href="#incantations_6Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Fire Monk Incantations</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="incantations_totals_6"></span>
             </h4>
@@ -2427,9 +2285,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -2458,9 +2314,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="incantations_7_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_7_9&amp;id=incantations_7_9&amp;link=/checklists/incantations.html%23item_7_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Catch+Flame&quot;&gt;Catch Flame&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_7_9&amp;id=incantations_7_9&amp;link=/checklists/incantations.html%23item_7_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Catch+Flame&quot;&gt;Catch Flame&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2493,9 +2347,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="incantations_7_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_7_8&amp;id=incantations_7_8&amp;link=/checklists/incantations.html%23item_7_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Fire's+Deadly+Sin&quot;&gt;Fire's Deadly Sin&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_7_8&amp;id=incantations_7_8&amp;link=/checklists/incantations.html%23item_7_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Fire's+Deadly+Sin&quot;&gt;Fire's Deadly Sin&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2528,9 +2380,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="incantations_7_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_7_1&amp;id=incantations_7_1&amp;link=/checklists/incantations.html%23item_7_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Flame+Sling&quot;&gt;Flame Sling&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_7_1&amp;id=incantations_7_1&amp;link=/checklists/incantations.html%23item_7_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Flame+Sling&quot;&gt;Flame Sling&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2563,9 +2413,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="incantations_7_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_7_2&amp;id=incantations_7_2&amp;link=/checklists/incantations.html%23item_7_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Flame+Cleanse+Me&quot;&gt;Flame, Cleanse Me&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_7_2&amp;id=incantations_7_2&amp;link=/checklists/incantations.html%23item_7_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Flame+Cleanse+Me&quot;&gt;Flame, Cleanse Me&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2598,9 +2446,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="incantations_7_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_7_3&amp;id=incantations_7_3&amp;link=/checklists/incantations.html%23item_7_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Flame+Grant+Me+Strength&quot;&gt;Flame, Grant Me Strength&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_7_3&amp;id=incantations_7_3&amp;link=/checklists/incantations.html%23item_7_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Flame+Grant+Me+Strength&quot;&gt;Flame, Grant Me Strength&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2633,9 +2479,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="incantations_7_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_7_4&amp;id=incantations_7_4&amp;link=/checklists/incantations.html%23item_7_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Flame+Protect+Me&quot;&gt;Flame, Protect Me&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_7_4&amp;id=incantations_7_4&amp;link=/checklists/incantations.html%23item_7_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Flame+Protect+Me&quot;&gt;Flame, Protect Me&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2668,9 +2512,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="incantations_7_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_7_5&amp;id=incantations_7_5&amp;link=/checklists/incantations.html%23item_7_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/O+Flame!&quot;&gt;O, Flame!&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_7_5&amp;id=incantations_7_5&amp;link=/checklists/incantations.html%23item_7_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/O+Flame!&quot;&gt;O, Flame!&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2703,9 +2545,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="incantations_7_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_7_6&amp;id=incantations_7_6&amp;link=/checklists/incantations.html%23item_7_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Surge+O+Flame!&quot;&gt;Surge, O Flame&lt;/a&gt;!">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_7_6&amp;id=incantations_7_6&amp;link=/checklists/incantations.html%23item_7_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Surge+O+Flame!&quot;&gt;Surge, O Flame&lt;/a&gt;!"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2738,9 +2578,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="incantations_7_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_7_7&amp;id=incantations_7_7&amp;link=/checklists/incantations.html%23item_7_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Whirl+O+Flame!&quot;&gt;Whirl, O Flame!&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_7_7&amp;id=incantations_7_7&amp;link=/checklists/incantations.html%23item_7_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Whirl+O+Flame!&quot;&gt;Whirl, O Flame!&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2774,9 +2612,7 @@
         <div class="card shadow-sm mb-3" id="incantations_section_7">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#incantations_7Col" data-bs-toggle="collapse" href="#incantations_7Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#incantations_7Col" data-bs-toggle="collapse" href="#incantations_7Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Frenzied Flame Incantations</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="incantations_totals_7"></span>
             </h4>
@@ -2788,9 +2624,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -2819,9 +2653,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="incantations_8_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_8_1&amp;id=incantations_8_1&amp;link=/checklists/incantations.html%23item_8_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Frenzied+Burst&quot;&gt;Frenzied Burst&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_8_1&amp;id=incantations_8_1&amp;link=/checklists/incantations.html%23item_8_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Frenzied+Burst&quot;&gt;Frenzied Burst&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2854,9 +2686,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="incantations_8_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_8_2&amp;id=incantations_8_2&amp;link=/checklists/incantations.html%23item_8_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Howl+of+Shabriri&quot;&gt;Howl Of Shabriri&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_8_2&amp;id=incantations_8_2&amp;link=/checklists/incantations.html%23item_8_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Howl+of+Shabriri&quot;&gt;Howl Of Shabriri&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2889,9 +2719,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="incantations_8_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_8_3&amp;id=incantations_8_3&amp;link=/checklists/incantations.html%23item_8_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Inescapable+Frenzy&quot;&gt;Inescapable Frenzy&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_8_3&amp;id=incantations_8_3&amp;link=/checklists/incantations.html%23item_8_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Inescapable+Frenzy&quot;&gt;Inescapable Frenzy&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2924,9 +2752,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="incantations_8_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_8_4&amp;id=incantations_8_4&amp;link=/checklists/incantations.html%23item_8_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/The+Flame+of+Frenzy&quot;&gt;The Flame Of Frenzy&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_8_4&amp;id=incantations_8_4&amp;link=/checklists/incantations.html%23item_8_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/The+Flame+of+Frenzy&quot;&gt;The Flame Of Frenzy&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2959,9 +2785,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="incantations_8_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_8_5&amp;id=incantations_8_5&amp;link=/checklists/incantations.html%23item_8_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Unendurable+Frenzy&quot;&gt;Unendurable Frenzy&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_8_5&amp;id=incantations_8_5&amp;link=/checklists/incantations.html%23item_8_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Unendurable+Frenzy&quot;&gt;Unendurable Frenzy&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2995,9 +2819,7 @@
         <div class="card shadow-sm mb-3" id="incantations_section_8">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#incantations_8Col" data-bs-toggle="collapse" href="#incantations_8Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#incantations_8Col" data-bs-toggle="collapse" href="#incantations_8Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Godskin Apostle Incantations</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="incantations_totals_8"></span>
             </h4>
@@ -3009,9 +2831,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -3040,9 +2860,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="incantations_9_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_9_1&amp;id=incantations_9_1&amp;link=/checklists/incantations.html%23item_9_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Black+Flame&quot;&gt;Black Flame&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_9_1&amp;id=incantations_9_1&amp;link=/checklists/incantations.html%23item_9_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Black+Flame&quot;&gt;Black Flame&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3075,9 +2893,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="incantations_9_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_9_2&amp;id=incantations_9_2&amp;link=/checklists/incantations.html%23item_9_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Black+Flame+Blade&quot;&gt;Black Flame Blade&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_9_2&amp;id=incantations_9_2&amp;link=/checklists/incantations.html%23item_9_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Black+Flame+Blade&quot;&gt;Black Flame Blade&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3110,9 +2926,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="incantations_9_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_9_3&amp;id=incantations_9_3&amp;link=/checklists/incantations.html%23item_9_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Black+Flame+Ritual&quot;&gt;Black Flame Ritual&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_9_3&amp;id=incantations_9_3&amp;link=/checklists/incantations.html%23item_9_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Black+Flame+Ritual&quot;&gt;Black Flame Ritual&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3145,9 +2959,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="incantations_9_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_9_4&amp;id=incantations_9_4&amp;link=/checklists/incantations.html%23item_9_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Black+Flame's+Protection&quot;&gt;Black Flame's Protection&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_9_4&amp;id=incantations_9_4&amp;link=/checklists/incantations.html%23item_9_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Black+Flame's+Protection&quot;&gt;Black Flame's Protection&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3180,9 +2992,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="incantations_9_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_9_5&amp;id=incantations_9_5&amp;link=/checklists/incantations.html%23item_9_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Noble+Presence&quot;&gt;Noble Presence&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_9_5&amp;id=incantations_9_5&amp;link=/checklists/incantations.html%23item_9_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Noble+Presence&quot;&gt;Noble Presence&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3215,9 +3025,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="incantations_9_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_9_6&amp;id=incantations_9_6&amp;link=/checklists/incantations.html%23item_9_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Scouring+Black+Flame&quot;&gt;Scouring Black Flame&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_9_6&amp;id=incantations_9_6&amp;link=/checklists/incantations.html%23item_9_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Scouring+Black+Flame&quot;&gt;Scouring Black Flame&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3251,9 +3059,7 @@
         <div class="card shadow-sm mb-3" id="incantations_section_9">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#incantations_9Col" data-bs-toggle="collapse" href="#incantations_9Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#incantations_9Col" data-bs-toggle="collapse" href="#incantations_9Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Golden Order Incantations</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="incantations_totals_9"></span>
             </h4>
@@ -3265,9 +3071,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -3296,9 +3100,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="incantations_10_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_10_1&amp;id=incantations_10_1&amp;link=/checklists/incantations.html%23item_10_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Discus+of+Light&quot;&gt;Discus Of Light&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_10_1&amp;id=incantations_10_1&amp;link=/checklists/incantations.html%23item_10_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Discus+of+Light&quot;&gt;Discus Of Light&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3331,9 +3133,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="incantations_10_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_10_2&amp;id=incantations_10_2&amp;link=/checklists/incantations.html%23item_10_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Immutable+Shield&quot;&gt;Immutable Shield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_10_2&amp;id=incantations_10_2&amp;link=/checklists/incantations.html%23item_10_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Immutable+Shield&quot;&gt;Immutable Shield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3366,9 +3166,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="incantations_10_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_10_3&amp;id=incantations_10_3&amp;link=/checklists/incantations.html%23item_10_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Law+of+Causality&quot;&gt;Law Of Causality&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_10_3&amp;id=incantations_10_3&amp;link=/checklists/incantations.html%23item_10_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Law+of+Causality&quot;&gt;Law Of Causality&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3401,9 +3199,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="incantations_10_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_10_4&amp;id=incantations_10_4&amp;link=/checklists/incantations.html%23item_10_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Law+of+Regression&quot;&gt;Law Of Regression&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_10_4&amp;id=incantations_10_4&amp;link=/checklists/incantations.html%23item_10_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Law+of+Regression&quot;&gt;Law Of Regression&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3436,9 +3232,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="incantations_10_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_10_5&amp;id=incantations_10_5&amp;link=/checklists/incantations.html%23item_10_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Litany+of+Proper+Death&quot;&gt;Litany Of Proper Death&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_10_5&amp;id=incantations_10_5&amp;link=/checklists/incantations.html%23item_10_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Litany+of+Proper+Death&quot;&gt;Litany Of Proper Death&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3471,9 +3265,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="incantations_10_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_10_6&amp;id=incantations_10_6&amp;link=/checklists/incantations.html%23item_10_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Order+Healing&quot;&gt;Order Healing&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_10_6&amp;id=incantations_10_6&amp;link=/checklists/incantations.html%23item_10_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Order+Healing&quot;&gt;Order Healing&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3506,9 +3298,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="incantations_10_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_10_7&amp;id=incantations_10_7&amp;link=/checklists/incantations.html%23item_10_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Order's+Blade&quot;&gt;Order's Blade&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_10_7&amp;id=incantations_10_7&amp;link=/checklists/incantations.html%23item_10_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Order's+Blade&quot;&gt;Order's Blade&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3541,9 +3331,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="incantations_10_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_10_8&amp;id=incantations_10_8&amp;link=/checklists/incantations.html%23item_10_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Radagon's+Rings+of+Light&quot;&gt;Radagon's Rings Of Light&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_10_8&amp;id=incantations_10_8&amp;link=/checklists/incantations.html%23item_10_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Radagon's+Rings+of+Light&quot;&gt;Radagon's Rings Of Light&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3576,9 +3364,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="incantations_10_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_10_9&amp;id=incantations_10_9&amp;link=/checklists/incantations.html%23item_10_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Triple+Rings+of+Light&quot;&gt;Triple Rings Of Light&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_10_9&amp;id=incantations_10_9&amp;link=/checklists/incantations.html%23item_10_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Triple+Rings+of+Light&quot;&gt;Triple Rings Of Light&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3612,9 +3398,7 @@
         <div class="card shadow-sm mb-3" id="incantations_section_10">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#incantations_10Col" data-bs-toggle="collapse" href="#incantations_10Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#incantations_10Col" data-bs-toggle="collapse" href="#incantations_10Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Servants Of Rot Incantations</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="incantations_totals_10"></span>
             </h4>
@@ -3626,9 +3410,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -3657,9 +3439,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="10" id="incantations_11_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_11_1&amp;id=incantations_11_1&amp;link=/checklists/incantations.html%23item_11_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Pest+Threads&quot;&gt;Pest Threads&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_11_1&amp;id=incantations_11_1&amp;link=/checklists/incantations.html%23item_11_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Pest+Threads&quot;&gt;Pest Threads&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3692,9 +3472,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="10" id="incantations_11_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_11_2&amp;id=incantations_11_2&amp;link=/checklists/incantations.html%23item_11_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Poison+Armament&quot;&gt;Poison Armament&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_11_2&amp;id=incantations_11_2&amp;link=/checklists/incantations.html%23item_11_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Poison+Armament&quot;&gt;Poison Armament&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3727,9 +3505,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="10" id="incantations_11_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_11_3&amp;id=incantations_11_3&amp;link=/checklists/incantations.html%23item_11_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Poison+Mist&quot;&gt;Poison Mist&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_11_3&amp;id=incantations_11_3&amp;link=/checklists/incantations.html%23item_11_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Poison+Mist&quot;&gt;Poison Mist&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3762,9 +3538,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="10" id="incantations_11_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_11_4&amp;id=incantations_11_4&amp;link=/checklists/incantations.html%23item_11_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Scarlet+Aeonia&quot;&gt;Scarlet Aeonia&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_11_4&amp;id=incantations_11_4&amp;link=/checklists/incantations.html%23item_11_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Scarlet+Aeonia&quot;&gt;Scarlet Aeonia&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3798,9 +3572,7 @@
         <div class="card shadow-sm mb-3" id="incantations_section_11">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#incantations_11Col" data-bs-toggle="collapse" href="#incantations_11Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#incantations_11Col" data-bs-toggle="collapse" href="#incantations_11Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Two Fingers Incantations</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="incantations_totals_11"></span>
             </h4>
@@ -3812,9 +3584,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -3843,9 +3613,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="11" id="incantations_12_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_12_1&amp;id=incantations_12_1&amp;link=/checklists/incantations.html%23item_12_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Assassin's+Approach&quot;&gt;Assassin's Approach&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_12_1&amp;id=incantations_12_1&amp;link=/checklists/incantations.html%23item_12_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Assassin's+Approach&quot;&gt;Assassin's Approach&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3878,9 +3646,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="11" id="incantations_12_16" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_12_16&amp;id=incantations_12_16&amp;link=/checklists/incantations.html%23item_12_16&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Cure+Poison&quot;&gt;Cure Poison&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_12_16&amp;id=incantations_12_16&amp;link=/checklists/incantations.html%23item_12_16&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Cure+Poison&quot;&gt;Cure Poison&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3913,9 +3679,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="11" id="incantations_12_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_12_2&amp;id=incantations_12_2&amp;link=/checklists/incantations.html%23item_12_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Darkness&quot;&gt;Darkness&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_12_2&amp;id=incantations_12_2&amp;link=/checklists/incantations.html%23item_12_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Darkness&quot;&gt;Darkness&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3948,9 +3712,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="11" id="incantations_12_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_12_3&amp;id=incantations_12_3&amp;link=/checklists/incantations.html%23item_12_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Divine+Fortification&quot;&gt;Divine Fortification&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_12_3&amp;id=incantations_12_3&amp;link=/checklists/incantations.html%23item_12_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Divine+Fortification&quot;&gt;Divine Fortification&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3983,9 +3745,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="11" id="incantations_12_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_12_4&amp;id=incantations_12_4&amp;link=/checklists/incantations.html%23item_12_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Flame+Fortification&quot;&gt;Flame Fortification&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_12_4&amp;id=incantations_12_4&amp;link=/checklists/incantations.html%23item_12_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Flame+Fortification&quot;&gt;Flame Fortification&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4018,9 +3778,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="11" id="incantations_12_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_12_5&amp;id=incantations_12_5&amp;link=/checklists/incantations.html%23item_12_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Great+Heal&quot;&gt;Great Heal&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_12_5&amp;id=incantations_12_5&amp;link=/checklists/incantations.html%23item_12_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Great+Heal&quot;&gt;Great Heal&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4053,9 +3811,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="11" id="incantations_12_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_12_6&amp;id=incantations_12_6&amp;link=/checklists/incantations.html%23item_12_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Heal&quot;&gt;Heal&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_12_6&amp;id=incantations_12_6&amp;link=/checklists/incantations.html%23item_12_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Heal&quot;&gt;Heal&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4088,9 +3844,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="11" id="incantations_12_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_12_7&amp;id=incantations_12_7&amp;link=/checklists/incantations.html%23item_12_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Lightning+Fortification&quot;&gt;Lightning Fortification&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_12_7&amp;id=incantations_12_7&amp;link=/checklists/incantations.html%23item_12_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Lightning+Fortification&quot;&gt;Lightning Fortification&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4123,9 +3877,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="11" id="incantations_12_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_12_8&amp;id=incantations_12_8&amp;link=/checklists/incantations.html%23item_12_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Lord's+Aid&quot;&gt;Lord's Aid&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_12_8&amp;id=incantations_12_8&amp;link=/checklists/incantations.html%23item_12_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Lord's+Aid&quot;&gt;Lord's Aid&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4158,9 +3910,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="11" id="incantations_12_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_12_9&amp;id=incantations_12_9&amp;link=/checklists/incantations.html%23item_12_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Lord's+Divine+Fortification&quot;&gt;Lord's Divine Fortification&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_12_9&amp;id=incantations_12_9&amp;link=/checklists/incantations.html%23item_12_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Lord's+Divine+Fortification&quot;&gt;Lord's Divine Fortification&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4193,9 +3943,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="11" id="incantations_12_11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_12_11&amp;id=incantations_12_11&amp;link=/checklists/incantations.html%23item_12_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Lord's+Heal&quot;&gt;Lord's Heal&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_12_11&amp;id=incantations_12_11&amp;link=/checklists/incantations.html%23item_12_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Lord's+Heal&quot;&gt;Lord's Heal&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4228,9 +3976,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="11" id="incantations_12_12" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_12_12&amp;id=incantations_12_12&amp;link=/checklists/incantations.html%23item_12_12&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Magic+Fortification&quot;&gt;Magic Fortification&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_12_12&amp;id=incantations_12_12&amp;link=/checklists/incantations.html%23item_12_12&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Magic+Fortification&quot;&gt;Magic Fortification&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4263,9 +4009,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="11" id="incantations_12_13" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_12_13&amp;id=incantations_12_13&amp;link=/checklists/incantations.html%23item_12_13&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Rejection&quot;&gt;Rejection&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_12_13&amp;id=incantations_12_13&amp;link=/checklists/incantations.html%23item_12_13&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Rejection&quot;&gt;Rejection&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4298,9 +4042,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="11" id="incantations_12_14" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_12_14&amp;id=incantations_12_14&amp;link=/checklists/incantations.html%23item_12_14&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Shadow+Bait&quot;&gt;Shadow Bait&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_12_14&amp;id=incantations_12_14&amp;link=/checklists/incantations.html%23item_12_14&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Shadow+Bait&quot;&gt;Shadow Bait&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4333,9 +4075,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="11" id="incantations_12_15" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_12_15&amp;id=incantations_12_15&amp;link=/checklists/incantations.html%23item_12_15&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Urgent+Heal&quot;&gt;Urgent Heal&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_12_15&amp;id=incantations_12_15&amp;link=/checklists/incantations.html%23item_12_15&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Urgent+Heal&quot;&gt;Urgent Heal&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4369,9 +4109,7 @@
         <div class="card shadow-sm mb-3" id="incantations_section_12">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#incantations_12Col" data-bs-toggle="collapse" href="#incantations_12Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#incantations_12Col" data-bs-toggle="collapse" href="#incantations_12Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Realm of Shadow</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="incantations_totals_12"></span>
             </h4>
@@ -4383,9 +4121,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -4414,9 +4150,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="incantations_20_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_20_1&amp;id=incantations_20_1&amp;link=/checklists/incantations.html%23item_20_1&amp;title=Furious Blade of Ansbach">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_20_1&amp;id=incantations_20_1&amp;link=/checklists/incantations.html%23item_20_1&amp;title=Furious Blade of Ansbach"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4449,9 +4183,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="incantations_20_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_20_2&amp;id=incantations_20_2&amp;link=/checklists/incantations.html%23item_20_2&amp;title=Heal from Afar">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_20_2&amp;id=incantations_20_2&amp;link=/checklists/incantations.html%23item_20_2&amp;title=Heal from Afar"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4484,9 +4216,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="incantations_20_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_20_3&amp;id=incantations_20_3&amp;link=/checklists/incantations.html%23item_20_3&amp;title=Aspects of the Crucible: Thorns">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_20_3&amp;id=incantations_20_3&amp;link=/checklists/incantations.html%23item_20_3&amp;title=Aspects of the Crucible: Thorns"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4519,9 +4249,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="incantations_20_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_20_4&amp;id=incantations_20_4&amp;link=/checklists/incantations.html%23item_20_4&amp;title=Aspects of the Crucible: Bloom">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_20_4&amp;id=incantations_20_4&amp;link=/checklists/incantations.html%23item_20_4&amp;title=Aspects of the Crucible: Bloom"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4554,9 +4282,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="incantations_20_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_20_5&amp;id=incantations_20_5&amp;link=/checklists/incantations.html%23item_20_5&amp;title=Minor Erdtree">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_20_5&amp;id=incantations_20_5&amp;link=/checklists/incantations.html%23item_20_5&amp;title=Minor Erdtree"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4589,9 +4315,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="incantations_20_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_20_6&amp;id=incantations_20_6&amp;link=/checklists/incantations.html%23item_20_6&amp;title=Land of Shadow">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_20_6&amp;id=incantations_20_6&amp;link=/checklists/incantations.html%23item_20_6&amp;title=Land of Shadow"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4624,9 +4348,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="incantations_20_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_20_7&amp;id=incantations_20_7&amp;link=/checklists/incantations.html%23item_20_7&amp;title=Wrath from Afar">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_20_7&amp;id=incantations_20_7&amp;link=/checklists/incantations.html%23item_20_7&amp;title=Wrath from Afar"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4659,9 +4381,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="incantations_20_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_20_8&amp;id=incantations_20_8&amp;link=/checklists/incantations.html%23item_20_8&amp;title=Light of Miquella">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_20_8&amp;id=incantations_20_8&amp;link=/checklists/incantations.html%23item_20_8&amp;title=Light of Miquella"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4694,9 +4414,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="incantations_20_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_20_9&amp;id=incantations_20_9&amp;link=/checklists/incantations.html%23item_20_9&amp;title=Multilayered Ring of Light">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_20_9&amp;id=incantations_20_9&amp;link=/checklists/incantations.html%23item_20_9&amp;title=Multilayered Ring of Light"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4729,9 +4447,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="incantations_20_10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_20_10&amp;id=incantations_20_10&amp;link=/checklists/incantations.html%23item_20_10&amp;title=Roar of Rugalea">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_20_10&amp;id=incantations_20_10&amp;link=/checklists/incantations.html%23item_20_10&amp;title=Roar of Rugalea"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4764,9 +4480,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="incantations_20_11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_20_11&amp;id=incantations_20_11&amp;link=/checklists/incantations.html%23item_20_11&amp;title=Knight's Lightning Spear">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_20_11&amp;id=incantations_20_11&amp;link=/checklists/incantations.html%23item_20_11&amp;title=Knight's Lightning Spear"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4799,9 +4513,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="incantations_20_12" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_20_12&amp;id=incantations_20_12&amp;link=/checklists/incantations.html%23item_20_12&amp;title=Dragonbolt of Florissax">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_20_12&amp;id=incantations_20_12&amp;link=/checklists/incantations.html%23item_20_12&amp;title=Dragonbolt of Florissax"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4834,9 +4546,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="incantations_20_13" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_20_13&amp;id=incantations_20_13&amp;link=/checklists/incantations.html%23item_20_13&amp;title=Electrocharge">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_20_13&amp;id=incantations_20_13&amp;link=/checklists/incantations.html%23item_20_13&amp;title=Electrocharge"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4869,9 +4579,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="incantations_20_14" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_20_14&amp;id=incantations_20_14&amp;link=/checklists/incantations.html%23item_20_14&amp;title=Bayle's Tyranny">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_20_14&amp;id=incantations_20_14&amp;link=/checklists/incantations.html%23item_20_14&amp;title=Bayle's Tyranny"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4904,9 +4612,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="incantations_20_15" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_20_15&amp;id=incantations_20_15&amp;link=/checklists/incantations.html%23item_20_15&amp;title=Bayle's Flame Lightning">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_20_15&amp;id=incantations_20_15&amp;link=/checklists/incantations.html%23item_20_15&amp;title=Bayle's Flame Lightning"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4939,9 +4645,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="incantations_20_16" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_20_16&amp;id=incantations_20_16&amp;link=/checklists/incantations.html%23item_20_16&amp;title=Ghostflame Breath">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_20_16&amp;id=incantations_20_16&amp;link=/checklists/incantations.html%23item_20_16&amp;title=Ghostflame Breath"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4974,9 +4678,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="incantations_20_17" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_20_17&amp;id=incantations_20_17&amp;link=/checklists/incantations.html%23item_20_17&amp;title=Rotten Butterflies">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_20_17&amp;id=incantations_20_17&amp;link=/checklists/incantations.html%23item_20_17&amp;title=Rotten Butterflies"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5009,9 +4711,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="incantations_20_18" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_20_18&amp;id=incantations_20_18&amp;link=/checklists/incantations.html%23item_20_18&amp;title=Pest-Thread Spears">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_20_18&amp;id=incantations_20_18&amp;link=/checklists/incantations.html%23item_20_18&amp;title=Pest-Thread Spears"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5044,9 +4744,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="incantations_20_19" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_20_19&amp;id=incantations_20_19&amp;link=/checklists/incantations.html%23item_20_19&amp;title=Midra's Flame of Frenzy">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_20_19&amp;id=incantations_20_19&amp;link=/checklists/incantations.html%23item_20_19&amp;title=Midra's Flame of Frenzy"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5079,9 +4777,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="incantations_20_24" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_20_24&amp;id=incantations_20_24&amp;link=/checklists/incantations.html%23item_20_24&amp;title=Divine Beast Tornado">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_20_24&amp;id=incantations_20_24&amp;link=/checklists/incantations.html%23item_20_24&amp;title=Divine Beast Tornado"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5114,9 +4810,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="incantations_20_25" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_20_25&amp;id=incantations_20_25&amp;link=/checklists/incantations.html%23item_20_25&amp;title=Divine Bird Feathers">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_20_25&amp;id=incantations_20_25&amp;link=/checklists/incantations.html%23item_20_25&amp;title=Divine Bird Feathers"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5149,9 +4843,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="incantations_20_26" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_20_26&amp;id=incantations_20_26&amp;link=/checklists/incantations.html%23item_20_26&amp;title=Fire Serpent">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_20_26&amp;id=incantations_20_26&amp;link=/checklists/incantations.html%23item_20_26&amp;title=Fire Serpent"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5184,9 +4876,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="incantations_20_27" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_20_27&amp;id=incantations_20_27&amp;link=/checklists/incantations.html%23item_20_27&amp;title=Rain of Fire">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_20_27&amp;id=incantations_20_27&amp;link=/checklists/incantations.html%23item_20_27&amp;title=Rain of Fire"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5219,9 +4909,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="incantations_20_28" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_20_28&amp;id=incantations_20_28&amp;link=/checklists/incantations.html%23item_20_28&amp;title=Messmer's Orb">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_20_28&amp;id=incantations_20_28&amp;link=/checklists/incantations.html%23item_20_28&amp;title=Messmer's Orb"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5254,9 +4942,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="incantations_20_20" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_20_20&amp;id=incantations_20_20&amp;link=/checklists/incantations.html%23item_20_20&amp;title=Watchful Spirit">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_20_20&amp;id=incantations_20_20&amp;link=/checklists/incantations.html%23item_20_20&amp;title=Watchful Spirit"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5289,9 +4975,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="incantations_20_21" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_20_21&amp;id=incantations_20_21&amp;link=/checklists/incantations.html%23item_20_21&amp;title=Golden Arcs">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_20_21&amp;id=incantations_20_21&amp;link=/checklists/incantations.html%23item_20_21&amp;title=Golden Arcs"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5324,9 +5008,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="incantations_20_22" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_20_22&amp;id=incantations_20_22&amp;link=/checklists/incantations.html%23item_20_22&amp;title=Giant Golden Arc">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_20_22&amp;id=incantations_20_22&amp;link=/checklists/incantations.html%23item_20_22&amp;title=Giant Golden Arc"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5359,9 +5041,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="incantations_20_23" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=incantations_20_23&amp;id=incantations_20_23&amp;link=/checklists/incantations.html%23item_20_23&amp;title=Spira">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=incantations_20_23&amp;id=incantations_20_23&amp;link=/checklists/incantations.html%23item_20_23&amp;title=Spira"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">

--- a/docs/checklists/landmarks_locations.html
+++ b/docs/checklists/landmarks_locations.html
@@ -27,14 +27,10 @@
         <a class="navbar-brand me-auto ms-2" href="/index.html">Roundtable Guides</a>
         <form class="d-none d-sm-flex order-2 order-xl-3">
           <input aria-label="search" class="form-control me-2" name="search" placeholder="Search" type="search">
-          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit">
-            <i class="bi bi-search"></i>
-          </button>
+          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit"><i class="bi bi-search"></i></button>
         </form>
         <div class="d-sm-none order-2">
-          <a class="nav-link me-0" href="/search.html">
-            <i class="bi bi-search sb-icon-search"></i>
-          </a>
+          <a class="nav-link me-0" href="/search.html"><i class="bi bi-search sb-icon-search"></i></a>
         </div>
         <div class="collapse navbar-collapse order-3 order-xl-2 ms-xl-2" id="nav-collapse">
           <ul class="nav navbar-nav navbar-nav-scroll mr-auto">
@@ -179,14 +175,10 @@
               </ul>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/map.html">
-                <i class="bi bi-map"></i> Map
-              </a>
+              <a class="nav-link hide-buttons" href="/map.html"><i class="bi bi-map"></i> Map</a>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/options.html">
-                <i class="bi bi-gear-fill"></i> Options
-              </a>
+              <a class="nav-link hide-buttons" href="/options.html"><i class="bi bi-gear-fill"></i> Options</a>
             </li>
           </ul>
         </div>
@@ -206,9 +198,7 @@
       </div>
       <nav class="text-muted toc d-print-none">
         <strong class="d-block h5">
-          <a class="toc-button" data-bs-toggle="collapse" href="#toc_caves" role="button">
-            <i class="bi bi-plus-lg"></i>Table Of Contents
-          </a>
+          <a class="toc-button" data-bs-toggle="collapse" href="#toc_caves" role="button"><i class="bi bi-plus-lg"></i>Table Of Contents</a>
         </strong>
         <ul class="toc_page collapse" id="toc_caves">
           <li>
@@ -264,9 +254,7 @@
         <div class="card shadow-sm mb-3" id="caves_section_0">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#caves_0Col" data-bs-toggle="collapse" href="#caves_0Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#caves_0Col" data-bs-toggle="collapse" href="#caves_0Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Limgrave</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="caves_totals_0"></span>
             </h4>
@@ -278,9 +266,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -314,9 +300,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="caves_1_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_1_1&amp;id=caves_1_1&amp;link=/checklists/landmarks_locations.html%23item_1_1&amp;title=Stranded Graveyard">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_1_1&amp;id=caves_1_1&amp;link=/checklists/landmarks_locations.html%23item_1_1&amp;title=Stranded Graveyard"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -352,9 +336,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="caves_1_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_1_5&amp;id=caves_1_5&amp;link=/checklists/landmarks_locations.html%23item_1_5&amp;title=Groveside Cave">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_1_5&amp;id=caves_1_5&amp;link=/checklists/landmarks_locations.html%23item_1_5&amp;title=Groveside Cave"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -390,9 +372,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="caves_1_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_1_3&amp;id=caves_1_3&amp;link=/checklists/landmarks_locations.html%23item_1_3&amp;title=Coastal Cave">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_1_3&amp;id=caves_1_3&amp;link=/checklists/landmarks_locations.html%23item_1_3&amp;title=Coastal Cave"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -429,9 +409,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="caves_1_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_1_9&amp;id=caves_1_9&amp;link=/checklists/landmarks_locations.html%23item_1_9&amp;title=Murkwater Cave">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_1_9&amp;id=caves_1_9&amp;link=/checklists/landmarks_locations.html%23item_1_9&amp;title=Murkwater Cave"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -467,9 +445,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="caves_1_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_1_6&amp;id=caves_1_6&amp;link=/checklists/landmarks_locations.html%23item_1_6&amp;title=Highroad Cave">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_1_6&amp;id=caves_1_6&amp;link=/checklists/landmarks_locations.html%23item_1_6&amp;title=Highroad Cave"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -505,9 +481,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="caves_1_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_1_4&amp;id=caves_1_4&amp;link=/checklists/landmarks_locations.html%23item_1_4&amp;title=Deathtouched Catacombs">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_1_4&amp;id=caves_1_4&amp;link=/checklists/landmarks_locations.html%23item_1_4&amp;title=Deathtouched Catacombs"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -543,9 +517,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="caves_1_10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_1_10&amp;id=caves_1_10&amp;link=/checklists/landmarks_locations.html%23item_1_10&amp;title=Stormfoot Catacombs">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_1_10&amp;id=caves_1_10&amp;link=/checklists/landmarks_locations.html%23item_1_10&amp;title=Stormfoot Catacombs"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -581,9 +553,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="caves_1_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_1_8&amp;id=caves_1_8&amp;link=/checklists/landmarks_locations.html%23item_1_8&amp;title=Murkwater Catacombs">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_1_8&amp;id=caves_1_8&amp;link=/checklists/landmarks_locations.html%23item_1_8&amp;title=Murkwater Catacombs"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -619,9 +589,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="caves_1_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_1_7&amp;id=caves_1_7&amp;link=/checklists/landmarks_locations.html%23item_1_7&amp;title=Limgrave Tunnels">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_1_7&amp;id=caves_1_7&amp;link=/checklists/landmarks_locations.html%23item_1_7&amp;title=Limgrave Tunnels"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -657,9 +625,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="caves_1_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_1_2&amp;id=caves_1_2&amp;link=/checklists/landmarks_locations.html%23item_1_2&amp;title=Fringefolk Hero's Grave">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_1_2&amp;id=caves_1_2&amp;link=/checklists/landmarks_locations.html%23item_1_2&amp;title=Fringefolk Hero's Grave"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -696,9 +662,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="caves_e1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_e1&amp;id=caves_e1&amp;link=/checklists/landmarks_locations.html%23item_e1&amp;title=Forlorn Hound Evergaol">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_e1&amp;id=caves_e1&amp;link=/checklists/landmarks_locations.html%23item_e1&amp;title=Forlorn Hound Evergaol"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -735,9 +699,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="caves_e2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_e2&amp;id=caves_e2&amp;link=/checklists/landmarks_locations.html%23item_e2&amp;title=Stormhill Evergaol">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_e2&amp;id=caves_e2&amp;link=/checklists/landmarks_locations.html%23item_e2&amp;title=Stormhill Evergaol"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -774,9 +736,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="caves_l1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l1&amp;id=caves_l1&amp;link=/checklists/landmarks_locations.html%23item_l1&amp;title=Minor Erdtree">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l1&amp;id=caves_l1&amp;link=/checklists/landmarks_locations.html%23item_l1&amp;title=Minor Erdtree"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -811,9 +771,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="caves_l2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l2&amp;id=caves_l2&amp;link=/checklists/landmarks_locations.html%23item_l2&amp;title=Divine Tower of Limgrave">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l2&amp;id=caves_l2&amp;link=/checklists/landmarks_locations.html%23item_l2&amp;title=Divine Tower of Limgrave"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -848,9 +806,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="caves_l3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l3&amp;id=caves_l3&amp;link=/checklists/landmarks_locations.html%23item_l3&amp;title=Dragon-Burnt Ruins">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l3&amp;id=caves_l3&amp;link=/checklists/landmarks_locations.html%23item_l3&amp;title=Dragon-Burnt Ruins"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -885,9 +841,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="caves_l4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l4&amp;id=caves_l4&amp;link=/checklists/landmarks_locations.html%23item_l4&amp;title=Gatefront Ruins">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l4&amp;id=caves_l4&amp;link=/checklists/landmarks_locations.html%23item_l4&amp;title=Gatefront Ruins"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -922,9 +876,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="caves_l5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l5&amp;id=caves_l5&amp;link=/checklists/landmarks_locations.html%23item_l5&amp;title=Mistwood Ruins">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l5&amp;id=caves_l5&amp;link=/checklists/landmarks_locations.html%23item_l5&amp;title=Mistwood Ruins"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -959,9 +911,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="caves_l6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l6&amp;id=caves_l6&amp;link=/checklists/landmarks_locations.html%23item_l6&amp;title=Waypoint Ruins">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l6&amp;id=caves_l6&amp;link=/checklists/landmarks_locations.html%23item_l6&amp;title=Waypoint Ruins"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -996,9 +946,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="caves_l7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l7&amp;id=caves_l7&amp;link=/checklists/landmarks_locations.html%23item_l7&amp;title=Summonwater Village">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l7&amp;id=caves_l7&amp;link=/checklists/landmarks_locations.html%23item_l7&amp;title=Summonwater Village"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1033,9 +981,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="caves_l8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l8&amp;id=caves_l8&amp;link=/checklists/landmarks_locations.html%23item_l8&amp;title=Stormhill Shack">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l8&amp;id=caves_l8&amp;link=/checklists/landmarks_locations.html%23item_l8&amp;title=Stormhill Shack"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1070,9 +1016,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="caves_l9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l9&amp;id=caves_l9&amp;link=/checklists/landmarks_locations.html%23item_l9&amp;title=Warmaster's Shack">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l9&amp;id=caves_l9&amp;link=/checklists/landmarks_locations.html%23item_l9&amp;title=Warmaster's Shack"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1107,9 +1051,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="caves_l10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l10&amp;id=caves_l10&amp;link=/checklists/landmarks_locations.html%23item_l10&amp;title=Artist's Shack">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l10&amp;id=caves_l10&amp;link=/checklists/landmarks_locations.html%23item_l10&amp;title=Artist's Shack"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1144,9 +1086,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="caves_l11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l11&amp;id=caves_l11&amp;link=/checklists/landmarks_locations.html%23item_l11&amp;title=Church of Elleh">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l11&amp;id=caves_l11&amp;link=/checklists/landmarks_locations.html%23item_l11&amp;title=Church of Elleh"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1181,9 +1121,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="caves_l12" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l12&amp;id=caves_l12&amp;link=/checklists/landmarks_locations.html%23item_l12&amp;title=Church of Dragon Communion">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l12&amp;id=caves_l12&amp;link=/checklists/landmarks_locations.html%23item_l12&amp;title=Church of Dragon Communion"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1218,9 +1156,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="caves_l13" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l13&amp;id=caves_l13&amp;link=/checklists/landmarks_locations.html%23item_l13&amp;title=Third Church of Marika">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l13&amp;id=caves_l13&amp;link=/checklists/landmarks_locations.html%23item_l13&amp;title=Third Church of Marika"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1255,9 +1191,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="caves_l14" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l14&amp;id=caves_l14&amp;link=/checklists/landmarks_locations.html%23item_l14&amp;title=Stormgate">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l14&amp;id=caves_l14&amp;link=/checklists/landmarks_locations.html%23item_l14&amp;title=Stormgate"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1292,9 +1226,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="caves_l15" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l15&amp;id=caves_l15&amp;link=/checklists/landmarks_locations.html%23item_l15&amp;title=Siofra River Well">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l15&amp;id=caves_l15&amp;link=/checklists/landmarks_locations.html%23item_l15&amp;title=Siofra River Well"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1329,9 +1261,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="caves_l16" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l16&amp;id=caves_l16&amp;link=/checklists/landmarks_locations.html%23item_l16&amp;title=Fort Haight">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l16&amp;id=caves_l16&amp;link=/checklists/landmarks_locations.html%23item_l16&amp;title=Fort Haight"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1367,9 +1297,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="caves_ld1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_ld1&amp;id=caves_ld1&amp;link=/checklists/landmarks_locations.html%23item_ld1&amp;title=Stormveil Castle">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_ld1&amp;id=caves_ld1&amp;link=/checklists/landmarks_locations.html%23item_ld1&amp;title=Stormveil Castle"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1407,9 +1335,7 @@
         <div class="card shadow-sm mb-3" id="caves_section_1">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#caves_1Col" data-bs-toggle="collapse" href="#caves_1Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#caves_1Col" data-bs-toggle="collapse" href="#caves_1Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Weeping Peninsula</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="caves_totals_1"></span>
             </h4>
@@ -1421,9 +1347,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -1457,9 +1381,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="caves_0_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_0_1&amp;id=caves_0_1&amp;link=/checklists/landmarks_locations.html%23item_0_1&amp;title=Earthbore Cave">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_0_1&amp;id=caves_0_1&amp;link=/checklists/landmarks_locations.html%23item_0_1&amp;title=Earthbore Cave"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1495,9 +1417,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="caves_0_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_0_5&amp;id=caves_0_5&amp;link=/checklists/landmarks_locations.html%23item_0_5&amp;title=Tombsward Cave">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_0_5&amp;id=caves_0_5&amp;link=/checklists/landmarks_locations.html%23item_0_5&amp;title=Tombsward Cave"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1533,9 +1453,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="caves_0_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_0_2&amp;id=caves_0_2&amp;link=/checklists/landmarks_locations.html%23item_0_2&amp;title=Impaler's Catacombs">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_0_2&amp;id=caves_0_2&amp;link=/checklists/landmarks_locations.html%23item_0_2&amp;title=Impaler's Catacombs"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1571,9 +1489,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="caves_0_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_0_4&amp;id=caves_0_4&amp;link=/checklists/landmarks_locations.html%23item_0_4&amp;title=Tombsward Catacombs">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_0_4&amp;id=caves_0_4&amp;link=/checklists/landmarks_locations.html%23item_0_4&amp;title=Tombsward Catacombs"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1609,9 +1525,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="caves_0_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_0_3&amp;id=caves_0_3&amp;link=/checklists/landmarks_locations.html%23item_0_3&amp;title=Morne Tunnel">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_0_3&amp;id=caves_0_3&amp;link=/checklists/landmarks_locations.html%23item_0_3&amp;title=Morne Tunnel"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1647,9 +1561,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="caves_e3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_e3&amp;id=caves_e3&amp;link=/checklists/landmarks_locations.html%23item_e3&amp;title=Weeping Evergaol">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_e3&amp;id=caves_e3&amp;link=/checklists/landmarks_locations.html%23item_e3&amp;title=Weeping Evergaol"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1686,9 +1598,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="caves_l17" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l17&amp;id=caves_l17&amp;link=/checklists/landmarks_locations.html%23item_l17&amp;title=Minor Erdtree">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l17&amp;id=caves_l17&amp;link=/checklists/landmarks_locations.html%23item_l17&amp;title=Minor Erdtree"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1724,9 +1634,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="caves_l18" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l18&amp;id=caves_l18&amp;link=/checklists/landmarks_locations.html%23item_l18&amp;title=Oridys's Rise">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l18&amp;id=caves_l18&amp;link=/checklists/landmarks_locations.html%23item_l18&amp;title=Oridys's Rise"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1761,9 +1669,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="caves_l19" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l19&amp;id=caves_l19&amp;link=/checklists/landmarks_locations.html%23item_l19&amp;title=Demi-Human Forest Ruins">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l19&amp;id=caves_l19&amp;link=/checklists/landmarks_locations.html%23item_l19&amp;title=Demi-Human Forest Ruins"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1798,9 +1704,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="caves_l20" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l20&amp;id=caves_l20&amp;link=/checklists/landmarks_locations.html%23item_l20&amp;title=Tombsward Ruins">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l20&amp;id=caves_l20&amp;link=/checklists/landmarks_locations.html%23item_l20&amp;title=Tombsward Ruins"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1835,9 +1739,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="caves_l21" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l21&amp;id=caves_l21&amp;link=/checklists/landmarks_locations.html%23item_l21&amp;title=Witchbane Ruins">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l21&amp;id=caves_l21&amp;link=/checklists/landmarks_locations.html%23item_l21&amp;title=Witchbane Ruins"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1872,9 +1774,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="caves_l22" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l22&amp;id=caves_l22&amp;link=/checklists/landmarks_locations.html%23item_l22&amp;title=Isolated Merchant's Shack">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l22&amp;id=caves_l22&amp;link=/checklists/landmarks_locations.html%23item_l22&amp;title=Isolated Merchant's Shack"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1909,9 +1809,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="caves_l23" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l23&amp;id=caves_l23&amp;link=/checklists/landmarks_locations.html%23item_l23&amp;title=Church of Pilgrimage">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l23&amp;id=caves_l23&amp;link=/checklists/landmarks_locations.html%23item_l23&amp;title=Church of Pilgrimage"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1946,9 +1844,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="caves_l24" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l24&amp;id=caves_l24&amp;link=/checklists/landmarks_locations.html%23item_l24&amp;title=Callu Baptismal Church">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l24&amp;id=caves_l24&amp;link=/checklists/landmarks_locations.html%23item_l24&amp;title=Callu Baptismal Church"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1983,9 +1879,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="caves_l25" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l25&amp;id=caves_l25&amp;link=/checklists/landmarks_locations.html%23item_l25&amp;title=Fourth Church of Marika">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l25&amp;id=caves_l25&amp;link=/checklists/landmarks_locations.html%23item_l25&amp;title=Fourth Church of Marika"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2020,9 +1914,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="caves_l26" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l26&amp;id=caves_l26&amp;link=/checklists/landmarks_locations.html%23item_l26&amp;title=Bridge of Sacrifice">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l26&amp;id=caves_l26&amp;link=/checklists/landmarks_locations.html%23item_l26&amp;title=Bridge of Sacrifice"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2057,9 +1949,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="caves_l27" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l27&amp;id=caves_l27&amp;link=/checklists/landmarks_locations.html%23item_l27&amp;title=Ailing Village">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l27&amp;id=caves_l27&amp;link=/checklists/landmarks_locations.html%23item_l27&amp;title=Ailing Village"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2094,9 +1984,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="caves_l28" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l28&amp;id=caves_l28&amp;link=/checklists/landmarks_locations.html%23item_l28&amp;title=Forest Lookout Tower">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l28&amp;id=caves_l28&amp;link=/checklists/landmarks_locations.html%23item_l28&amp;title=Forest Lookout Tower"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2131,9 +2019,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="caves_l29" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l29&amp;id=caves_l29&amp;link=/checklists/landmarks_locations.html%23item_l29&amp;title=Tower of Return">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l29&amp;id=caves_l29&amp;link=/checklists/landmarks_locations.html%23item_l29&amp;title=Tower of Return"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2168,9 +2054,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="caves_ld2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_ld2&amp;id=caves_ld2&amp;link=/checklists/landmarks_locations.html%23item_ld2&amp;title=Castle Morne">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_ld2&amp;id=caves_ld2&amp;link=/checklists/landmarks_locations.html%23item_ld2&amp;title=Castle Morne"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2208,9 +2092,7 @@
         <div class="card shadow-sm mb-3" id="caves_section_2">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#caves_2Col" data-bs-toggle="collapse" href="#caves_2Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#caves_2Col" data-bs-toggle="collapse" href="#caves_2Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Liurnia of the Lakes</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="caves_totals_2"></span>
             </h4>
@@ -2222,9 +2104,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -2258,9 +2138,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="caves_2_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_2_1&amp;id=caves_2_1&amp;link=/checklists/landmarks_locations.html%23item_2_1&amp;title=Academy Crystal Cave">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_2_1&amp;id=caves_2_1&amp;link=/checklists/landmarks_locations.html%23item_2_1&amp;title=Academy Crystal Cave"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2297,9 +2175,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="caves_2_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_2_4&amp;id=caves_2_4&amp;link=/checklists/landmarks_locations.html%23item_2_4&amp;title=Lakeside Crystal Cave">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_2_4&amp;id=caves_2_4&amp;link=/checklists/landmarks_locations.html%23item_2_4&amp;title=Lakeside Crystal Cave"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2335,9 +2211,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="caves_2_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_2_8&amp;id=caves_2_8&amp;link=/checklists/landmarks_locations.html%23item_2_8&amp;title=Stillwater Cave">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_2_8&amp;id=caves_2_8&amp;link=/checklists/landmarks_locations.html%23item_2_8&amp;title=Stillwater Cave"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2373,9 +2247,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="caves_2_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_2_2&amp;id=caves_2_2&amp;link=/checklists/landmarks_locations.html%23item_2_2&amp;title=Black Knife Catacombs">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_2_2&amp;id=caves_2_2&amp;link=/checklists/landmarks_locations.html%23item_2_2&amp;title=Black Knife Catacombs"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2412,9 +2284,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="caves_2_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_2_3&amp;id=caves_2_3&amp;link=/checklists/landmarks_locations.html%23item_2_3&amp;title=Cliffbottom Catacombs">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_2_3&amp;id=caves_2_3&amp;link=/checklists/landmarks_locations.html%23item_2_3&amp;title=Cliffbottom Catacombs"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2451,9 +2321,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="caves_2_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_2_6&amp;id=caves_2_6&amp;link=/checklists/landmarks_locations.html%23item_2_6&amp;title=Road's End Catacombs">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_2_6&amp;id=caves_2_6&amp;link=/checklists/landmarks_locations.html%23item_2_6&amp;title=Road's End Catacombs"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2489,9 +2357,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="caves_2_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_2_5&amp;id=caves_2_5&amp;link=/checklists/landmarks_locations.html%23item_2_5&amp;title=Raya Lucaria Crystal Tunnel">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_2_5&amp;id=caves_2_5&amp;link=/checklists/landmarks_locations.html%23item_2_5&amp;title=Raya Lucaria Crystal Tunnel"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2527,9 +2393,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="caves_e4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_e4&amp;id=caves_e4&amp;link=/checklists/landmarks_locations.html%23item_e4&amp;title=Malefactor's Evergaol">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_e4&amp;id=caves_e4&amp;link=/checklists/landmarks_locations.html%23item_e4&amp;title=Malefactor's Evergaol"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2566,9 +2430,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="caves_e5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_e5&amp;id=caves_e5&amp;link=/checklists/landmarks_locations.html%23item_e5&amp;title=Cuckoo's Evergaol">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_e5&amp;id=caves_e5&amp;link=/checklists/landmarks_locations.html%23item_e5&amp;title=Cuckoo's Evergaol"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2605,9 +2467,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="caves_e6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_e6&amp;id=caves_e6&amp;link=/checklists/landmarks_locations.html%23item_e6&amp;title=Royal Grave Evergaol">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_e6&amp;id=caves_e6&amp;link=/checklists/landmarks_locations.html%23item_e6&amp;title=Royal Grave Evergaol"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2644,9 +2504,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="caves_e7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_e7&amp;id=caves_e7&amp;link=/checklists/landmarks_locations.html%23item_e7&amp;title=Ringleader's Evergaol">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_e7&amp;id=caves_e7&amp;link=/checklists/landmarks_locations.html%23item_e7&amp;title=Ringleader's Evergaol"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2683,9 +2541,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="caves_l30" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l30&amp;id=caves_l30&amp;link=/checklists/landmarks_locations.html%23item_l30&amp;title=Minor Erdtree (southwest)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l30&amp;id=caves_l30&amp;link=/checklists/landmarks_locations.html%23item_l30&amp;title=Minor Erdtree (southwest)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2721,9 +2577,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="caves_l31" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l31&amp;id=caves_l31&amp;link=/checklists/landmarks_locations.html%23item_l31&amp;title=Minor Erdtree (northeast)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l31&amp;id=caves_l31&amp;link=/checklists/landmarks_locations.html%23item_l31&amp;title=Minor Erdtree (northeast)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2759,9 +2613,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="caves_l32" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l32&amp;id=caves_l32&amp;link=/checklists/landmarks_locations.html%23item_l32&amp;title=Divine Tower of Liurnia">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l32&amp;id=caves_l32&amp;link=/checklists/landmarks_locations.html%23item_l32&amp;title=Divine Tower of Liurnia"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2796,9 +2648,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="caves_l33" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l33&amp;id=caves_l33&amp;link=/checklists/landmarks_locations.html%23item_l33&amp;title=Converted Tower">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l33&amp;id=caves_l33&amp;link=/checklists/landmarks_locations.html%23item_l33&amp;title=Converted Tower"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2833,9 +2683,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="caves_l34" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l34&amp;id=caves_l34&amp;link=/checklists/landmarks_locations.html%23item_l34&amp;title=Testu's Rise">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l34&amp;id=caves_l34&amp;link=/checklists/landmarks_locations.html%23item_l34&amp;title=Testu's Rise"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2870,9 +2718,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="caves_l35" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l35&amp;id=caves_l35&amp;link=/checklists/landmarks_locations.html%23item_l35&amp;title=Converted Fringe Tower">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l35&amp;id=caves_l35&amp;link=/checklists/landmarks_locations.html%23item_l35&amp;title=Converted Fringe Tower"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2907,9 +2753,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="caves_l36" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l36&amp;id=caves_l36&amp;link=/checklists/landmarks_locations.html%23item_l36&amp;title=Ranni's Rise">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l36&amp;id=caves_l36&amp;link=/checklists/landmarks_locations.html%23item_l36&amp;title=Ranni's Rise"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2944,9 +2788,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="caves_l38" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l38&amp;id=caves_l38&amp;link=/checklists/landmarks_locations.html%23item_l38&amp;title=Seluvis's Rise">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l38&amp;id=caves_l38&amp;link=/checklists/landmarks_locations.html%23item_l38&amp;title=Seluvis's Rise"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2981,9 +2823,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="caves_l39" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l39&amp;id=caves_l39&amp;link=/checklists/landmarks_locations.html%23item_l39&amp;title=Renna's Rise">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l39&amp;id=caves_l39&amp;link=/checklists/landmarks_locations.html%23item_l39&amp;title=Renna's Rise"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3018,9 +2858,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="caves_l50" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l50&amp;id=caves_l50&amp;link=/checklists/landmarks_locations.html%23item_l50&amp;title=Chelona's Rise">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l50&amp;id=caves_l50&amp;link=/checklists/landmarks_locations.html%23item_l50&amp;title=Chelona's Rise"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3055,9 +2893,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="caves_l40" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l40&amp;id=caves_l40&amp;link=/checklists/landmarks_locations.html%23item_l40&amp;title=Laskyar Ruins">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l40&amp;id=caves_l40&amp;link=/checklists/landmarks_locations.html%23item_l40&amp;title=Laskyar Ruins"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3092,9 +2928,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="caves_l41" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l41&amp;id=caves_l41&amp;link=/checklists/landmarks_locations.html%23item_l41&amp;title=Purified Ruins">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l41&amp;id=caves_l41&amp;link=/checklists/landmarks_locations.html%23item_l41&amp;title=Purified Ruins"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3129,9 +2963,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="caves_l42" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l42&amp;id=caves_l42&amp;link=/checklists/landmarks_locations.html%23item_l42&amp;title=Kingsrealm Ruins">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l42&amp;id=caves_l42&amp;link=/checklists/landmarks_locations.html%23item_l42&amp;title=Kingsrealm Ruins"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3166,9 +2998,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="caves_l43" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l43&amp;id=caves_l43&amp;link=/checklists/landmarks_locations.html%23item_l43&amp;title=Lunar Estate Ruins">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l43&amp;id=caves_l43&amp;link=/checklists/landmarks_locations.html%23item_l43&amp;title=Lunar Estate Ruins"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3203,9 +3033,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="caves_l44" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l44&amp;id=caves_l44&amp;link=/checklists/landmarks_locations.html%23item_l44&amp;title=Moonfolk Ruins">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l44&amp;id=caves_l44&amp;link=/checklists/landmarks_locations.html%23item_l44&amp;title=Moonfolk Ruins"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3240,9 +3068,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="caves_l45" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l45&amp;id=caves_l45&amp;link=/checklists/landmarks_locations.html%23item_l45&amp;title=Slumbering Wolf's Shack">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l45&amp;id=caves_l45&amp;link=/checklists/landmarks_locations.html%23item_l45&amp;title=Slumbering Wolf's Shack"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3277,9 +3103,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="caves_l46" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l46&amp;id=caves_l46&amp;link=/checklists/landmarks_locations.html%23item_l46&amp;title=Boilprawn Shack">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l46&amp;id=caves_l46&amp;link=/checklists/landmarks_locations.html%23item_l46&amp;title=Boilprawn Shack"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3314,9 +3138,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="caves_l47" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l47&amp;id=caves_l47&amp;link=/checklists/landmarks_locations.html%23item_l47&amp;title=Artist's Shack">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l47&amp;id=caves_l47&amp;link=/checklists/landmarks_locations.html%23item_l47&amp;title=Artist's Shack"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3351,9 +3173,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="caves_l48" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l48&amp;id=caves_l48&amp;link=/checklists/landmarks_locations.html%23item_l48&amp;title=Revenger's Shack">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l48&amp;id=caves_l48&amp;link=/checklists/landmarks_locations.html%23item_l48&amp;title=Revenger's Shack"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3388,9 +3208,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="caves_l131" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l131&amp;id=caves_l131&amp;link=/checklists/landmarks_locations.html%23item_l131&amp;title=Church of Irith">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l131&amp;id=caves_l131&amp;link=/checklists/landmarks_locations.html%23item_l131&amp;title=Church of Irith"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3425,9 +3243,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="caves_l51" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l51&amp;id=caves_l51&amp;link=/checklists/landmarks_locations.html%23item_l51&amp;title=Rose Church">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l51&amp;id=caves_l51&amp;link=/checklists/landmarks_locations.html%23item_l51&amp;title=Rose Church"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3462,9 +3278,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="caves_l52" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l52&amp;id=caves_l52&amp;link=/checklists/landmarks_locations.html%23item_l52&amp;title=Church of Vows">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l52&amp;id=caves_l52&amp;link=/checklists/landmarks_locations.html%23item_l52&amp;title=Church of Vows"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3499,9 +3313,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="caves_l53" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l53&amp;id=caves_l53&amp;link=/checklists/landmarks_locations.html%23item_l53&amp;title=Bellum Church">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l53&amp;id=caves_l53&amp;link=/checklists/landmarks_locations.html%23item_l53&amp;title=Bellum Church"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3536,9 +3348,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="caves_l54" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l54&amp;id=caves_l54&amp;link=/checklists/landmarks_locations.html%23item_l54&amp;title=Church of Inhibition">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l54&amp;id=caves_l54&amp;link=/checklists/landmarks_locations.html%23item_l54&amp;title=Church of Inhibition"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3573,9 +3383,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="caves_l55" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l55&amp;id=caves_l55&amp;link=/checklists/landmarks_locations.html%23item_l55&amp;title=Cathedral of Manus Celes">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l55&amp;id=caves_l55&amp;link=/checklists/landmarks_locations.html%23item_l55&amp;title=Cathedral of Manus Celes"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3610,9 +3418,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="caves_l56" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l56&amp;id=caves_l56&amp;link=/checklists/landmarks_locations.html%23item_l56&amp;title=Highway Lookout Tower">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l56&amp;id=caves_l56&amp;link=/checklists/landmarks_locations.html%23item_l56&amp;title=Highway Lookout Tower"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3647,9 +3453,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="caves_l57" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l57&amp;id=caves_l57&amp;link=/checklists/landmarks_locations.html%23item_l57&amp;title=Carian Study Hall">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l57&amp;id=caves_l57&amp;link=/checklists/landmarks_locations.html%23item_l57&amp;title=Carian Study Hall"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3684,9 +3488,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="caves_l58" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l58&amp;id=caves_l58&amp;link=/checklists/landmarks_locations.html%23item_l58&amp;title=Jarburg">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l58&amp;id=caves_l58&amp;link=/checklists/landmarks_locations.html%23item_l58&amp;title=Jarburg"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3721,9 +3523,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="caves_l59" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l59&amp;id=caves_l59&amp;link=/checklists/landmarks_locations.html%23item_l59&amp;title=Academy Gate Town">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l59&amp;id=caves_l59&amp;link=/checklists/landmarks_locations.html%23item_l59&amp;title=Academy Gate Town"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3758,9 +3558,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="caves_l60" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l60&amp;id=caves_l60&amp;link=/checklists/landmarks_locations.html%23item_l60&amp;title=Temple Quarter">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l60&amp;id=caves_l60&amp;link=/checklists/landmarks_locations.html%23item_l60&amp;title=Temple Quarter"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3795,9 +3593,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="caves_l61" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l61&amp;id=caves_l61&amp;link=/checklists/landmarks_locations.html%23item_l61&amp;title=Village of the Albinaurics">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l61&amp;id=caves_l61&amp;link=/checklists/landmarks_locations.html%23item_l61&amp;title=Village of the Albinaurics"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3832,9 +3628,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="caves_l62" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l62&amp;id=caves_l62&amp;link=/checklists/landmarks_locations.html%23item_l62&amp;title=The Four Belfries">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l62&amp;id=caves_l62&amp;link=/checklists/landmarks_locations.html%23item_l62&amp;title=The Four Belfries"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3869,9 +3663,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="caves_l63" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l63&amp;id=caves_l63&amp;link=/checklists/landmarks_locations.html%23item_l63&amp;title=Frenzied Flame Village">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l63&amp;id=caves_l63&amp;link=/checklists/landmarks_locations.html%23item_l63&amp;title=Frenzied Flame Village"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3906,9 +3698,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="caves_l64" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l64&amp;id=caves_l64&amp;link=/checklists/landmarks_locations.html%23item_l64&amp;title=Frenzy-Flaming Tower">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l64&amp;id=caves_l64&amp;link=/checklists/landmarks_locations.html%23item_l64&amp;title=Frenzy-Flaming Tower"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3943,9 +3733,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="caves_l65" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l65&amp;id=caves_l65&amp;link=/checklists/landmarks_locations.html%23item_l65&amp;title=Ainsel River Well">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l65&amp;id=caves_l65&amp;link=/checklists/landmarks_locations.html%23item_l65&amp;title=Ainsel River Well"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3980,9 +3768,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="caves_l66" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l66&amp;id=caves_l66&amp;link=/checklists/landmarks_locations.html%23item_l66&amp;title=Deep Ainsel Well">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l66&amp;id=caves_l66&amp;link=/checklists/landmarks_locations.html%23item_l66&amp;title=Deep Ainsel Well"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4017,9 +3803,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="caves_ld3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_ld3&amp;id=caves_ld3&amp;link=/checklists/landmarks_locations.html%23item_ld3&amp;title=Academy of Raya Lucaria">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_ld3&amp;id=caves_ld3&amp;link=/checklists/landmarks_locations.html%23item_ld3&amp;title=Academy of Raya Lucaria"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4056,9 +3840,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="caves_ld4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_ld4&amp;id=caves_ld4&amp;link=/checklists/landmarks_locations.html%23item_ld4&amp;title=Caria Manor">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_ld4&amp;id=caves_ld4&amp;link=/checklists/landmarks_locations.html%23item_ld4&amp;title=Caria Manor"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4095,9 +3877,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="caves_2_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_2_7&amp;id=caves_2_7&amp;link=/checklists/landmarks_locations.html%23item_2_7&amp;title=Ruin-Strewn Precipice">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_2_7&amp;id=caves_2_7&amp;link=/checklists/landmarks_locations.html%23item_2_7&amp;title=Ruin-Strewn Precipice"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4135,9 +3915,7 @@
         <div class="card shadow-sm mb-3" id="caves_section_3">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#caves_3Col" data-bs-toggle="collapse" href="#caves_3Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#caves_3Col" data-bs-toggle="collapse" href="#caves_3Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Caelid</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="caves_totals_3"></span>
             </h4>
@@ -4149,9 +3927,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -4185,9 +3961,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="caves_3_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_3_1&amp;id=caves_3_1&amp;link=/checklists/landmarks_locations.html%23item_3_1&amp;title=Abandoned Cave">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_3_1&amp;id=caves_3_1&amp;link=/checklists/landmarks_locations.html%23item_3_1&amp;title=Abandoned Cave"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4223,9 +3997,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="caves_3_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_3_4&amp;id=caves_3_4&amp;link=/checklists/landmarks_locations.html%23item_3_4&amp;title=Gaol Cave">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_3_4&amp;id=caves_3_4&amp;link=/checklists/landmarks_locations.html%23item_3_4&amp;title=Gaol Cave"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4262,9 +4034,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="caves_3_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_3_7&amp;id=caves_3_7&amp;link=/checklists/landmarks_locations.html%23item_3_7&amp;title=Dragonbarrow Cave">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_3_7&amp;id=caves_3_7&amp;link=/checklists/landmarks_locations.html%23item_3_7&amp;title=Dragonbarrow Cave"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4300,9 +4070,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="caves_3_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_3_9&amp;id=caves_3_9&amp;link=/checklists/landmarks_locations.html%23item_3_9&amp;title=Sellia Hideaway">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_3_9&amp;id=caves_3_9&amp;link=/checklists/landmarks_locations.html%23item_3_9&amp;title=Sellia Hideaway"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4339,9 +4107,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="caves_3_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_3_2&amp;id=caves_3_2&amp;link=/checklists/landmarks_locations.html%23item_3_2&amp;title=Caelid Catacombs">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_3_2&amp;id=caves_3_2&amp;link=/checklists/landmarks_locations.html%23item_3_2&amp;title=Caelid Catacombs"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4377,9 +4143,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="caves_3_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_3_5&amp;id=caves_3_5&amp;link=/checklists/landmarks_locations.html%23item_3_5&amp;title=Minor Erdtree Catacombs">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_3_5&amp;id=caves_3_5&amp;link=/checklists/landmarks_locations.html%23item_3_5&amp;title=Minor Erdtree Catacombs"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4415,9 +4179,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="caves_3_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_3_8&amp;id=caves_3_8&amp;link=/checklists/landmarks_locations.html%23item_3_8&amp;title=War-Dead Catacombs">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_3_8&amp;id=caves_3_8&amp;link=/checklists/landmarks_locations.html%23item_3_8&amp;title=War-Dead Catacombs"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4453,9 +4215,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="caves_3_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_3_3&amp;id=caves_3_3&amp;link=/checklists/landmarks_locations.html%23item_3_3&amp;title=Gael Tunnel">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_3_3&amp;id=caves_3_3&amp;link=/checklists/landmarks_locations.html%23item_3_3&amp;title=Gael Tunnel"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4491,9 +4251,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="caves_3_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_3_6&amp;id=caves_3_6&amp;link=/checklists/landmarks_locations.html%23item_3_6&amp;title=Sellia Crystal Tunnel">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_3_6&amp;id=caves_3_6&amp;link=/checklists/landmarks_locations.html%23item_3_6&amp;title=Sellia Crystal Tunnel"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4529,9 +4287,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="caves_e8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_e8&amp;id=caves_e8&amp;link=/checklists/landmarks_locations.html%23item_e8&amp;title=Sellia Evergaol">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_e8&amp;id=caves_e8&amp;link=/checklists/landmarks_locations.html%23item_e8&amp;title=Sellia Evergaol"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4568,9 +4324,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="caves_l67" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l67&amp;id=caves_l67&amp;link=/checklists/landmarks_locations.html%23item_l67&amp;title=Minor Erdtree (west)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l67&amp;id=caves_l67&amp;link=/checklists/landmarks_locations.html%23item_l67&amp;title=Minor Erdtree (west)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4606,9 +4360,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="caves_l68" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l68&amp;id=caves_l68&amp;link=/checklists/landmarks_locations.html%23item_l68&amp;title=Minor Erdtree (east)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l68&amp;id=caves_l68&amp;link=/checklists/landmarks_locations.html%23item_l68&amp;title=Minor Erdtree (east)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4644,9 +4396,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="caves_l69" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l69&amp;id=caves_l69&amp;link=/checklists/landmarks_locations.html%23item_l69&amp;title=Divine Tower of Caelid">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l69&amp;id=caves_l69&amp;link=/checklists/landmarks_locations.html%23item_l69&amp;title=Divine Tower of Caelid"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4681,9 +4431,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="caves_l70" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l70&amp;id=caves_l70&amp;link=/checklists/landmarks_locations.html%23item_l70&amp;title=Isolated Divine Tower">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l70&amp;id=caves_l70&amp;link=/checklists/landmarks_locations.html%23item_l70&amp;title=Isolated Divine Tower"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4718,9 +4466,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="caves_l71" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l71&amp;id=caves_l71&amp;link=/checklists/landmarks_locations.html%23item_l71&amp;title=Lenne's Rise">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l71&amp;id=caves_l71&amp;link=/checklists/landmarks_locations.html%23item_l71&amp;title=Lenne's Rise"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4755,9 +4501,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="caves_l72" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l72&amp;id=caves_l72&amp;link=/checklists/landmarks_locations.html%23item_l72&amp;title=Forsaken Ruins">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l72&amp;id=caves_l72&amp;link=/checklists/landmarks_locations.html%23item_l72&amp;title=Forsaken Ruins"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4792,9 +4536,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="caves_l73" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l73&amp;id=caves_l73&amp;link=/checklists/landmarks_locations.html%23item_l73&amp;title=Caelem Ruins">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l73&amp;id=caves_l73&amp;link=/checklists/landmarks_locations.html%23item_l73&amp;title=Caelem Ruins"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4829,9 +4571,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="caves_l74" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l74&amp;id=caves_l74&amp;link=/checklists/landmarks_locations.html%23item_l74&amp;title=Caelid Waypoint Ruins">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l74&amp;id=caves_l74&amp;link=/checklists/landmarks_locations.html%23item_l74&amp;title=Caelid Waypoint Ruins"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4866,9 +4606,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="caves_l75" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l75&amp;id=caves_l75&amp;link=/checklists/landmarks_locations.html%23item_l75&amp;title=Street of Sages Ruins">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l75&amp;id=caves_l75&amp;link=/checklists/landmarks_locations.html%23item_l75&amp;title=Street of Sages Ruins"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4903,9 +4641,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="caves_l76" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l76&amp;id=caves_l76&amp;link=/checklists/landmarks_locations.html%23item_l76&amp;title=Shack of the Rotting">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l76&amp;id=caves_l76&amp;link=/checklists/landmarks_locations.html%23item_l76&amp;title=Shack of the Rotting"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4940,9 +4676,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="caves_l77" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l77&amp;id=caves_l77&amp;link=/checklists/landmarks_locations.html%23item_l77&amp;title=Isolated Merchant's Shack">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l77&amp;id=caves_l77&amp;link=/checklists/landmarks_locations.html%23item_l77&amp;title=Isolated Merchant's Shack"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4977,9 +4711,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="caves_l78" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l78&amp;id=caves_l78&amp;link=/checklists/landmarks_locations.html%23item_l78&amp;title=Gowry's Shack">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l78&amp;id=caves_l78&amp;link=/checklists/landmarks_locations.html%23item_l78&amp;title=Gowry's Shack"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5014,9 +4746,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="caves_l79" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l79&amp;id=caves_l79&amp;link=/checklists/landmarks_locations.html%23item_l79&amp;title=Smouldering Church">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l79&amp;id=caves_l79&amp;link=/checklists/landmarks_locations.html%23item_l79&amp;title=Smouldering Church"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5051,9 +4781,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="caves_l80" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l80&amp;id=caves_l80&amp;link=/checklists/landmarks_locations.html%23item_l80&amp;title=Cathedral of Dragon Communion">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l80&amp;id=caves_l80&amp;link=/checklists/landmarks_locations.html%23item_l80&amp;title=Cathedral of Dragon Communion"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5088,9 +4816,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="caves_l81" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l81&amp;id=caves_l81&amp;link=/checklists/landmarks_locations.html%23item_l81&amp;title=Church of the Plague">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l81&amp;id=caves_l81&amp;link=/checklists/landmarks_locations.html%23item_l81&amp;title=Church of the Plague"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5125,9 +4851,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="caves_l82" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l82&amp;id=caves_l82&amp;link=/checklists/landmarks_locations.html%23item_l82&amp;title=Sellia, Town of Sorcery">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l82&amp;id=caves_l82&amp;link=/checklists/landmarks_locations.html%23item_l82&amp;title=Sellia, Town of Sorcery"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5162,9 +4886,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="caves_l83" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l83&amp;id=caves_l83&amp;link=/checklists/landmarks_locations.html%23item_l83&amp;title=Sellia Gateway">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l83&amp;id=caves_l83&amp;link=/checklists/landmarks_locations.html%23item_l83&amp;title=Sellia Gateway"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5199,9 +4921,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="caves_l84" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l84&amp;id=caves_l84&amp;link=/checklists/landmarks_locations.html%23item_l84&amp;title=Bestial Sanctum">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l84&amp;id=caves_l84&amp;link=/checklists/landmarks_locations.html%23item_l84&amp;title=Bestial Sanctum"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5236,9 +4956,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="caves_l85" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l85&amp;id=caves_l85&amp;link=/checklists/landmarks_locations.html%23item_l85&amp;title=Deep Siofra Well">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l85&amp;id=caves_l85&amp;link=/checklists/landmarks_locations.html%23item_l85&amp;title=Deep Siofra Well"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5273,9 +4991,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="caves_l86" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l86&amp;id=caves_l86&amp;link=/checklists/landmarks_locations.html%23item_l86&amp;title=Fort Gael">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l86&amp;id=caves_l86&amp;link=/checklists/landmarks_locations.html%23item_l86&amp;title=Fort Gael"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5310,9 +5026,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="caves_l87" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l87&amp;id=caves_l87&amp;link=/checklists/landmarks_locations.html%23item_l87&amp;title=Fort Faroth">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l87&amp;id=caves_l87&amp;link=/checklists/landmarks_locations.html%23item_l87&amp;title=Fort Faroth"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5347,9 +5061,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="caves_l88" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l88&amp;id=caves_l88&amp;link=/checklists/landmarks_locations.html%23item_l88&amp;title=Swamp Lookout Tower">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l88&amp;id=caves_l88&amp;link=/checklists/landmarks_locations.html%23item_l88&amp;title=Swamp Lookout Tower"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5384,9 +5096,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="caves_ld5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_ld5&amp;id=caves_ld5&amp;link=/checklists/landmarks_locations.html%23item_ld5&amp;title=Redmane Castle">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_ld5&amp;id=caves_ld5&amp;link=/checklists/landmarks_locations.html%23item_ld5&amp;title=Redmane Castle"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5424,9 +5134,7 @@
         <div class="card shadow-sm mb-3" id="caves_section_4">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#caves_4Col" data-bs-toggle="collapse" href="#caves_4Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#caves_4Col" data-bs-toggle="collapse" href="#caves_4Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Altus Plateau</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="caves_totals_4"></span>
             </h4>
@@ -5438,9 +5146,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -5474,9 +5180,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="caves_4_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_4_3&amp;id=caves_4_3&amp;link=/checklists/landmarks_locations.html%23item_4_3&amp;title=Perfumer's Grotto">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_4_3&amp;id=caves_4_3&amp;link=/checklists/landmarks_locations.html%23item_4_3&amp;title=Perfumer's Grotto"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5512,9 +5216,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="caves_5_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_5_2&amp;id=caves_5_2&amp;link=/checklists/landmarks_locations.html%23item_5_2&amp;title=Sage's Cave">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_5_2&amp;id=caves_5_2&amp;link=/checklists/landmarks_locations.html%23item_5_2&amp;title=Sage's Cave"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5550,9 +5252,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="caves_5_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_5_4&amp;id=caves_5_4&amp;link=/checklists/landmarks_locations.html%23item_5_4&amp;title=Unsightly Catacombs">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_5_4&amp;id=caves_5_4&amp;link=/checklists/landmarks_locations.html%23item_5_4&amp;title=Unsightly Catacombs"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5589,9 +5289,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="caves_4_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_4_1&amp;id=caves_4_1&amp;link=/checklists/landmarks_locations.html%23item_4_1&amp;title=Old Altus Tunnel">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_4_1&amp;id=caves_4_1&amp;link=/checklists/landmarks_locations.html%23item_4_1&amp;title=Old Altus Tunnel"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5627,9 +5325,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="caves_4_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_4_2&amp;id=caves_4_2&amp;link=/checklists/landmarks_locations.html%23item_4_2&amp;title=Altus Tunnel">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_4_2&amp;id=caves_4_2&amp;link=/checklists/landmarks_locations.html%23item_4_2&amp;title=Altus Tunnel"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5665,9 +5361,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="caves_4_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_4_4&amp;id=caves_4_4&amp;link=/checklists/landmarks_locations.html%23item_4_4&amp;title=Sainted Hero's Grave">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_4_4&amp;id=caves_4_4&amp;link=/checklists/landmarks_locations.html%23item_4_4&amp;title=Sainted Hero's Grave"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5704,9 +5398,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="caves_e9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_e9&amp;id=caves_e9&amp;link=/checklists/landmarks_locations.html%23item_e9&amp;title=Golden Lineage Evergaol">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_e9&amp;id=caves_e9&amp;link=/checklists/landmarks_locations.html%23item_e9&amp;title=Golden Lineage Evergaol"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5743,9 +5435,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="caves_l89" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l89&amp;id=caves_l89&amp;link=/checklists/landmarks_locations.html%23item_l89&amp;title=Minor Erdtree">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l89&amp;id=caves_l89&amp;link=/checklists/landmarks_locations.html%23item_l89&amp;title=Minor Erdtree"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5781,9 +5471,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="caves_l90" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l90&amp;id=caves_l90&amp;link=/checklists/landmarks_locations.html%23item_l90&amp;title=Mirage Rise">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l90&amp;id=caves_l90&amp;link=/checklists/landmarks_locations.html%23item_l90&amp;title=Mirage Rise"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5818,9 +5506,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="caves_l91" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l91&amp;id=caves_l91&amp;link=/checklists/landmarks_locations.html%23item_l91&amp;title=Perfumer's Ruins">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l91&amp;id=caves_l91&amp;link=/checklists/landmarks_locations.html%23item_l91&amp;title=Perfumer's Ruins"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5855,9 +5541,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="caves_l92" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l92&amp;id=caves_l92&amp;link=/checklists/landmarks_locations.html%23item_l92&amp;title=Lux Ruins">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l92&amp;id=caves_l92&amp;link=/checklists/landmarks_locations.html%23item_l92&amp;title=Lux Ruins"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5892,9 +5576,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="caves_l93" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l93&amp;id=caves_l93&amp;link=/checklists/landmarks_locations.html%23item_l93&amp;title=Wyndham Ruins">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l93&amp;id=caves_l93&amp;link=/checklists/landmarks_locations.html%23item_l93&amp;title=Wyndham Ruins"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5929,9 +5611,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="caves_l94" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l94&amp;id=caves_l94&amp;link=/checklists/landmarks_locations.html%23item_l94&amp;title=Writheblood Ruins">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l94&amp;id=caves_l94&amp;link=/checklists/landmarks_locations.html%23item_l94&amp;title=Writheblood Ruins"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5966,9 +5646,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="caves_l95" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l95&amp;id=caves_l95&amp;link=/checklists/landmarks_locations.html%23item_l95&amp;title=Woodfolk Ruins">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l95&amp;id=caves_l95&amp;link=/checklists/landmarks_locations.html%23item_l95&amp;title=Woodfolk Ruins"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6003,9 +5681,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="caves_l96" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l96&amp;id=caves_l96&amp;link=/checklists/landmarks_locations.html%23item_l96&amp;title=Stormcaller Church">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l96&amp;id=caves_l96&amp;link=/checklists/landmarks_locations.html%23item_l96&amp;title=Stormcaller Church"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6040,9 +5716,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="caves_l97" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l97&amp;id=caves_l97&amp;link=/checklists/landmarks_locations.html%23item_l97&amp;title=Second Church of Marika">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l97&amp;id=caves_l97&amp;link=/checklists/landmarks_locations.html%23item_l97&amp;title=Second Church of Marika"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6077,9 +5751,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="caves_l98" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l98&amp;id=caves_l98&amp;link=/checklists/landmarks_locations.html%23item_l98&amp;title=Grand Lift of Dectus">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l98&amp;id=caves_l98&amp;link=/checklists/landmarks_locations.html%23item_l98&amp;title=Grand Lift of Dectus"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6114,9 +5786,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="caves_l99" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l99&amp;id=caves_l99&amp;link=/checklists/landmarks_locations.html%23item_l99&amp;title=West Windmill Pasture">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l99&amp;id=caves_l99&amp;link=/checklists/landmarks_locations.html%23item_l99&amp;title=West Windmill Pasture"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6151,9 +5821,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="caves_l100" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l100&amp;id=caves_l100&amp;link=/checklists/landmarks_locations.html%23item_l100&amp;title=East Windmill Pasture">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l100&amp;id=caves_l100&amp;link=/checklists/landmarks_locations.html%23item_l100&amp;title=East Windmill Pasture"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6188,9 +5856,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="caves_l101" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l101&amp;id=caves_l101&amp;link=/checklists/landmarks_locations.html%23item_l101&amp;title=Village Windmill Pasture">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l101&amp;id=caves_l101&amp;link=/checklists/landmarks_locations.html%23item_l101&amp;title=Village Windmill Pasture"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6225,9 +5891,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="caves_l102" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l102&amp;id=caves_l102&amp;link=/checklists/landmarks_locations.html%23item_l102&amp;title=Dominula, Windmill Village">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l102&amp;id=caves_l102&amp;link=/checklists/landmarks_locations.html%23item_l102&amp;title=Dominula, Windmill Village"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6262,9 +5926,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="caves_l103" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l103&amp;id=caves_l103&amp;link=/checklists/landmarks_locations.html%23item_l103&amp;title=Highway Lookout Tower">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l103&amp;id=caves_l103&amp;link=/checklists/landmarks_locations.html%23item_l103&amp;title=Highway Lookout Tower"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6299,9 +5961,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="caves_ld6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_ld6&amp;id=caves_ld6&amp;link=/checklists/landmarks_locations.html%23item_ld6&amp;title=The Shaded Castle">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_ld6&amp;id=caves_ld6&amp;link=/checklists/landmarks_locations.html%23item_ld6&amp;title=The Shaded Castle"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6339,9 +5999,7 @@
         <div class="card shadow-sm mb-3" id="caves_section_5">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#caves_5Col" data-bs-toggle="collapse" href="#caves_5Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#caves_5Col" data-bs-toggle="collapse" href="#caves_5Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Mt. Gelmir</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="caves_totals_5"></span>
             </h4>
@@ -6353,9 +6011,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -6389,9 +6045,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="caves_5_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_5_3&amp;id=caves_5_3&amp;link=/checklists/landmarks_locations.html%23item_5_3&amp;title=Seethewater Cave">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_5_3&amp;id=caves_5_3&amp;link=/checklists/landmarks_locations.html%23item_5_3&amp;title=Seethewater Cave"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6428,9 +6082,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="caves_5_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_5_5&amp;id=caves_5_5&amp;link=/checklists/landmarks_locations.html%23item_5_5&amp;title=Volcano Cave">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_5_5&amp;id=caves_5_5&amp;link=/checklists/landmarks_locations.html%23item_5_5&amp;title=Volcano Cave"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6466,9 +6118,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="caves_5_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_5_6&amp;id=caves_5_6&amp;link=/checklists/landmarks_locations.html%23item_5_6&amp;title=Wyndham Catacombs">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_5_6&amp;id=caves_5_6&amp;link=/checklists/landmarks_locations.html%23item_5_6&amp;title=Wyndham Catacombs"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6505,9 +6155,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="caves_5_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_5_1&amp;id=caves_5_1&amp;link=/checklists/landmarks_locations.html%23item_5_1&amp;title=Gelmir Hero's Grave">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_5_1&amp;id=caves_5_1&amp;link=/checklists/landmarks_locations.html%23item_5_1&amp;title=Gelmir Hero's Grave"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6543,9 +6191,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="caves_l104" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l104&amp;id=caves_l104&amp;link=/checklists/landmarks_locations.html%23item_l104&amp;title=Minor Erdtree">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l104&amp;id=caves_l104&amp;link=/checklists/landmarks_locations.html%23item_l104&amp;title=Minor Erdtree"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6581,9 +6227,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="caves_l105" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l105&amp;id=caves_l105&amp;link=/checklists/landmarks_locations.html%23item_l105&amp;title=Corpse-Stench Shack">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l105&amp;id=caves_l105&amp;link=/checklists/landmarks_locations.html%23item_l105&amp;title=Corpse-Stench Shack"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6618,9 +6262,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="caves_l106" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l106&amp;id=caves_l106&amp;link=/checklists/landmarks_locations.html%23item_l106&amp;title=Craftsman's Shack">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l106&amp;id=caves_l106&amp;link=/checklists/landmarks_locations.html%23item_l106&amp;title=Craftsman's Shack"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6655,9 +6297,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="caves_l107" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l107&amp;id=caves_l107&amp;link=/checklists/landmarks_locations.html%23item_l107&amp;title=Hermit's Shack">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l107&amp;id=caves_l107&amp;link=/checklists/landmarks_locations.html%23item_l107&amp;title=Hermit's Shack"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6692,9 +6332,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="caves_l108" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l108&amp;id=caves_l108&amp;link=/checklists/landmarks_locations.html%23item_l108&amp;title=Hermit Village">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l108&amp;id=caves_l108&amp;link=/checklists/landmarks_locations.html%23item_l108&amp;title=Hermit Village"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6730,9 +6368,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="caves_l109" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l109&amp;id=caves_l109&amp;link=/checklists/landmarks_locations.html%23item_l109&amp;title=Fort Laiedd">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l109&amp;id=caves_l109&amp;link=/checklists/landmarks_locations.html%23item_l109&amp;title=Fort Laiedd"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6767,9 +6403,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="caves_ld7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_ld7&amp;id=caves_ld7&amp;link=/checklists/landmarks_locations.html%23item_ld7&amp;title=Volcano Manor">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_ld7&amp;id=caves_ld7&amp;link=/checklists/landmarks_locations.html%23item_ld7&amp;title=Volcano Manor"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6807,9 +6441,7 @@
         <div class="card shadow-sm mb-3" id="caves_section_6">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#caves_6Col" data-bs-toggle="collapse" href="#caves_6Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#caves_6Col" data-bs-toggle="collapse" href="#caves_6Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Leyndell, Royal Capital</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="caves_totals_6"></span>
             </h4>
@@ -6821,9 +6453,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -6857,9 +6487,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="caves_6_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_6_4&amp;id=caves_6_4&amp;link=/checklists/landmarks_locations.html%23item_6_4&amp;title=Auriza Side Tomb">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_6_4&amp;id=caves_6_4&amp;link=/checklists/landmarks_locations.html%23item_6_4&amp;title=Auriza Side Tomb"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6895,9 +6523,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="caves_6_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_6_3&amp;id=caves_6_3&amp;link=/checklists/landmarks_locations.html%23item_6_3&amp;title=Leyndell Catacombs">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_6_3&amp;id=caves_6_3&amp;link=/checklists/landmarks_locations.html%23item_6_3&amp;title=Leyndell Catacombs"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6934,9 +6560,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="caves_6_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_6_1&amp;id=caves_6_1&amp;link=/checklists/landmarks_locations.html%23item_6_1&amp;title=Sealed Tunnel">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_6_1&amp;id=caves_6_1&amp;link=/checklists/landmarks_locations.html%23item_6_1&amp;title=Sealed Tunnel"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6972,9 +6596,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="caves_6_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_6_2&amp;id=caves_6_2&amp;link=/checklists/landmarks_locations.html%23item_6_2&amp;title=Auriza Hero's Grave">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_6_2&amp;id=caves_6_2&amp;link=/checklists/landmarks_locations.html%23item_6_2&amp;title=Auriza Hero's Grave"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7011,9 +6633,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="caves_l110" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l110&amp;id=caves_l110&amp;link=/checklists/landmarks_locations.html%23item_l110&amp;title=Minor Erdtree">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l110&amp;id=caves_l110&amp;link=/checklists/landmarks_locations.html%23item_l110&amp;title=Minor Erdtree"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7049,9 +6669,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="caves_l111" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l111&amp;id=caves_l111&amp;link=/checklists/landmarks_locations.html%23item_l111&amp;title=Divine Tower of West Altus">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l111&amp;id=caves_l111&amp;link=/checklists/landmarks_locations.html%23item_l111&amp;title=Divine Tower of West Altus"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7086,9 +6704,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="caves_l112" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l112&amp;id=caves_l112&amp;link=/checklists/landmarks_locations.html%23item_l112&amp;title=Hermit Merchant's Shack">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l112&amp;id=caves_l112&amp;link=/checklists/landmarks_locations.html%23item_l112&amp;title=Hermit Merchant's Shack"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7123,9 +6739,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="caves_l113" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l113&amp;id=caves_l113&amp;link=/checklists/landmarks_locations.html%23item_l113&amp;title=Minor Erdtree Church">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l113&amp;id=caves_l113&amp;link=/checklists/landmarks_locations.html%23item_l113&amp;title=Minor Erdtree Church"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7160,9 +6774,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="caves_ld8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_ld8&amp;id=caves_ld8&amp;link=/checklists/landmarks_locations.html%23item_ld8&amp;title=Leyndell, Royal Capital">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_ld8&amp;id=caves_ld8&amp;link=/checklists/landmarks_locations.html%23item_ld8&amp;title=Leyndell, Royal Capital"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7199,9 +6811,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="caves_ld9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_ld9&amp;id=caves_ld9&amp;link=/checklists/landmarks_locations.html%23item_ld9&amp;title=Subterranean Shunning-Grounds">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_ld9&amp;id=caves_ld9&amp;link=/checklists/landmarks_locations.html%23item_ld9&amp;title=Subterranean Shunning-Grounds"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7239,9 +6849,7 @@
         <div class="card shadow-sm mb-3" id="caves_section_7">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#caves_7Col" data-bs-toggle="collapse" href="#caves_7Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#caves_7Col" data-bs-toggle="collapse" href="#caves_7Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Mountaintops of the Giants</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="caves_totals_7"></span>
             </h4>
@@ -7253,9 +6861,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -7289,9 +6895,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="caves_7_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_7_3&amp;id=caves_7_3&amp;link=/checklists/landmarks_locations.html%23item_7_3&amp;title=Spiritcaller Cave">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_7_3&amp;id=caves_7_3&amp;link=/checklists/landmarks_locations.html%23item_7_3&amp;title=Spiritcaller Cave"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7328,9 +6932,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="caves_7_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_7_2&amp;id=caves_7_2&amp;link=/checklists/landmarks_locations.html%23item_7_2&amp;title=Giants' Mountaintop Catacombs">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_7_2&amp;id=caves_7_2&amp;link=/checklists/landmarks_locations.html%23item_7_2&amp;title=Giants' Mountaintop Catacombs"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7366,9 +6968,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="caves_7_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_7_1&amp;id=caves_7_1&amp;link=/checklists/landmarks_locations.html%23item_7_1&amp;title=Giant-Conquering Hero's Grave">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_7_1&amp;id=caves_7_1&amp;link=/checklists/landmarks_locations.html%23item_7_1&amp;title=Giant-Conquering Hero's Grave"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7404,9 +7004,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="caves_e10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_e10&amp;id=caves_e10&amp;link=/checklists/landmarks_locations.html%23item_e10&amp;title=Lord Contender's Evergaol">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_e10&amp;id=caves_e10&amp;link=/checklists/landmarks_locations.html%23item_e10&amp;title=Lord Contender's Evergaol"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7443,9 +7041,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="caves_l114" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l114&amp;id=caves_l114&amp;link=/checklists/landmarks_locations.html%23item_l114&amp;title=Minor Erdtree">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l114&amp;id=caves_l114&amp;link=/checklists/landmarks_locations.html%23item_l114&amp;title=Minor Erdtree"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7481,9 +7077,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="caves_l115" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l115&amp;id=caves_l115&amp;link=/checklists/landmarks_locations.html%23item_l115&amp;title=Divine Tower of East Altus">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l115&amp;id=caves_l115&amp;link=/checklists/landmarks_locations.html%23item_l115&amp;title=Divine Tower of East Altus"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7518,9 +7112,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="caves_l116" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l116&amp;id=caves_l116&amp;link=/checklists/landmarks_locations.html%23item_l116&amp;title=Heretical Rise">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l116&amp;id=caves_l116&amp;link=/checklists/landmarks_locations.html%23item_l116&amp;title=Heretical Rise"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7555,9 +7147,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="caves_l117" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l117&amp;id=caves_l117&amp;link=/checklists/landmarks_locations.html%23item_l117&amp;title=Zamor Ruins">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l117&amp;id=caves_l117&amp;link=/checklists/landmarks_locations.html%23item_l117&amp;title=Zamor Ruins"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7592,9 +7182,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="caves_l118" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l118&amp;id=caves_l118&amp;link=/checklists/landmarks_locations.html%23item_l118&amp;title=Stargazer's Ruins">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l118&amp;id=caves_l118&amp;link=/checklists/landmarks_locations.html%23item_l118&amp;title=Stargazer's Ruins"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7629,9 +7217,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="caves_l119" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l119&amp;id=caves_l119&amp;link=/checklists/landmarks_locations.html%23item_l119&amp;title=Shack of the Lofty">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l119&amp;id=caves_l119&amp;link=/checklists/landmarks_locations.html%23item_l119&amp;title=Shack of the Lofty"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7666,9 +7252,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="caves_l120" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l120&amp;id=caves_l120&amp;link=/checklists/landmarks_locations.html%23item_l120&amp;title=First Church of Marika">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l120&amp;id=caves_l120&amp;link=/checklists/landmarks_locations.html%23item_l120&amp;title=First Church of Marika"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7703,9 +7287,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="caves_l121" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l121&amp;id=caves_l121&amp;link=/checklists/landmarks_locations.html%23item_l121&amp;title=Church of Repose">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l121&amp;id=caves_l121&amp;link=/checklists/landmarks_locations.html%23item_l121&amp;title=Church of Repose"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7740,9 +7322,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="caves_l122" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l122&amp;id=caves_l122&amp;link=/checklists/landmarks_locations.html%23item_l122&amp;title=Grand Lift of Rold">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l122&amp;id=caves_l122&amp;link=/checklists/landmarks_locations.html%23item_l122&amp;title=Grand Lift of Rold"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7777,9 +7357,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="caves_l123" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l123&amp;id=caves_l123&amp;link=/checklists/landmarks_locations.html%23item_l123&amp;title=Guardians' Garrison">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l123&amp;id=caves_l123&amp;link=/checklists/landmarks_locations.html%23item_l123&amp;title=Guardians' Garrison"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7814,9 +7392,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="caves_l125" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l125&amp;id=caves_l125&amp;link=/checklists/landmarks_locations.html%23item_l125&amp;title=Forge of the Giants">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l125&amp;id=caves_l125&amp;link=/checklists/landmarks_locations.html%23item_l125&amp;title=Forge of the Giants"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7851,9 +7427,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="caves_ld10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_ld10&amp;id=caves_ld10&amp;link=/checklists/landmarks_locations.html%23item_ld10&amp;title=Castle Sol">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_ld10&amp;id=caves_ld10&amp;link=/checklists/landmarks_locations.html%23item_ld10&amp;title=Castle Sol"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7891,9 +7465,7 @@
         <div class="card shadow-sm mb-3" id="caves_section_8">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#caves_8Col" data-bs-toggle="collapse" href="#caves_8Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#caves_8Col" data-bs-toggle="collapse" href="#caves_8Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Consecrated Snowfield</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="caves_totals_8"></span>
             </h4>
@@ -7905,9 +7477,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -7941,9 +7511,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="caves_8_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_8_4&amp;id=caves_8_4&amp;link=/checklists/landmarks_locations.html%23item_8_4&amp;title=Cave of the Forlorn">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_8_4&amp;id=caves_8_4&amp;link=/checklists/landmarks_locations.html%23item_8_4&amp;title=Cave of the Forlorn"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7979,9 +7547,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="caves_8_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_8_2&amp;id=caves_8_2&amp;link=/checklists/landmarks_locations.html%23item_8_2&amp;title=Hidden Path to the Haligtree">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_8_2&amp;id=caves_8_2&amp;link=/checklists/landmarks_locations.html%23item_8_2&amp;title=Hidden Path to the Haligtree"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8017,9 +7583,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="caves_8_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_8_1&amp;id=caves_8_1&amp;link=/checklists/landmarks_locations.html%23item_8_1&amp;title=Consecrated Snowfield Catacombs">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_8_1&amp;id=caves_8_1&amp;link=/checklists/landmarks_locations.html%23item_8_1&amp;title=Consecrated Snowfield Catacombs"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8055,9 +7619,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="caves_8_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_8_3&amp;id=caves_8_3&amp;link=/checklists/landmarks_locations.html%23item_8_3&amp;title=Yelough Anix Tunnel">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_8_3&amp;id=caves_8_3&amp;link=/checklists/landmarks_locations.html%23item_8_3&amp;title=Yelough Anix Tunnel"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8093,9 +7655,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="caves_l126" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l126&amp;id=caves_l126&amp;link=/checklists/landmarks_locations.html%23item_l126&amp;title=Minor Erdtree">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l126&amp;id=caves_l126&amp;link=/checklists/landmarks_locations.html%23item_l126&amp;title=Minor Erdtree"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8131,9 +7691,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="caves_l127" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l127&amp;id=caves_l127&amp;link=/checklists/landmarks_locations.html%23item_l127&amp;title=Albinauric Rise">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l127&amp;id=caves_l127&amp;link=/checklists/landmarks_locations.html%23item_l127&amp;title=Albinauric Rise"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8168,9 +7726,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="caves_l128" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l128&amp;id=caves_l128&amp;link=/checklists/landmarks_locations.html%23item_l128&amp;title=Yelough Anix Ruins">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l128&amp;id=caves_l128&amp;link=/checklists/landmarks_locations.html%23item_l128&amp;title=Yelough Anix Ruins"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8205,9 +7761,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="caves_l129" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l129&amp;id=caves_l129&amp;link=/checklists/landmarks_locations.html%23item_l129&amp;title=Apostate Derelict">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l129&amp;id=caves_l129&amp;link=/checklists/landmarks_locations.html%23item_l129&amp;title=Apostate Derelict"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8242,9 +7796,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="caves_l130" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_l130&amp;id=caves_l130&amp;link=/checklists/landmarks_locations.html%23item_l130&amp;title=Ordina, Liturgical Town">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_l130&amp;id=caves_l130&amp;link=/checklists/landmarks_locations.html%23item_l130&amp;title=Ordina, Liturgical Town"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8279,9 +7831,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="caves_ld11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_ld11&amp;id=caves_ld11&amp;link=/checklists/landmarks_locations.html%23item_ld11&amp;title=Miquella's Haligtree">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_ld11&amp;id=caves_ld11&amp;link=/checklists/landmarks_locations.html%23item_ld11&amp;title=Miquella's Haligtree"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8318,9 +7868,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="caves_ld12" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_ld12&amp;id=caves_ld12&amp;link=/checklists/landmarks_locations.html%23item_ld12&amp;title=Elphael, Brace of the Haligtree">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_ld12&amp;id=caves_ld12&amp;link=/checklists/landmarks_locations.html%23item_ld12&amp;title=Elphael, Brace of the Haligtree"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8358,9 +7906,7 @@
         <div class="card shadow-sm mb-3" id="caves_section_9">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#caves_9Col" data-bs-toggle="collapse" href="#caves_9Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#caves_9Col" data-bs-toggle="collapse" href="#caves_9Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Crumbling Farum Azula</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="caves_totals_9"></span>
             </h4>
@@ -8372,9 +7918,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -8408,9 +7952,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="caves_ld13" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=caves_ld13&amp;id=caves_ld13&amp;link=/checklists/landmarks_locations.html%23item_ld13&amp;title=Crumbling Farum Azula">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=caves_ld13&amp;id=caves_ld13&amp;link=/checklists/landmarks_locations.html%23item_ld13&amp;title=Crumbling Farum Azula"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8448,9 +7990,7 @@
         <div class="card shadow-sm mb-3" id="caves_section_10">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#caves_10Col" data-bs-toggle="collapse" href="#caves_10Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#caves_10Col" data-bs-toggle="collapse" href="#caves_10Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Leyndell, Ashen Capital</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="caves_totals_10"></span>
             </h4>
@@ -8462,9 +8002,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -8498,9 +8036,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="10" id="caves_ld14" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?x=4271&amp;y=3531&amp;id=caves_ld14&amp;link=/checklists/landmarks_locations.html%23item_ld14&amp;title=Leyndell, Ashen Capital">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?x=4271&amp;y=3531&amp;id=caves_ld14&amp;link=/checklists/landmarks_locations.html%23item_ld14&amp;title=Leyndell, Ashen Capital"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">

--- a/docs/checklists/larval_tears_celestial_dews.html
+++ b/docs/checklists/larval_tears_celestial_dews.html
@@ -27,14 +27,10 @@
         <a class="navbar-brand me-auto ms-2" href="/index.html">Roundtable Guides</a>
         <form class="d-none d-sm-flex order-2 order-xl-3">
           <input aria-label="search" class="form-control me-2" name="search" placeholder="Search" type="search">
-          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit">
-            <i class="bi bi-search"></i>
-          </button>
+          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit"><i class="bi bi-search"></i></button>
         </form>
         <div class="d-sm-none order-2">
-          <a class="nav-link me-0" href="/search.html">
-            <i class="bi bi-search sb-icon-search"></i>
-          </a>
+          <a class="nav-link me-0" href="/search.html"><i class="bi bi-search sb-icon-search"></i></a>
         </div>
         <div class="collapse navbar-collapse order-3 order-xl-2 ms-xl-2" id="nav-collapse">
           <ul class="nav navbar-nav navbar-nav-scroll mr-auto">
@@ -179,14 +175,10 @@
               </ul>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/map.html">
-                <i class="bi bi-map"></i> Map
-              </a>
+              <a class="nav-link hide-buttons" href="/map.html"><i class="bi bi-map"></i> Map</a>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/options.html">
-                <i class="bi bi-gear-fill"></i> Options
-              </a>
+              <a class="nav-link hide-buttons" href="/options.html"><i class="bi bi-gear-fill"></i> Options</a>
             </li>
           </ul>
         </div>
@@ -206,9 +198,7 @@
       </div>
       <nav class="text-muted toc d-print-none">
         <strong class="d-block h5">
-          <a class="toc-button" data-bs-toggle="collapse" href="#toc_tears_dews" role="button">
-            <i class="bi bi-plus-lg"></i>Table Of Contents
-          </a>
+          <a class="toc-button" data-bs-toggle="collapse" href="#toc_tears_dews" role="button"><i class="bi bi-plus-lg"></i>Table Of Contents</a>
         </strong>
         <ul class="toc_page collapse" id="toc_tears_dews">
           <li>
@@ -228,9 +218,7 @@
         <div class="card shadow-sm mb-3" id="tears_dews_section_0">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#tears_dews_0Col" data-bs-toggle="collapse" href="#tears_dews_0Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#tears_dews_0Col" data-bs-toggle="collapse" href="#tears_dews_0Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <img class="me-1" data-src="/img/icons/keys/edited/03075.png" loading="lazy" style="height: 70px; width: 70px">
               <span class="d-print-inline">Larval Tears</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="tears_dews_totals_0"></span>
@@ -434,9 +422,7 @@
         <div class="card shadow-sm mb-3" id="tears_dews_section_1">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#tears_dews_1Col" data-bs-toggle="collapse" href="#tears_dews_1Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#tears_dews_1Col" data-bs-toggle="collapse" href="#tears_dews_1Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <img class="me-1" data-src="/img/icons/keys/edited/00624.png" loading="lazy" style="height: 70px; width: 70px">
               <span class="d-print-inline">Celestial Dews</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="tears_dews_totals_1"></span>

--- a/docs/checklists/legendaries.html
+++ b/docs/checklists/legendaries.html
@@ -27,14 +27,10 @@
         <a class="navbar-brand me-auto ms-2" href="/index.html">Roundtable Guides</a>
         <form class="d-none d-sm-flex order-2 order-xl-3">
           <input aria-label="search" class="form-control me-2" name="search" placeholder="Search" type="search">
-          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit">
-            <i class="bi bi-search"></i>
-          </button>
+          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit"><i class="bi bi-search"></i></button>
         </form>
         <div class="d-sm-none order-2">
-          <a class="nav-link me-0" href="/search.html">
-            <i class="bi bi-search sb-icon-search"></i>
-          </a>
+          <a class="nav-link me-0" href="/search.html"><i class="bi bi-search sb-icon-search"></i></a>
         </div>
         <div class="collapse navbar-collapse order-3 order-xl-2 ms-xl-2" id="nav-collapse">
           <ul class="nav navbar-nav navbar-nav-scroll mr-auto">
@@ -179,14 +175,10 @@
               </ul>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/map.html">
-                <i class="bi bi-map"></i> Map
-              </a>
+              <a class="nav-link hide-buttons" href="/map.html"><i class="bi bi-map"></i> Map</a>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/options.html">
-                <i class="bi bi-gear-fill"></i> Options
-              </a>
+              <a class="nav-link hide-buttons" href="/options.html"><i class="bi bi-gear-fill"></i> Options</a>
             </li>
           </ul>
         </div>
@@ -206,9 +198,7 @@
       </div>
       <nav class="text-muted toc d-print-none">
         <strong class="d-block h5">
-          <a class="toc-button" data-bs-toggle="collapse" href="#toc_legendaries" role="button">
-            <i class="bi bi-plus-lg"></i>Table Of Contents
-          </a>
+          <a class="toc-button" data-bs-toggle="collapse" href="#toc_legendaries" role="button"><i class="bi bi-plus-lg"></i>Table Of Contents</a>
         </strong>
         <ul class="toc_page collapse" id="toc_legendaries">
           <li>
@@ -240,9 +230,7 @@
         <div class="card shadow-sm mb-3" id="legendaries_section_0">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#legendaries_0Col" data-bs-toggle="collapse" href="#legendaries_0Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#legendaries_0Col" data-bs-toggle="collapse" href="#legendaries_0Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Legendary Weapons</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="legendaries_totals_0"></span>
             </h4>
@@ -341,9 +329,7 @@
         <div class="card shadow-sm mb-3" id="legendaries_section_1">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#legendaries_1Col" data-bs-toggle="collapse" href="#legendaries_1Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#legendaries_1Col" data-bs-toggle="collapse" href="#legendaries_1Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Legendary Talismans</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="legendaries_totals_1"></span>
             </h4>
@@ -420,9 +406,7 @@
         <div class="card shadow-sm mb-3" id="legendaries_section_2">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#legendaries_2Col" data-bs-toggle="collapse" href="#legendaries_2Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#legendaries_2Col" data-bs-toggle="collapse" href="#legendaries_2Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Legendary Ashes</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="legendaries_totals_2"></span>
             </h4>
@@ -483,9 +467,7 @@
         <div class="card shadow-sm mb-3" id="legendaries_section_3">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#legendaries_3Col" data-bs-toggle="collapse" href="#legendaries_3Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#legendaries_3Col" data-bs-toggle="collapse" href="#legendaries_3Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Legendary Sorceries</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="legendaries_totals_3"></span>
             </h4>
@@ -530,9 +512,7 @@
         <div class="card shadow-sm mb-3" id="legendaries_section_4">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#legendaries_4Col" data-bs-toggle="collapse" href="#legendaries_4Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#legendaries_4Col" data-bs-toggle="collapse" href="#legendaries_4Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Legendary Incantations</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="legendaries_totals_4"></span>
             </h4>

--- a/docs/checklists/memory_stones_talisman_pouches.html
+++ b/docs/checklists/memory_stones_talisman_pouches.html
@@ -27,14 +27,10 @@
         <a class="navbar-brand me-auto ms-2" href="/index.html">Roundtable Guides</a>
         <form class="d-none d-sm-flex order-2 order-xl-3">
           <input aria-label="search" class="form-control me-2" name="search" placeholder="Search" type="search">
-          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit">
-            <i class="bi bi-search"></i>
-          </button>
+          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit"><i class="bi bi-search"></i></button>
         </form>
         <div class="d-sm-none order-2">
-          <a class="nav-link me-0" href="/search.html">
-            <i class="bi bi-search sb-icon-search"></i>
-          </a>
+          <a class="nav-link me-0" href="/search.html"><i class="bi bi-search sb-icon-search"></i></a>
         </div>
         <div class="collapse navbar-collapse order-3 order-xl-2 ms-xl-2" id="nav-collapse">
           <ul class="nav navbar-nav navbar-nav-scroll mr-auto">
@@ -179,14 +175,10 @@
               </ul>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/map.html">
-                <i class="bi bi-map"></i> Map
-              </a>
+              <a class="nav-link hide-buttons" href="/map.html"><i class="bi bi-map"></i> Map</a>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/options.html">
-                <i class="bi bi-gear-fill"></i> Options
-              </a>
+              <a class="nav-link hide-buttons" href="/options.html"><i class="bi bi-gear-fill"></i> Options</a>
             </li>
           </ul>
         </div>
@@ -206,9 +198,7 @@
       </div>
       <nav class="text-muted toc d-print-none">
         <strong class="d-block h5">
-          <a class="toc-button" data-bs-toggle="collapse" href="#toc_memory_stones_talisman_pouches" role="button">
-            <i class="bi bi-plus-lg"></i>Table Of Contents
-          </a>
+          <a class="toc-button" data-bs-toggle="collapse" href="#toc_memory_stones_talisman_pouches" role="button"><i class="bi bi-plus-lg"></i>Table Of Contents</a>
         </strong>
         <ul class="toc_page collapse" id="toc_memory_stones_talisman_pouches">
           <li>
@@ -228,9 +218,7 @@
         <div class="card shadow-sm mb-3" id="memory_stones_talisman_pouches_section_0">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#memory_stones_talisman_pouches_0Col" data-bs-toggle="collapse" href="#memory_stones_talisman_pouches_0Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#memory_stones_talisman_pouches_0Col" data-bs-toggle="collapse" href="#memory_stones_talisman_pouches_0Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <img class="me-1" data-src="/img/icons/keys/edited/00553.png" loading="lazy" style="height: 70px; width: 70px">
               <span class="d-print-inline">Memory Stones</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="memory_stones_talisman_pouches_totals_0"></span>
@@ -241,72 +229,56 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="memory_stones_talisman_pouches_0_1" type="checkbox" value="">
                     <label class="form-check-label item_content" for="memory_stones_talisman_pouches_0_1">Found in Oridys' Rise, on the plateau to the east side of the Weeping Peninsula.</label>
-                    <a class="ms-2" href="/map.html?target=memory_stones_talisman_pouches_0_1&amp;id=memory_stones_talisman_pouches_0_1&amp;link=/checklists/memory_stones_talisman_pouches.html%23item_0_1&amp;title=Memory Stone">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=memory_stones_talisman_pouches_0_1&amp;id=memory_stones_talisman_pouches_0_1&amp;link=/checklists/memory_stones_talisman_pouches.html%23item_0_1&amp;title=Memory Stone"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="memory_stones_talisman_pouches_0_2" id="item_0_2">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="memory_stones_talisman_pouches_0_2" type="checkbox" value="">
                     <label class="form-check-label item_content" for="memory_stones_talisman_pouches_0_2">Purchasable from Twin Maiden Husks at the Roundtable Hold for 3,000 Runes.</label>
-                    <a class="ms-2" href="/map.html?target=memory_stones_talisman_pouches_0_2&amp;id=memory_stones_talisman_pouches_0_2&amp;link=/checklists/memory_stones_talisman_pouches.html%23item_0_2&amp;title=Memory Stone">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=memory_stones_talisman_pouches_0_2&amp;id=memory_stones_talisman_pouches_0_2&amp;link=/checklists/memory_stones_talisman_pouches.html%23item_0_2&amp;title=Memory Stone"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="memory_stones_talisman_pouches_0_3" id="item_0_3">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="memory_stones_talisman_pouches_0_3" type="checkbox" value="">
                     <label class="form-check-label item_content" for="memory_stones_talisman_pouches_0_3">Found in the Converted Tower, in the southwest of Liurnia of the Lakes.</label>
-                    <a class="ms-2" href="/map.html?target=memory_stones_talisman_pouches_0_3&amp;id=memory_stones_talisman_pouches_0_3&amp;link=/checklists/memory_stones_talisman_pouches.html%23item_0_3&amp;title=Memory Stone">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=memory_stones_talisman_pouches_0_3&amp;id=memory_stones_talisman_pouches_0_3&amp;link=/checklists/memory_stones_talisman_pouches.html%23item_0_3&amp;title=Memory Stone"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="memory_stones_talisman_pouches_0_4" id="item_0_4">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="memory_stones_talisman_pouches_0_4" type="checkbox" value="">
                     <label class="form-check-label item_content" for="memory_stones_talisman_pouches_0_4">Reward for defeating Red Wolf of Radagon in Raya Lucaria Academy.</label>
-                    <a class="ms-2" href="/map.html?target=memory_stones_talisman_pouches_0_4&amp;id=memory_stones_talisman_pouches_0_4&amp;link=/checklists/memory_stones_talisman_pouches.html%23item_0_4&amp;title=Memory Stone">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=memory_stones_talisman_pouches_0_4&amp;id=memory_stones_talisman_pouches_0_4&amp;link=/checklists/memory_stones_talisman_pouches.html%23item_0_4&amp;title=Memory Stone"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="memory_stones_talisman_pouches_0_5" id="item_0_5">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="memory_stones_talisman_pouches_0_5" type="checkbox" value="">
                     <label class="form-check-label item_content" for="memory_stones_talisman_pouches_0_5">Found in Testu's Rise, north of Raya Lucaria Academy.</label>
-                    <a class="ms-2" href="/map.html?target=memory_stones_talisman_pouches_0_5&amp;id=memory_stones_talisman_pouches_0_5&amp;link=/checklists/memory_stones_talisman_pouches.html%23item_0_5&amp;title=Memory Stone">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=memory_stones_talisman_pouches_0_5&amp;id=memory_stones_talisman_pouches_0_5&amp;link=/checklists/memory_stones_talisman_pouches.html%23item_0_5&amp;title=Memory Stone"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="memory_stones_talisman_pouches_0_6" id="item_0_6">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="memory_stones_talisman_pouches_0_6" type="checkbox" value="">
                     <label class="form-check-label item_content" for="memory_stones_talisman_pouches_0_6">Found in Seluvis's Rise behind Caria Manor in Liurnia of the Lakes.</label>
-                    <a class="ms-2" href="/map.html?target=memory_stones_talisman_pouches_0_6&amp;id=memory_stones_talisman_pouches_0_6&amp;link=/checklists/memory_stones_talisman_pouches.html%23item_0_6&amp;title=Memory Stone">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=memory_stones_talisman_pouches_0_6&amp;id=memory_stones_talisman_pouches_0_6&amp;link=/checklists/memory_stones_talisman_pouches.html%23item_0_6&amp;title=Memory Stone"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="memory_stones_talisman_pouches_0_7" id="item_0_7">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="memory_stones_talisman_pouches_0_7" type="checkbox" value="">
                     <label class="form-check-label item_content" for="memory_stones_talisman_pouches_0_7">Found in Lenne's Rise in eastern Caelid.</label>
-                    <a class="ms-2" href="/map.html?target=memory_stones_talisman_pouches_0_7&amp;id=memory_stones_talisman_pouches_0_7&amp;link=/checklists/memory_stones_talisman_pouches.html%23item_0_7&amp;title=Memory Stone">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=memory_stones_talisman_pouches_0_7&amp;id=memory_stones_talisman_pouches_0_7&amp;link=/checklists/memory_stones_talisman_pouches.html%23item_0_7&amp;title=Memory Stone"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="memory_stones_talisman_pouches_0_8" id="item_0_8">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="memory_stones_talisman_pouches_0_8" type="checkbox" value="">
                     <label class="form-check-label item_content" for="memory_stones_talisman_pouches_0_8">Reward for defeating Demi-Human Queen Maggie, northeast of Hermit Village in Mt. Gelmir.</label>
-                    <a class="ms-2" href="/map.html?target=memory_stones_talisman_pouches_0_8&amp;id=memory_stones_talisman_pouches_0_8&amp;link=/checklists/memory_stones_talisman_pouches.html%23item_0_8&amp;title=Memory Stone">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=memory_stones_talisman_pouches_0_8&amp;id=memory_stones_talisman_pouches_0_8&amp;link=/checklists/memory_stones_talisman_pouches.html%23item_0_8&amp;title=Memory Stone"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -316,9 +288,7 @@
         <div class="card shadow-sm mb-3" id="memory_stones_talisman_pouches_section_1">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#memory_stones_talisman_pouches_1Col" data-bs-toggle="collapse" href="#memory_stones_talisman_pouches_1Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#memory_stones_talisman_pouches_1Col" data-bs-toggle="collapse" href="#memory_stones_talisman_pouches_1Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <img class="me-1" data-src="/img/icons/keys/edited/00554.png" loading="lazy" style="height: 70px; width: 70px">
               <span class="d-print-inline">Talisman Pouches</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="memory_stones_talisman_pouches_totals_1"></span>
@@ -329,27 +299,21 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="memory_stones_talisman_pouches_1_2" type="checkbox" value="">
                     <label class="form-check-label item_content" for="memory_stones_talisman_pouches_1_2">Reward for defeating Margit, the Fell Omen in Stormveil Castle.</label>
-                    <a class="ms-2" href="/map.html?target=memory_stones_talisman_pouches_1_2&amp;id=memory_stones_talisman_pouches_1_2&amp;link=/checklists/memory_stones_talisman_pouches.html%23item_1_2&amp;title=Talisman Pouch">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=memory_stones_talisman_pouches_1_2&amp;id=memory_stones_talisman_pouches_1_2&amp;link=/checklists/memory_stones_talisman_pouches.html%23item_1_2&amp;title=Talisman Pouch"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="memory_stones_talisman_pouches_1_3" id="item_1_3">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="memory_stones_talisman_pouches_1_3" type="checkbox" value="">
                     <label class="form-check-label item_content" for="memory_stones_talisman_pouches_1_3">Speak to Finger Reader Enia after acquiring two Great Runes. Will appear in Twin Maiden Husks' shop if you progress too far.</label>
-                    <a class="ms-2" href="/map.html?target=memory_stones_talisman_pouches_1_3&amp;id=memory_stones_talisman_pouches_1_3&amp;link=/checklists/memory_stones_talisman_pouches.html%23item_1_3&amp;title=Talisman Pouch">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=memory_stones_talisman_pouches_1_3&amp;id=memory_stones_talisman_pouches_1_3&amp;link=/checklists/memory_stones_talisman_pouches.html%23item_1_3&amp;title=Talisman Pouch"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="memory_stones_talisman_pouches_1_4" id="item_1_4">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="memory_stones_talisman_pouches_1_4" type="checkbox" value="">
                     <label class="form-check-label item_content" for="memory_stones_talisman_pouches_1_4">Reward for defeating Godfrey, First Elden Lord (Golden Shade) in Leydell, Royal Capital.</label>
-                    <a class="ms-2" href="/map.html?target=memory_stones_talisman_pouches_1_4&amp;id=memory_stones_talisman_pouches_1_4&amp;link=/checklists/memory_stones_talisman_pouches.html%23item_1_4&amp;title=Talisman Pouch">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=memory_stones_talisman_pouches_1_4&amp;id=memory_stones_talisman_pouches_1_4&amp;link=/checklists/memory_stones_talisman_pouches.html%23item_1_4&amp;title=Talisman Pouch"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>

--- a/docs/checklists/npc_questlines.html
+++ b/docs/checklists/npc_questlines.html
@@ -27,14 +27,10 @@
         <a class="navbar-brand me-auto ms-2" href="/index.html">Roundtable Guides</a>
         <form class="d-none d-sm-flex order-2 order-xl-3">
           <input aria-label="search" class="form-control me-2" name="search" placeholder="Search" type="search">
-          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit">
-            <i class="bi bi-search"></i>
-          </button>
+          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit"><i class="bi bi-search"></i></button>
         </form>
         <div class="d-sm-none order-2">
-          <a class="nav-link me-0" href="/search.html">
-            <i class="bi bi-search sb-icon-search"></i>
-          </a>
+          <a class="nav-link me-0" href="/search.html"><i class="bi bi-search sb-icon-search"></i></a>
         </div>
         <div class="collapse navbar-collapse order-3 order-xl-2 ms-xl-2" id="nav-collapse">
           <ul class="nav navbar-nav navbar-nav-scroll mr-auto">
@@ -179,14 +175,10 @@
               </ul>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/map.html">
-                <i class="bi bi-map"></i> Map
-              </a>
+              <a class="nav-link hide-buttons" href="/map.html"><i class="bi bi-map"></i> Map</a>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/options.html">
-                <i class="bi bi-gear-fill"></i> Options
-              </a>
+              <a class="nav-link hide-buttons" href="/options.html"><i class="bi bi-gear-fill"></i> Options</a>
             </li>
           </ul>
         </div>
@@ -206,9 +198,7 @@
       </div>
       <nav class="text-muted toc d-print-none">
         <strong class="d-block h5">
-          <a class="toc-button" data-bs-toggle="collapse" href="#toc_npc_quests" role="button">
-            <i class="bi bi-plus-lg"></i>Table Of Contents
-          </a>
+          <a class="toc-button" data-bs-toggle="collapse" href="#toc_npc_quests" role="button"><i class="bi bi-plus-lg"></i>Table Of Contents</a>
         </strong>
         <ul class="toc_page collapse" id="toc_npc_quests">
           <li>
@@ -388,9 +378,7 @@
         <div class="card shadow-sm mb-3" id="npc_quests_section_0">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_0Col" data-bs-toggle="collapse" href="#npc_quests_0Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_0Col" data-bs-toggle="collapse" href="#npc_quests_0Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Albus">Albus</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="npc_quests_totals_0"></span>
             </h4>
@@ -421,9 +409,7 @@
         <div class="card shadow-sm mb-3" id="npc_quests_section_1">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_1Col" data-bs-toggle="collapse" href="#npc_quests_1Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_1Col" data-bs-toggle="collapse" href="#npc_quests_1Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Bernahl</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="npc_quests_totals_1"></span>
             </h4>
@@ -472,9 +458,7 @@
         <div class="card shadow-sm mb-3" id="npc_quests_section_2">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_2Col" data-bs-toggle="collapse" href="#npc_quests_2Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_2Col" data-bs-toggle="collapse" href="#npc_quests_2Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Blackguard+Big+Boggart">Blackguard Big Boggart</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="npc_quests_totals_2"></span>
             </h4>
@@ -523,9 +507,7 @@
         <div class="card shadow-sm mb-3" id="npc_quests_section_3">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_3Col" data-bs-toggle="collapse" href="#npc_quests_3Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_3Col" data-bs-toggle="collapse" href="#npc_quests_3Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Smithing+Master+Hewg">Blacksmith Hewg</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="npc_quests_totals_3"></span>
             </h4>
@@ -556,9 +538,7 @@
         <div class="card shadow-sm mb-3" id="npc_quests_section_4">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_4Col" data-bs-toggle="collapse" href="#npc_quests_4Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_4Col" data-bs-toggle="collapse" href="#npc_quests_4Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Blaidd</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="npc_quests_totals_4"></span>
             </h4>
@@ -663,9 +643,7 @@
         <div class="card shadow-sm mb-3" id="npc_quests_section_5">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_5Col" data-bs-toggle="collapse" href="#npc_quests_5Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_5Col" data-bs-toggle="collapse" href="#npc_quests_5Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Bloody+Finger+Hunter+Yura">Bloody Finger Hunter Yura</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="npc_quests_totals_5"></span>
             </h4>
@@ -714,9 +692,7 @@
         <div class="card shadow-sm mb-3" id="npc_quests_section_6">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_6Col" data-bs-toggle="collapse" href="#npc_quests_6Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_6Col" data-bs-toggle="collapse" href="#npc_quests_6Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Boc+the+Seamster">Boc the Seamster</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="npc_quests_totals_6"></span>
             </h4>
@@ -809,9 +785,7 @@
         <div class="card shadow-sm mb-3" id="npc_quests_section_7">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_7Col" data-bs-toggle="collapse" href="#npc_quests_7Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_7Col" data-bs-toggle="collapse" href="#npc_quests_7Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Brother+Corhyn">Brother Corhyn/Goldmask</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="npc_quests_totals_7"></span>
             </h4>
@@ -890,9 +864,7 @@
         <div class="card shadow-sm mb-3" id="npc_quests_section_8">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_8Col" data-bs-toggle="collapse" href="#npc_quests_8Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_8Col" data-bs-toggle="collapse" href="#npc_quests_8Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/D+Hunter+of+the+Dead">D, Hunter of the Dead not to be confused with his twin brother D</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="npc_quests_totals_8"></span>
             </h4>
@@ -961,9 +933,7 @@
         <div class="card shadow-sm mb-3" id="npc_quests_section_9">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_9Col" data-bs-toggle="collapse" href="#npc_quests_9Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_9Col" data-bs-toggle="collapse" href="#npc_quests_9Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/D's+Twin+Brother">D, Beholder of the Dead aka D's Twin Brother</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="npc_quests_totals_9"></span>
             </h4>
@@ -1008,9 +978,7 @@
         <div class="card shadow-sm mb-3" id="npc_quests_section_10">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_10Col" data-bs-toggle="collapse" href="#npc_quests_10Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_10Col" data-bs-toggle="collapse" href="#npc_quests_10Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Diallos">Diallos</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="npc_quests_totals_10"></span>
             </h4>
@@ -1059,9 +1027,7 @@
         <div class="card shadow-sm mb-3" id="npc_quests_section_11">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_11Col" data-bs-toggle="collapse" href="#npc_quests_11Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_11Col" data-bs-toggle="collapse" href="#npc_quests_11Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Dung+Eater">Dung-Eater</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="npc_quests_totals_11"></span>
             </h4>
@@ -1130,9 +1096,7 @@
         <div class="card shadow-sm mb-3" id="npc_quests_section_12">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_12Col" data-bs-toggle="collapse" href="#npc_quests_12Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_12Col" data-bs-toggle="collapse" href="#npc_quests_12Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Edgar">Edgar</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="npc_quests_totals_12"></span>
             </h4>
@@ -1199,9 +1163,7 @@
         <div class="card shadow-sm mb-3" id="npc_quests_section_13">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_13Col" data-bs-toggle="collapse" href="#npc_quests_13Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_13Col" data-bs-toggle="collapse" href="#npc_quests_13Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Ensha">Ensha</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="npc_quests_totals_13"></span>
             </h4>
@@ -1232,9 +1194,7 @@
         <div class="card shadow-sm mb-3" id="npc_quests_section_14">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_14Col" data-bs-toggle="collapse" href="#npc_quests_14Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_14Col" data-bs-toggle="collapse" href="#npc_quests_14Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Fia">Fia</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="npc_quests_totals_14"></span>
             </h4>
@@ -1313,9 +1273,7 @@
         <div class="card shadow-sm mb-3" id="npc_quests_section_15">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_15Col" data-bs-toggle="collapse" href="#npc_quests_15Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_15Col" data-bs-toggle="collapse" href="#npc_quests_15Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Gatekeeper+Gostoc">Gatekeeper Gostoc</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="npc_quests_totals_15"></span>
             </h4>
@@ -1370,9 +1328,7 @@
         <div class="card shadow-sm mb-3" id="npc_quests_section_16">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_16Col" data-bs-toggle="collapse" href="#npc_quests_16Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_16Col" data-bs-toggle="collapse" href="#npc_quests_16Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Gideon+Ofnir">Gideon Ofnir</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="npc_quests_totals_16"></span>
             </h4>
@@ -1483,9 +1439,7 @@
         <div class="card shadow-sm mb-3" id="npc_quests_section_17">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_17Col" data-bs-toggle="collapse" href="#npc_quests_17Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_17Col" data-bs-toggle="collapse" href="#npc_quests_17Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/The+Great-Jar">Great Jar</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="npc_quests_totals_17"></span>
             </h4>
@@ -1504,9 +1458,7 @@
         <div class="card shadow-sm mb-3" id="npc_quests_section_18">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_18Col" data-bs-toggle="collapse" href="#npc_quests_18Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_18Col" data-bs-toggle="collapse" href="#npc_quests_18Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Gurranq+Beast+Clergyman">Gurranq, Beast Clergyman</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="npc_quests_totals_18"></span>
             </h4>
@@ -1549,9 +1501,7 @@
         <div class="card shadow-sm mb-3" id="npc_quests_section_19">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_19Col" data-bs-toggle="collapse" href="#npc_quests_19Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_19Col" data-bs-toggle="collapse" href="#npc_quests_19Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Hyetta">Hyetta</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="npc_quests_totals_19"></span>
             </h4>
@@ -1600,9 +1550,7 @@
         <div class="card shadow-sm mb-3" id="npc_quests_section_20">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_20Col" data-bs-toggle="collapse" href="#npc_quests_20Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_20Col" data-bs-toggle="collapse" href="#npc_quests_20Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Iji</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="npc_quests_totals_20"></span>
             </h4>
@@ -1645,9 +1593,7 @@
         <div class="card shadow-sm mb-3" id="npc_quests_section_21">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_21Col" data-bs-toggle="collapse" href="#npc_quests_21Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_21Col" data-bs-toggle="collapse" href="#npc_quests_21Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Irina">Irina</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="npc_quests_totals_21"></span>
             </h4>
@@ -1678,9 +1624,7 @@
         <div class="card shadow-sm mb-3" id="npc_quests_section_22">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_22Col" data-bs-toggle="collapse" href="#npc_quests_22Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_22Col" data-bs-toggle="collapse" href="#npc_quests_22Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Iron+Fist+Alexander">Iron Fist Alexander</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="npc_quests_totals_22"></span>
             </h4>
@@ -1767,9 +1711,7 @@
         <div class="card shadow-sm mb-3" id="npc_quests_section_23">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_23Col" data-bs-toggle="collapse" href="#npc_quests_23Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_23Col" data-bs-toggle="collapse" href="#npc_quests_23Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Jar+Bairn">Jar-Bairn</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="npc_quests_totals_23"></span>
             </h4>
@@ -1818,9 +1760,7 @@
         <div class="card shadow-sm mb-3" id="npc_quests_section_24">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_24Col" data-bs-toggle="collapse" href="#npc_quests_24Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_24Col" data-bs-toggle="collapse" href="#npc_quests_24Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Kenneth+Haight">Kenneth Haight</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="npc_quests_totals_24"></span>
             </h4>
@@ -1869,9 +1809,7 @@
         <div class="card shadow-sm mb-3" id="npc_quests_section_25">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_25Col" data-bs-toggle="collapse" href="#npc_quests_25Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_25Col" data-bs-toggle="collapse" href="#npc_quests_25Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Latenna">Latenna</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="npc_quests_totals_25"></span>
             </h4>
@@ -1920,9 +1858,7 @@
         <div class="card shadow-sm mb-3" id="npc_quests_section_26">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_26Col" data-bs-toggle="collapse" href="#npc_quests_26Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_26Col" data-bs-toggle="collapse" href="#npc_quests_26Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Melina</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="npc_quests_totals_26"></span>
             </h4>
@@ -2059,9 +1995,7 @@
         <div class="card shadow-sm mb-3" id="npc_quests_section_27">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_27Col" data-bs-toggle="collapse" href="#npc_quests_27Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_27Col" data-bs-toggle="collapse" href="#npc_quests_27Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Millicent">Millicent/Gowry</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="npc_quests_totals_27"></span>
             </h4>
@@ -2236,9 +2170,7 @@
         <div class="card shadow-sm mb-3" id="npc_quests_section_28">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_28Col" data-bs-toggle="collapse" href="#npc_quests_28Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_28Col" data-bs-toggle="collapse" href="#npc_quests_28Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Miriel+Pastor+of+Vows">Miriel, Pastor of Vows</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="npc_quests_totals_28"></span>
             </h4>
@@ -2269,9 +2201,7 @@
         <div class="card shadow-sm mb-3" id="npc_quests_section_29">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_29Col" data-bs-toggle="collapse" href="#npc_quests_29Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_29Col" data-bs-toggle="collapse" href="#npc_quests_29Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Nepheli+Loux">Nepheli Loux</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="npc_quests_totals_29"></span>
             </h4>
@@ -2384,9 +2314,7 @@
         <div class="card shadow-sm mb-3" id="npc_quests_section_30">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_30Col" data-bs-toggle="collapse" href="#npc_quests_30Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_30Col" data-bs-toggle="collapse" href="#npc_quests_30Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Patches">Patches the Untethered</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="npc_quests_totals_30"></span>
             </h4>
@@ -2459,9 +2387,7 @@
         <div class="card shadow-sm mb-3" id="npc_quests_section_31">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_31Col" data-bs-toggle="collapse" href="#npc_quests_31Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_31Col" data-bs-toggle="collapse" href="#npc_quests_31Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Pidia,+Carian+Servant">Pidia</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="npc_quests_totals_31"></span>
             </h4>
@@ -2492,9 +2418,7 @@
         <div class="card shadow-sm mb-3" id="npc_quests_section_32">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_32Col" data-bs-toggle="collapse" href="#npc_quests_32Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_32Col" data-bs-toggle="collapse" href="#npc_quests_32Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Ranni</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="npc_quests_totals_32"></span>
             </h4>
@@ -2555,9 +2479,7 @@
         <div class="card shadow-sm mb-3" id="npc_quests_section_33">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_33Col" data-bs-toggle="collapse" href="#npc_quests_33Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_33Col" data-bs-toggle="collapse" href="#npc_quests_33Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Roderika">Roderika</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="npc_quests_totals_33"></span>
             </h4>
@@ -2618,9 +2540,7 @@
         <div class="card shadow-sm mb-3" id="npc_quests_section_34">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_34Col" data-bs-toggle="collapse" href="#npc_quests_34Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_34Col" data-bs-toggle="collapse" href="#npc_quests_34Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Sorcerer+Rogier">Rogier</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="npc_quests_totals_34"></span>
             </h4>
@@ -2683,9 +2603,7 @@
         <div class="card shadow-sm mb-3" id="npc_quests_section_35">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_35Col" data-bs-toggle="collapse" href="#npc_quests_35Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_35Col" data-bs-toggle="collapse" href="#npc_quests_35Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Rya</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="npc_quests_totals_35"></span>
             </h4>
@@ -2766,9 +2684,7 @@
         <div class="card shadow-sm mb-3" id="npc_quests_section_36">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_36Col" data-bs-toggle="collapse" href="#npc_quests_36Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_36Col" data-bs-toggle="collapse" href="#npc_quests_36Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Sorceress+Sellen">Sellen/Jerren</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="npc_quests_totals_36"></span>
             </h4>
@@ -2861,9 +2777,7 @@
         <div class="card shadow-sm mb-3" id="npc_quests_section_37">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_37Col" data-bs-toggle="collapse" href="#npc_quests_37Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_37Col" data-bs-toggle="collapse" href="#npc_quests_37Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Preceptor+Seluvis">Seluvis</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="npc_quests_totals_37"></span>
             </h4>
@@ -2956,9 +2870,7 @@
         <div class="card shadow-sm mb-3" id="npc_quests_section_38">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_38Col" data-bs-toggle="collapse" href="#npc_quests_38Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_38Col" data-bs-toggle="collapse" href="#npc_quests_38Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Shabriri</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="npc_quests_totals_38"></span>
             </h4>
@@ -2989,9 +2901,7 @@
         <div class="card shadow-sm mb-3" id="npc_quests_section_39">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_39Col" data-bs-toggle="collapse" href="#npc_quests_39Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_39Col" data-bs-toggle="collapse" href="#npc_quests_39Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Tanith</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="npc_quests_totals_39"></span>
             </h4>
@@ -3034,9 +2944,7 @@
         <div class="card shadow-sm mb-3" id="npc_quests_section_40">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_40Col" data-bs-toggle="collapse" href="#npc_quests_40Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_40Col" data-bs-toggle="collapse" href="#npc_quests_40Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Thops">Thops</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="npc_quests_totals_40"></span>
             </h4>
@@ -3073,9 +2981,7 @@
         <div class="card shadow-sm mb-3" id="npc_quests_section_41">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_41Col" data-bs-toggle="collapse" href="#npc_quests_41Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#npc_quests_41Col" data-bs-toggle="collapse" href="#npc_quests_41Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/White+Mask+Varre">White-Faced Varré</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="npc_quests_totals_41"></span>
             </h4>

--- a/docs/checklists/paintings.html
+++ b/docs/checklists/paintings.html
@@ -27,14 +27,10 @@
         <a class="navbar-brand me-auto ms-2" href="/index.html">Roundtable Guides</a>
         <form class="d-none d-sm-flex order-2 order-xl-3">
           <input aria-label="search" class="form-control me-2" name="search" placeholder="Search" type="search">
-          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit">
-            <i class="bi bi-search"></i>
-          </button>
+          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit"><i class="bi bi-search"></i></button>
         </form>
         <div class="d-sm-none order-2">
-          <a class="nav-link me-0" href="/search.html">
-            <i class="bi bi-search sb-icon-search"></i>
-          </a>
+          <a class="nav-link me-0" href="/search.html"><i class="bi bi-search sb-icon-search"></i></a>
         </div>
         <div class="collapse navbar-collapse order-3 order-xl-2 ms-xl-2" id="nav-collapse">
           <ul class="nav navbar-nav navbar-nav-scroll mr-auto">
@@ -179,14 +175,10 @@
               </ul>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/map.html">
-                <i class="bi bi-map"></i> Map
-              </a>
+              <a class="nav-link hide-buttons" href="/map.html"><i class="bi bi-map"></i> Map</a>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/options.html">
-                <i class="bi bi-gear-fill"></i> Options
-              </a>
+              <a class="nav-link hide-buttons" href="/options.html"><i class="bi bi-gear-fill"></i> Options</a>
             </li>
           </ul>
         </div>
@@ -206,9 +198,7 @@
       </div>
       <nav class="text-muted toc d-print-none">
         <strong class="d-block h5">
-          <a class="toc-button" data-bs-toggle="collapse" href="#toc_paintings" role="button">
-            <i class="bi bi-plus-lg"></i>Table Of Contents
-          </a>
+          <a class="toc-button" data-bs-toggle="collapse" href="#toc_paintings" role="button"><i class="bi bi-plus-lg"></i>Table Of Contents</a>
         </strong>
         <ul class="toc_page collapse" id="toc_paintings">
           <li>
@@ -228,9 +218,7 @@
         <div class="card shadow-sm mb-3" id="paintings_section_0">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#paintings_0Col" data-bs-toggle="collapse" href="#paintings_0Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#paintings_0Col" data-bs-toggle="collapse" href="#paintings_0Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Painting Locations</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="paintings_totals_0"></span>
             </h4>
@@ -242,9 +230,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -273,9 +259,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="paintings_1_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=paintings_1_1&amp;id=paintings_1_1&amp;link=/checklists/paintings.html%23item_1_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Prophecy+Painting&quot;&gt;Prophecy Painting&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=paintings_1_1&amp;id=paintings_1_1&amp;link=/checklists/paintings.html%23item_1_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Prophecy+Painting&quot;&gt;Prophecy Painting&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -308,9 +292,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="paintings_1_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=paintings_1_2&amp;id=paintings_1_2&amp;link=/checklists/paintings.html%23item_1_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Homing+Instinct+Painting&quot;&gt;Homing Instinct Painting&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=paintings_1_2&amp;id=paintings_1_2&amp;link=/checklists/paintings.html%23item_1_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Homing+Instinct+Painting&quot;&gt;Homing Instinct Painting&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -343,9 +325,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="paintings_2_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=paintings_2_1&amp;id=paintings_2_1&amp;link=/checklists/paintings.html%23item_2_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Resurrection+Painting&quot;&gt;Resurrection Painting&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=paintings_2_1&amp;id=paintings_2_1&amp;link=/checklists/paintings.html%23item_2_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Resurrection+Painting&quot;&gt;Resurrection Painting&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -378,9 +358,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="paintings_3_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=paintings_3_1&amp;id=paintings_3_1&amp;link=/checklists/paintings.html%23item_3_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Redmane+Painting&quot;&gt;Redmane Painting&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=paintings_3_1&amp;id=paintings_3_1&amp;link=/checklists/paintings.html%23item_3_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Redmane+Painting&quot;&gt;Redmane Painting&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -413,9 +391,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="paintings_4_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=paintings_4_1&amp;id=paintings_4_1&amp;link=/checklists/paintings.html%23item_4_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Champion's+Song+Painting&quot;&gt;Champion's Song Painting&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=paintings_4_1&amp;id=paintings_4_1&amp;link=/checklists/paintings.html%23item_4_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Champion's+Song+Painting&quot;&gt;Champion's Song Painting&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -448,9 +424,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="paintings_5_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=paintings_5_1&amp;id=paintings_5_1&amp;link=/checklists/paintings.html%23item_5_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Flightless+Bird+Painting&quot;&gt;Flightless Bird Painting&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=paintings_5_1&amp;id=paintings_5_1&amp;link=/checklists/paintings.html%23item_5_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Flightless+Bird+Painting&quot;&gt;Flightless Bird Painting&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -483,9 +457,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="paintings_6_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=paintings_6_1&amp;id=paintings_6_1&amp;link=/checklists/paintings.html%23item_6_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Sorcerer+Painting&quot;&gt;Sorcerer Painting&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=paintings_6_1&amp;id=paintings_6_1&amp;link=/checklists/paintings.html%23item_6_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Sorcerer+Painting&quot;&gt;Sorcerer Painting&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -518,9 +490,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="paintings_11_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=paintings_11_1&amp;id=paintings_11_1&amp;link=/checklists/paintings.html%23item_11_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Incursion+Painting&quot;&gt;Incursion Painting&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=paintings_11_1&amp;id=paintings_11_1&amp;link=/checklists/paintings.html%23item_11_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Incursion+Painting&quot;&gt;Incursion Painting&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -553,9 +523,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="paintings_11_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=paintings_11_2&amp;id=paintings_11_2&amp;link=/checklists/paintings.html%23item_11_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/The+Sacred+Tower+Painting&quot;&gt;The Sacred Tower Painting&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=paintings_11_2&amp;id=paintings_11_2&amp;link=/checklists/paintings.html%23item_11_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/The+Sacred+Tower+Painting&quot;&gt;The Sacred Tower Painting&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -588,9 +556,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="paintings_11_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=paintings_11_3&amp;id=paintings_11_3&amp;link=/checklists/paintings.html%23item_11_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Domain+of+Dragons+Painting&quot;&gt;Domain of Dragons Painting&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=paintings_11_3&amp;id=paintings_11_3&amp;link=/checklists/paintings.html%23item_11_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Domain+of+Dragons+Painting&quot;&gt;Domain of Dragons Painting&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -624,9 +590,7 @@
         <div class="card shadow-sm mb-3" id="paintings_section_1">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#paintings_1Col" data-bs-toggle="collapse" href="#paintings_1Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#paintings_1Col" data-bs-toggle="collapse" href="#paintings_1Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Painting Rewards</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="paintings_totals_1"></span>
             </h4>
@@ -638,9 +602,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -669,9 +631,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="paintings_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=paintings_1&amp;id=paintings_1&amp;link=/checklists/paintings.html%23item_1&amp;title=Prophecy Painting solution">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=paintings_1&amp;id=paintings_1&amp;link=/checklists/paintings.html%23item_1&amp;title=Prophecy Painting solution"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -704,9 +664,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="paintings_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=paintings_2&amp;id=paintings_2&amp;link=/checklists/paintings.html%23item_2&amp;title=Homing Instinct Painting solution">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=paintings_2&amp;id=paintings_2&amp;link=/checklists/paintings.html%23item_2&amp;title=Homing Instinct Painting solution"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -739,9 +697,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="paintings_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=paintings_3&amp;id=paintings_3&amp;link=/checklists/paintings.html%23item_3&amp;title=Resurrection Painting solution">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=paintings_3&amp;id=paintings_3&amp;link=/checklists/paintings.html%23item_3&amp;title=Resurrection Painting solution"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -774,9 +730,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="paintings_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=paintings_4&amp;id=paintings_4&amp;link=/checklists/paintings.html%23item_4&amp;title=Redmane Painting solution">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=paintings_4&amp;id=paintings_4&amp;link=/checklists/paintings.html%23item_4&amp;title=Redmane Painting solution"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -809,9 +763,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="paintings_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=paintings_5&amp;id=paintings_5&amp;link=/checklists/paintings.html%23item_5&amp;title=Champion's Song Painting solution">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=paintings_5&amp;id=paintings_5&amp;link=/checklists/paintings.html%23item_5&amp;title=Champion's Song Painting solution"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -844,9 +796,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="paintings_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=paintings_6&amp;id=paintings_6&amp;link=/checklists/paintings.html%23item_6&amp;title=Flightless Bird Painting solution">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=paintings_6&amp;id=paintings_6&amp;link=/checklists/paintings.html%23item_6&amp;title=Flightless Bird Painting solution"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -879,9 +829,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="paintings_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=paintings_7&amp;id=paintings_7&amp;link=/checklists/paintings.html%23item_7&amp;title=Sorcerer Painting solution">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=paintings_7&amp;id=paintings_7&amp;link=/checklists/paintings.html%23item_7&amp;title=Sorcerer Painting solution"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -914,9 +862,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="paintings_11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=paintings_11&amp;id=paintings_11&amp;link=/checklists/paintings.html%23item_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Incursion+Painting&quot;&gt;Incursion Painting&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=paintings_11&amp;id=paintings_11&amp;link=/checklists/paintings.html%23item_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Incursion+Painting&quot;&gt;Incursion Painting&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -949,9 +895,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="paintings_12" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=paintings_12&amp;id=paintings_12&amp;link=/checklists/paintings.html%23item_12&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/The+Sacred+Tower+Painting&quot;&gt;The Sacred Tower Painting&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=paintings_12&amp;id=paintings_12&amp;link=/checklists/paintings.html%23item_12&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/The+Sacred+Tower+Painting&quot;&gt;The Sacred Tower Painting&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -984,9 +928,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="paintings_13" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=paintings_13&amp;id=paintings_13&amp;link=/checklists/paintings.html%23item_13&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Domain+of+Dragons+Painting&quot;&gt;Domain of Dragons Painting&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=paintings_13&amp;id=paintings_13&amp;link=/checklists/paintings.html%23item_13&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Domain+of+Dragons+Painting&quot;&gt;Domain of Dragons Painting&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">

--- a/docs/checklists/pots_bottles.html
+++ b/docs/checklists/pots_bottles.html
@@ -27,14 +27,10 @@
         <a class="navbar-brand me-auto ms-2" href="/index.html">Roundtable Guides</a>
         <form class="d-none d-sm-flex order-2 order-xl-3">
           <input aria-label="search" class="form-control me-2" name="search" placeholder="Search" type="search">
-          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit">
-            <i class="bi bi-search"></i>
-          </button>
+          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit"><i class="bi bi-search"></i></button>
         </form>
         <div class="d-sm-none order-2">
-          <a class="nav-link me-0" href="/search.html">
-            <i class="bi bi-search sb-icon-search"></i>
-          </a>
+          <a class="nav-link me-0" href="/search.html"><i class="bi bi-search sb-icon-search"></i></a>
         </div>
         <div class="collapse navbar-collapse order-3 order-xl-2 ms-xl-2" id="nav-collapse">
           <ul class="nav navbar-nav navbar-nav-scroll mr-auto">
@@ -179,14 +175,10 @@
               </ul>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/map.html">
-                <i class="bi bi-map"></i> Map
-              </a>
+              <a class="nav-link hide-buttons" href="/map.html"><i class="bi bi-map"></i> Map</a>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/options.html">
-                <i class="bi bi-gear-fill"></i> Options
-              </a>
+              <a class="nav-link hide-buttons" href="/options.html"><i class="bi bi-gear-fill"></i> Options</a>
             </li>
           </ul>
         </div>
@@ -206,9 +198,7 @@
       </div>
       <nav class="text-muted toc d-print-none">
         <strong class="d-block h5">
-          <a class="toc-button" data-bs-toggle="collapse" href="#toc_pots_bottles" role="button">
-            <i class="bi bi-plus-lg"></i>Table Of Contents
-          </a>
+          <a class="toc-button" data-bs-toggle="collapse" href="#toc_pots_bottles" role="button"><i class="bi bi-plus-lg"></i>Table Of Contents</a>
         </strong>
         <ul class="toc_page collapse" id="toc_pots_bottles">
           <li>
@@ -236,9 +226,7 @@
         <div class="card shadow-sm mb-3" id="pots_bottles_section_0">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#pots_bottles_0Col" data-bs-toggle="collapse" href="#pots_bottles_0Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#pots_bottles_0Col" data-bs-toggle="collapse" href="#pots_bottles_0Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <img class="me-1" data-src="/img/icons/keys/edited/03800.png" loading="lazy" style="height: 70px; width: 70px">
               <span class="d-print-inline">Hefty Cracked Pots</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="pots_bottles_totals_0"></span>
@@ -312,9 +300,7 @@
         <div class="card shadow-sm mb-3" id="pots_bottles_section_1">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#pots_bottles_1Col" data-bs-toggle="collapse" href="#pots_bottles_1Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#pots_bottles_1Col" data-bs-toggle="collapse" href="#pots_bottles_1Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <img class="me-1" data-src="/img/icons/keys/edited/00504.png" loading="lazy" style="height: 70px; width: 70px">
               <span class="d-print-inline">Cracked Pots</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="pots_bottles_totals_1"></span>
@@ -326,45 +312,35 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="pots_bottles_1_1" type="checkbox" value="">
                     <label class="form-check-label item_content" for="pots_bottles_1_1">Church of Elleh, North-West of game's start: sold by Kalé for 300 runes</label>
-                    <a class="ms-2" href="/map.html?target=pots_bottles_1_1&amp;id=pots_bottles_1_1&amp;link=/checklists/pots_bottles.html%23item_1_1&amp;title=Cracked Pot x3">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=pots_bottles_1_1&amp;id=pots_bottles_1_1&amp;link=/checklists/pots_bottles.html%23item_1_1&amp;title=Cracked Pot x3"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="pots_bottles_1_2" id="item_1_2">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="pots_bottles_1_2" type="checkbox" value="">
                     <label class="form-check-label item_content" for="pots_bottles_1_2">Church of Elleh, North-West of game's start: sold by Kalé for 300 runes</label>
-                    <a class="ms-2" href="/map.html?x=3667&amp;y=7210&amp;id=pots_bottles_1_2&amp;link=/checklists/pots_bottles.html%23item_1_2&amp;title=Cracked Pot">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3667&amp;y=7210&amp;id=pots_bottles_1_2&amp;link=/checklists/pots_bottles.html%23item_1_2&amp;title=Cracked Pot"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="pots_bottles_1_3" id="item_1_3">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="pots_bottles_1_3" type="checkbox" value="">
                     <label class="form-check-label item_content" for="pots_bottles_1_3">Church of Elleh, North-West of game's start: sold by Kalé for 300 runes</label>
-                    <a class="ms-2" href="/map.html?x=3667&amp;y=7210&amp;id=pots_bottles_1_3&amp;link=/checklists/pots_bottles.html%23item_1_3&amp;title=Cracked Pot">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3667&amp;y=7210&amp;id=pots_bottles_1_3&amp;link=/checklists/pots_bottles.html%23item_1_3&amp;title=Cracked Pot"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="pots_bottles_1_5" id="item_1_5">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="pots_bottles_1_5" type="checkbox" value="">
                     <label class="form-check-label item_content" for="pots_bottles_1_5">Groveside Cave, in cliffs North of Church of Elleh: near the entrance, on a body near wolves</label>
-                    <a class="ms-2" href="/map.html?target=pots_bottles_1_5&amp;id=pots_bottles_1_5&amp;link=/checklists/pots_bottles.html%23item_1_5&amp;title=Cracked Pot">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=pots_bottles_1_5&amp;id=pots_bottles_1_5&amp;link=/checklists/pots_bottles.html%23item_1_5&amp;title=Cracked Pot"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="pots_bottles_1_4" id="item_1_4">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="pots_bottles_1_4" type="checkbox" value="">
                     <label class="form-check-label item_content" for="pots_bottles_1_4">East of Saintsbridge Grace in the North: Sold by Nomadic Merchant for 600 runes</label>
-                    <a class="ms-2" href="/map.html?target=pots_bottles_1_4&amp;id=pots_bottles_1_4&amp;link=/checklists/pots_bottles.html%23item_1_4&amp;title=Cracked Pot">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=pots_bottles_1_4&amp;id=pots_bottles_1_4&amp;link=/checklists/pots_bottles.html%23item_1_4&amp;title=Cracked Pot"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -374,9 +350,7 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="pots_bottles_1_6" type="checkbox" value="">
                     <label class="form-check-label item_content" for="pots_bottles_1_6">Castle Morne Rampart Grace: Sold by Nomadic Merchant for 600 runes</label>
-                    <a class="ms-2" href="/map.html?target=pots_bottles_1_6&amp;id=pots_bottles_1_6&amp;link=/checklists/pots_bottles.html%23item_1_6&amp;title=Cracked Pot">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=pots_bottles_1_6&amp;id=pots_bottles_1_6&amp;link=/checklists/pots_bottles.html%23item_1_6&amp;title=Cracked Pot"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -386,18 +360,14 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="pots_bottles_1_7" type="checkbox" value="">
                     <label class="form-check-label item_content" for="pots_bottles_1_7">On the path between Liftside Chamber Grace and Secluded Cell Grace. Amongst the Living Pots</label>
-                    <a class="ms-2" href="/map.html?target=pots_bottles_1_7&amp;id=pots_bottles_1_7&amp;link=/checklists/pots_bottles.html%23item_1_7&amp;title=Cracked Pot">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=pots_bottles_1_7&amp;id=pots_bottles_1_7&amp;link=/checklists/pots_bottles.html%23item_1_7&amp;title=Cracked Pot"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="pots_bottles_1_8" id="item_1_8">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="pots_bottles_1_8" type="checkbox" value="">
                     <label class="form-check-label item_content" for="pots_bottles_1_8">On the path between Liftside Chamber Grace and Secluded Cell Grace. Amongst the Living Pots</label>
-                    <a class="ms-2" href="/map.html?target=pots_bottles_1_8&amp;id=pots_bottles_1_8&amp;link=/checklists/pots_bottles.html%23item_1_8&amp;title=Cracked Pot">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=pots_bottles_1_8&amp;id=pots_bottles_1_8&amp;link=/checklists/pots_bottles.html%23item_1_8&amp;title=Cracked Pot"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -407,36 +377,28 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="pots_bottles_1_9" type="checkbox" value="">
                     <label class="form-check-label item_content" for="pots_bottles_1_9">Jarburg, located in the East, down the cliffs just South of Carian Study Hall. Found by a large headstone on the southern end of town</label>
-                    <a class="ms-2" href="/map.html?target=pots_bottles_1_9&amp;id=pots_bottles_1_9&amp;link=/checklists/pots_bottles.html%23item_1_9&amp;title=Cracked Pot">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=pots_bottles_1_9&amp;id=pots_bottles_1_9&amp;link=/checklists/pots_bottles.html%23item_1_9&amp;title=Cracked Pot"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="pots_bottles_1_10" id="item_1_10">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="pots_bottles_1_10" type="checkbox" value="">
                     <label class="form-check-label item_content" for="pots_bottles_1_10">Jarburg, located in the East, down the cliffs just South of Carian Study Hall. Found on the doorstep of a building's blocked entrance on the northern end of town, directly beneath a Ritual Pot on the roof</label>
-                    <a class="ms-2" href="/map.html?target=pots_bottles_1_10&amp;id=pots_bottles_1_10&amp;link=/checklists/pots_bottles.html%23item_1_10&amp;title=Cracked Pot">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=pots_bottles_1_10&amp;id=pots_bottles_1_10&amp;link=/checklists/pots_bottles.html%23item_1_10&amp;title=Cracked Pot"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="pots_bottles_1_11" id="item_1_11">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="pots_bottles_1_11" type="checkbox" value="">
                     <label class="form-check-label item_content" for="pots_bottles_1_11">Jarburg, located in the East, down the cliffs just South of Carian Study Hall. Found in a hut just northeast of the previous</label>
-                    <a class="ms-2" href="/map.html?target=pots_bottles_1_11&amp;id=pots_bottles_1_11&amp;link=/checklists/pots_bottles.html%23item_1_11&amp;title=Cracked Pot">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=pots_bottles_1_11&amp;id=pots_bottles_1_11&amp;link=/checklists/pots_bottles.html%23item_1_11&amp;title=Cracked Pot"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="pots_bottles_1_13" id="item_1_13">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="pots_bottles_1_13" type="checkbox" value="">
                     <label class="form-check-label item_content" for="pots_bottles_1_13">Caria Manor, located in the North-West: Left of the entrance to the boss, find a small archway in the wall to walk through, then drop down to ground level; as soon as you do, without dropping further, follow the wall to the left and find it on the cliff edge</label>
-                    <a class="ms-2" href="/map.html?target=pots_bottles_1_13&amp;id=pots_bottles_1_13&amp;link=/checklists/pots_bottles.html%23item_1_13&amp;title=Cracked Pot">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=pots_bottles_1_13&amp;id=pots_bottles_1_13&amp;link=/checklists/pots_bottles.html%23item_1_13&amp;title=Cracked Pot"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -446,9 +408,7 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="pots_bottles_1_12" type="checkbox" value="">
                     <label class="form-check-label item_content" for="pots_bottles_1_12">From Debate Parlor Grace, go outside then up the stairs to the left. On a body amongst Living Pots</label>
-                    <a class="ms-2" href="/map.html?target=pots_bottles_1_12&amp;id=pots_bottles_1_12&amp;link=/checklists/pots_bottles.html%23item_1_12&amp;title=Cracked Pot">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=pots_bottles_1_12&amp;id=pots_bottles_1_12&amp;link=/checklists/pots_bottles.html%23item_1_12&amp;title=Cracked Pot"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -458,18 +418,14 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="pots_bottles_1_15" type="checkbox" value="">
                     <label class="form-check-label item_content" for="pots_bottles_1_15">Behind the Minor Erdtree in the North-West, on a tree branch extending from the northwest cliffs</label>
-                    <a class="ms-2" href="/map.html?target=pots_bottles_1_15&amp;id=pots_bottles_1_15&amp;link=/checklists/pots_bottles.html%23item_1_15&amp;title=Cracked Pot">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=pots_bottles_1_15&amp;id=pots_bottles_1_15&amp;link=/checklists/pots_bottles.html%23item_1_15&amp;title=Cracked Pot"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="pots_bottles_1_14" id="item_1_14">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="pots_bottles_1_14" type="checkbox" value="">
                     <label class="form-check-label item_content" for="pots_bottles_1_14">South-West of Southern Aeonia Swamp Bank Grace, South of the rot swamp. Sold by Nomadic Merchant for 1500 runes (NOTE: choosing Cracked Pots as a Keepsake gives you this pot early)</label>
-                    <a class="ms-2" href="/map.html?target=pots_bottles_1_14&amp;id=pots_bottles_1_14&amp;link=/checklists/pots_bottles.html%23item_1_14&amp;title=Cracked Pot">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=pots_bottles_1_14&amp;id=pots_bottles_1_14&amp;link=/checklists/pots_bottles.html%23item_1_14&amp;title=Cracked Pot"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -479,36 +435,28 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="pots_bottles_1_16" type="checkbox" value="">
                     <label class="form-check-label item_content" for="pots_bottles_1_16">Auriza Side Tomb, just North-East of Leyndell: In the gated-off watery rooms at the bottom (NOTE: choosing Cracked Pots as a Keepsake gives you this pot early)</label>
-                    <a class="ms-2" href="/map.html?target=pots_bottles_1_16&amp;id=pots_bottles_1_16&amp;link=/checklists/pots_bottles.html%23item_1_16&amp;title=Cracked Pot x4">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=pots_bottles_1_16&amp;id=pots_bottles_1_16&amp;link=/checklists/pots_bottles.html%23item_1_16&amp;title=Cracked Pot x4"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="pots_bottles_1_17" id="item_1_17">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="pots_bottles_1_17" type="checkbox" value="">
                     <label class="form-check-label item_content" for="pots_bottles_1_17">Auriza Side Tomb, just North-East of Leyndell: In the gated-off watery rooms at the bottom (NOTE: choosing Cracked Pots as a Keepsake gives you this pot early)</label>
-                    <a class="ms-2" href="/map.html?x=4597&amp;y=3173&amp;id=pots_bottles_1_17&amp;link=/checklists/pots_bottles.html%23item_1_17&amp;title=Cracked Pot">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4597&amp;y=3173&amp;id=pots_bottles_1_17&amp;link=/checklists/pots_bottles.html%23item_1_17&amp;title=Cracked Pot"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="pots_bottles_1_18" id="item_1_18">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="pots_bottles_1_18" type="checkbox" value="">
                     <label class="form-check-label item_content" for="pots_bottles_1_18">Auriza Side Tomb, just North-East of Leyndell: In the gated-off watery rooms at the bottom</label>
-                    <a class="ms-2" href="/map.html?x=4597&amp;y=3173&amp;id=pots_bottles_1_18&amp;link=/checklists/pots_bottles.html%23item_1_18&amp;title=Cracked Pot">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4597&amp;y=3173&amp;id=pots_bottles_1_18&amp;link=/checklists/pots_bottles.html%23item_1_18&amp;title=Cracked Pot"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="pots_bottles_1_19" id="item_1_19">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="pots_bottles_1_19" type="checkbox" value="">
                     <label class="form-check-label item_content" for="pots_bottles_1_19">Auriza Side Tomb, just North-East of Leyndell: In the gated-off watery rooms at the bottom</label>
-                    <a class="ms-2" href="/map.html?x=4597&amp;y=3173&amp;id=pots_bottles_1_19&amp;link=/checklists/pots_bottles.html%23item_1_19&amp;title=Cracked Pot">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4597&amp;y=3173&amp;id=pots_bottles_1_19&amp;link=/checklists/pots_bottles.html%23item_1_19&amp;title=Cracked Pot"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -518,9 +466,7 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="pots_bottles_1_20" type="checkbox" value="">
                     <label class="form-check-label item_content" for="pots_bottles_1_20">Northwest of the Avenue Balcony Site of Grace and one level below, through a couple doors, on a corpse</label>
-                    <a class="ms-2" href="/map.html?target=pots_bottles_1_20&amp;id=pots_bottles_1_20&amp;link=/checklists/pots_bottles.html%23item_1_20&amp;title=Cracked Pot">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=pots_bottles_1_20&amp;id=pots_bottles_1_20&amp;link=/checklists/pots_bottles.html%23item_1_20&amp;title=Cracked Pot"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -530,9 +476,7 @@
         <div class="card shadow-sm mb-3" id="pots_bottles_section_2">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#pots_bottles_2Col" data-bs-toggle="collapse" href="#pots_bottles_2Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#pots_bottles_2Col" data-bs-toggle="collapse" href="#pots_bottles_2Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <img class="me-1" data-src="/img/icons/keys/edited/03010.png" loading="lazy" style="height: 70px; width: 70px">
               <span class="d-print-inline">Ritual Pots</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="pots_bottles_totals_2"></span>
@@ -544,36 +488,28 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="2" id="pots_bottles_2_1" type="checkbox" value="">
                     <label class="form-check-label item_content" for="pots_bottles_2_1">Laskyar Ruins, North-West of Liurnia Lake Shore Grace: near columns on the northern side</label>
-                    <a class="ms-2" href="/map.html?target=pots_bottles_2_1&amp;id=pots_bottles_2_1&amp;link=/checklists/pots_bottles.html%23item_2_1&amp;title=Ritual Pot">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=pots_bottles_2_1&amp;id=pots_bottles_2_1&amp;link=/checklists/pots_bottles.html%23item_2_1&amp;title=Ritual Pot"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="pots_bottles_2_2" id="item_2_2">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="2" id="pots_bottles_2_2" type="checkbox" value="">
                     <label class="form-check-label item_content" for="pots_bottles_2_2">Jarburg, located in the East, down the cliffs just South of Carian Study Hall. Found on a rooftop; jump onto it from above near Jar-Bairn's perch.</label>
-                    <a class="ms-2" href="/map.html?target=pots_bottles_2_2&amp;id=pots_bottles_2_2&amp;link=/checklists/pots_bottles.html%23item_2_2&amp;title=Ritual Pot">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=pots_bottles_2_2&amp;id=pots_bottles_2_2&amp;link=/checklists/pots_bottles.html%23item_2_2&amp;title=Ritual Pot"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="pots_bottles_2_3" id="item_2_3">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="2" id="pots_bottles_2_3" type="checkbox" value="">
                     <label class="form-check-label item_content" for="pots_bottles_2_3">Jarburg, located in the East, down the cliffs just South of Carian Study Hall. South of the previous, on a large decorative jar</label>
-                    <a class="ms-2" href="/map.html?target=pots_bottles_2_3&amp;id=pots_bottles_2_3&amp;link=/checklists/pots_bottles.html%23item_2_3&amp;title=Ritual Pot">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=pots_bottles_2_3&amp;id=pots_bottles_2_3&amp;link=/checklists/pots_bottles.html%23item_2_3&amp;title=Ritual Pot"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="pots_bottles_2_5" id="item_2_5">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="2" id="pots_bottles_2_5" type="checkbox" value="">
                     <label class="form-check-label item_content" for="pots_bottles_2_5">After Caria Manor, go West of the Manor then head South. Along the cliffs on the East side, you can jump down, back into Caria manor. Sold by Pidia for 1500 runes</label>
-                    <a class="ms-2" href="/map.html?target=pots_bottles_2_5&amp;id=pots_bottles_2_5&amp;link=/checklists/pots_bottles.html%23item_2_5&amp;title=Ritual Pot">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=pots_bottles_2_5&amp;id=pots_bottles_2_5&amp;link=/checklists/pots_bottles.html%23item_2_5&amp;title=Ritual Pot"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -583,9 +519,7 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="2" id="pots_bottles_2_4" type="checkbox" value="">
                     <label class="form-check-label item_content" for="pots_bottles_2_4">Near the Schoolhouse Classroom Site of Grace, in a chest guarded by mages and a giant Living Jar</label>
-                    <a class="ms-2" href="/map.html?target=pots_bottles_2_4&amp;id=pots_bottles_2_4&amp;link=/checklists/pots_bottles.html%23item_2_4&amp;title=Ritual Pot">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=pots_bottles_2_4&amp;id=pots_bottles_2_4&amp;link=/checklists/pots_bottles.html%23item_2_4&amp;title=Ritual Pot"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -595,9 +529,7 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="2" id="pots_bottles_2_6" type="checkbox" value="">
                     <label class="form-check-label item_content" for="pots_bottles_2_6">Isolated Merchant's Shack in the North. Sold by the Isolated Merchant for 3000 runes</label>
-                    <a class="ms-2" href="/map.html?target=pots_bottles_2_6&amp;id=pots_bottles_2_6&amp;link=/checklists/pots_bottles.html%23item_2_6&amp;title=Ritual Pot">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=pots_bottles_2_6&amp;id=pots_bottles_2_6&amp;link=/checklists/pots_bottles.html%23item_2_6&amp;title=Ritual Pot"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -607,18 +539,14 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="2" id="pots_bottles_2_7" type="checkbox" value="">
                     <label class="form-check-label item_content" for="pots_bottles_2_7">Auriza Side Tomb, just North-East of Leyndell: In a room with a giant Living Jar</label>
-                    <a class="ms-2" href="/map.html?target=pots_bottles_2_7&amp;id=pots_bottles_2_7&amp;link=/checklists/pots_bottles.html%23item_2_7&amp;title=Ritual Pot x2">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=pots_bottles_2_7&amp;id=pots_bottles_2_7&amp;link=/checklists/pots_bottles.html%23item_2_7&amp;title=Ritual Pot x2"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="pots_bottles_2_8" id="item_2_8">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="2" id="pots_bottles_2_8" type="checkbox" value="">
                     <label class="form-check-label item_content" for="pots_bottles_2_8">Auriza Side Tomb, just North-East of Leyndell: In a room with a giant Living Jar</label>
-                    <a class="ms-2" href="/map.html?x=4606&amp;y=3184&amp;id=pots_bottles_2_8&amp;link=/checklists/pots_bottles.html%23item_2_8&amp;title=Ritual Pot">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4606&amp;y=3184&amp;id=pots_bottles_2_8&amp;link=/checklists/pots_bottles.html%23item_2_8&amp;title=Ritual Pot"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -628,9 +556,7 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="2" id="pots_bottles_2_9" type="checkbox" value="">
                     <label class="form-check-label item_content" for="pots_bottles_2_9">In the Sewers at the end of the maze of tunnels, just before the elevator to the Forsaken Depths Grace.</label>
-                    <a class="ms-2" href="/map.html?target=pots_bottles_2_9&amp;id=pots_bottles_2_9&amp;link=/checklists/pots_bottles.html%23item_2_9&amp;title=Ritual Pot">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=pots_bottles_2_9&amp;id=pots_bottles_2_9&amp;link=/checklists/pots_bottles.html%23item_2_9&amp;title=Ritual Pot"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -640,9 +566,7 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="2" id="pots_bottles_2_10" type="checkbox" value="">
                     <label class="form-check-label item_content" for="pots_bottles_2_10">Giants' Mountaintop Catacombs. Follow the path North from Zamor Ruins and when you reach the fire enemies, turn around to the right to enter. In a room with a giant Living Jar.</label>
-                    <a class="ms-2" href="/map.html?target=pots_bottles_2_10&amp;id=pots_bottles_2_10&amp;link=/checklists/pots_bottles.html%23item_2_10&amp;title=Ritual Pot">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=pots_bottles_2_10&amp;id=pots_bottles_2_10&amp;link=/checklists/pots_bottles.html%23item_2_10&amp;title=Ritual Pot"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -652,9 +576,7 @@
         <div class="card shadow-sm mb-3" id="pots_bottles_section_3">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#pots_bottles_3Col" data-bs-toggle="collapse" href="#pots_bottles_3Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#pots_bottles_3Col" data-bs-toggle="collapse" href="#pots_bottles_3Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <img class="me-1" data-src="/img/icons/keys/edited/00443.png" loading="lazy" style="height: 70px; width: 70px">
               <span class="d-print-inline">Perfume Bottles</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="pots_bottles_totals_3"></span>
@@ -666,9 +588,7 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="pots_bottles_3_1" type="checkbox" value="">
                     <label class="form-check-label item_content" for="pots_bottles_3_1">Street of Sages Ruins in the North-West part of the rot swamp: in the corner of a ruined building guarded by Miranda Sprouts and a Servant of Rot</label>
-                    <a class="ms-2" href="/map.html?target=pots_bottles_3_1&amp;id=pots_bottles_3_1&amp;link=/checklists/pots_bottles.html%23item_3_1&amp;title=Perfume Bottle">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=pots_bottles_3_1&amp;id=pots_bottles_3_1&amp;link=/checklists/pots_bottles.html%23item_3_1&amp;title=Perfume Bottle"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -678,45 +598,35 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="pots_bottles_3_2" type="checkbox" value="">
                     <label class="form-check-label item_content" for="pots_bottles_3_2">Found North of the Altus Highway Junction Site of Grace, on a body in the small camp near the Erdtree sapling</label>
-                    <a class="ms-2" href="/map.html?target=pots_bottles_3_2&amp;id=pots_bottles_3_2&amp;link=/checklists/pots_bottles.html%23item_3_2&amp;title=Perfume Bottle">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=pots_bottles_3_2&amp;id=pots_bottles_3_2&amp;link=/checklists/pots_bottles.html%23item_3_2&amp;title=Perfume Bottle"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="pots_bottles_3_5" id="item_3_5">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="pots_bottles_3_5" type="checkbox" value="">
                     <label class="form-check-label item_content" for="pots_bottles_3_5">Perfumer's Grotto, East of the Altus Highway Junction: in a chest near the second Giant Miranda Sprout</label>
-                    <a class="ms-2" href="/map.html?target=pots_bottles_3_5&amp;id=pots_bottles_3_5&amp;link=/checklists/pots_bottles.html%23item_3_5&amp;title=Perfume Bottle">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=pots_bottles_3_5&amp;id=pots_bottles_3_5&amp;link=/checklists/pots_bottles.html%23item_3_5&amp;title=Perfume Bottle"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="pots_bottles_3_3" id="item_3_3">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="pots_bottles_3_3" type="checkbox" value="">
                     <label class="form-check-label item_content" for="pots_bottles_3_3">Perfumer's Ruins, in the far South-West, North-West from the Abandoned Coffin Grace: on a body near the chest with the Perfumer's Cookbook</label>
-                    <a class="ms-2" href="/map.html?target=pots_bottles_3_3&amp;id=pots_bottles_3_3&amp;link=/checklists/pots_bottles.html%23item_3_3&amp;title=Perfume Bottle">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=pots_bottles_3_3&amp;id=pots_bottles_3_3&amp;link=/checklists/pots_bottles.html%23item_3_3&amp;title=Perfume Bottle"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="pots_bottles_3_4" id="item_3_4">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="pots_bottles_3_4" type="checkbox" value="">
                     <label class="form-check-label item_content" for="pots_bottles_3_4">Perfumer's Ruins, in the far South-West, North-West from the Abandoned Coffin Grace: in the back, near the Giant Miranda Sprout</label>
-                    <a class="ms-2" href="/map.html?target=pots_bottles_3_4&amp;id=pots_bottles_3_4&amp;link=/checklists/pots_bottles.html%23item_3_4&amp;title=Perfume Bottle">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=pots_bottles_3_4&amp;id=pots_bottles_3_4&amp;link=/checklists/pots_bottles.html%23item_3_4&amp;title=Perfume Bottle"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="pots_bottles_3_6" id="item_3_6">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="pots_bottles_3_6" type="checkbox" value="">
                     <label class="form-check-label item_content" for="pots_bottles_3_6">Shaded Castle, in the North-West: on a body atop a wall, accessible via the second swamp ladder</label>
-                    <a class="ms-2" href="/map.html?target=pots_bottles_3_6&amp;id=pots_bottles_3_6&amp;link=/checklists/pots_bottles.html%23item_3_6&amp;title=Perfume Bottle">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=pots_bottles_3_6&amp;id=pots_bottles_3_6&amp;link=/checklists/pots_bottles.html%23item_3_6&amp;title=Perfume Bottle"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -726,9 +636,7 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="pots_bottles_3_7" type="checkbox" value="">
                     <label class="form-check-label item_content" for="pots_bottles_3_7">Volcano Manor: on a body in a room unlocked with the Drawing-Room Key</label>
-                    <a class="ms-2" href="/map.html?target=pots_bottles_3_7&amp;id=pots_bottles_3_7&amp;link=/checklists/pots_bottles.html%23item_3_7&amp;title=Perfume Bottle">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=pots_bottles_3_7&amp;id=pots_bottles_3_7&amp;link=/checklists/pots_bottles.html%23item_3_7&amp;title=Perfume Bottle"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -738,9 +646,7 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="pots_bottles_3_8" type="checkbox" value="">
                     <label class="form-check-label item_content" for="pots_bottles_3_8">Hermit Merchant's Shack, on the cliff North-East from the Outer Wall Battleground Grace on the North side of the outer wall: sold by Hermit Merchant for 2000 runes</label>
-                    <a class="ms-2" href="/map.html?target=pots_bottles_3_8&amp;id=pots_bottles_3_8&amp;link=/checklists/pots_bottles.html%23item_3_8&amp;title=Perfume Bottle">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=pots_bottles_3_8&amp;id=pots_bottles_3_8&amp;link=/checklists/pots_bottles.html%23item_3_8&amp;title=Perfume Bottle"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -750,18 +656,14 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="pots_bottles_3_9" type="checkbox" value="">
                     <label class="form-check-label item_content" for="pots_bottles_3_9">Follow the path from the East Capital Rampart Grace along the rampart, into the tower, down the elevator, into the next tower, and up a ladder guarded by a Perfumer. It's in a chest in the room at the top</label>
-                    <a class="ms-2" href="/map.html?target=pots_bottles_3_9&amp;id=pots_bottles_3_9&amp;link=/checklists/pots_bottles.html%23item_3_9&amp;title=Perfume Bottle">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=pots_bottles_3_9&amp;id=pots_bottles_3_9&amp;link=/checklists/pots_bottles.html%23item_3_9&amp;title=Perfume Bottle"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="pots_bottles_3_10" id="item_3_10">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="pots_bottles_3_10" type="checkbox" value="">
                     <label class="form-check-label item_content" for="pots_bottles_3_10">Through the large double doors in Leyndell leading to the path to the Forbidden Lands, all the way in the back without going up the stairs, on a body guarded by a Lesser Misbegotten</label>
-                    <a class="ms-2" href="/map.html?target=pots_bottles_3_10&amp;id=pots_bottles_3_10&amp;link=/checklists/pots_bottles.html%23item_3_10&amp;title=Perfume Bottle">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=pots_bottles_3_10&amp;id=pots_bottles_3_10&amp;link=/checklists/pots_bottles.html%23item_3_10&amp;title=Perfume Bottle"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>

--- a/docs/checklists/remembrances_mausoleums.html
+++ b/docs/checklists/remembrances_mausoleums.html
@@ -27,14 +27,10 @@
         <a class="navbar-brand me-auto ms-2" href="/index.html">Roundtable Guides</a>
         <form class="d-none d-sm-flex order-2 order-xl-3">
           <input aria-label="search" class="form-control me-2" name="search" placeholder="Search" type="search">
-          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit">
-            <i class="bi bi-search"></i>
-          </button>
+          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit"><i class="bi bi-search"></i></button>
         </form>
         <div class="d-sm-none order-2">
-          <a class="nav-link me-0" href="/search.html">
-            <i class="bi bi-search sb-icon-search"></i>
-          </a>
+          <a class="nav-link me-0" href="/search.html"><i class="bi bi-search sb-icon-search"></i></a>
         </div>
         <div class="collapse navbar-collapse order-3 order-xl-2 ms-xl-2" id="nav-collapse">
           <ul class="nav navbar-nav navbar-nav-scroll mr-auto">
@@ -179,14 +175,10 @@
               </ul>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/map.html">
-                <i class="bi bi-map"></i> Map
-              </a>
+              <a class="nav-link hide-buttons" href="/map.html"><i class="bi bi-map"></i> Map</a>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/options.html">
-                <i class="bi bi-gear-fill"></i> Options
-              </a>
+              <a class="nav-link hide-buttons" href="/options.html"><i class="bi bi-gear-fill"></i> Options</a>
             </li>
           </ul>
         </div>
@@ -207,9 +199,7 @@
       <p>Remembrances are dropped by <i>Elden Ring</i>'s most significant bosses. They have a basic function as consumable rune items, but more importantly, each can be redeemed by Enia for a reward, your choice of one of two pieces of equipment associated with the boss.<br><br>Wandering Mausoleums are crypts on the backs of massive stone turtles that often amble around in a small path. They are covered, either on top or on their feet, in dark magical residue resembling many skulls. To interact with the Mausoleum, you must clear much of the residue off with attacks, until finally it collapses and becomes inert, allowing you to climb inside. Here you can duplicate one of your Remembrances, even if you've used it already, meaning you can redeem both rewards. Only one duplication is allowed per Mausoleum per playthrough. Mausoleums without big bells attached can only duplicate select Remembrances.</p>
       <nav class="text-muted toc d-print-none">
         <strong class="d-block h5">
-          <a class="toc-button" data-bs-toggle="collapse" href="#toc_remembrances_mausoleums" role="button">
-            <i class="bi bi-plus-lg"></i>Table Of Contents
-          </a>
+          <a class="toc-button" data-bs-toggle="collapse" href="#toc_remembrances_mausoleums" role="button"><i class="bi bi-plus-lg"></i>Table Of Contents</a>
         </strong>
         <ul class="toc_page collapse" id="toc_remembrances_mausoleums">
           <li>
@@ -229,9 +219,7 @@
         <div class="card shadow-sm mb-3" id="remembrances_mausoleums_section_0">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#remembrances_mausoleums_0Col" data-bs-toggle="collapse" href="#remembrances_mausoleums_0Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#remembrances_mausoleums_0Col" data-bs-toggle="collapse" href="#remembrances_mausoleums_0Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Remembrances</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="remembrances_mausoleums_totals_0"></span>
             </h4>
@@ -243,9 +231,7 @@
                     <label class="form-check-label item_content" for="remembrances_mausoleums_1_1">
                       <img class="float-md-none float-end me-md-1" data-src="/img/icons/tools/remembrances/00163.png" loading="lazy" style="height: 70px; width: 70px"><a href="https://eldenring.wiki.fextralife.com/Remembrance+of+the+Grafted">Remembrance of the Grafted</a> (20,000 Runes)
                     </label>
-                    <a class="ms-2" href="/map.html?x=3087&amp;y=6447&amp;id=remembrances_mausoleums_1_1&amp;link=/checklists/remembrances_mausoleums.html%23item_1_1&amp;title=Remembrance of the Grafted">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3087&amp;y=6447&amp;id=remembrances_mausoleums_1_1&amp;link=/checklists/remembrances_mausoleums.html%23item_1_1&amp;title=Remembrance of the Grafted"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <ul class="list-group-flush">
@@ -272,9 +258,7 @@
                     <label class="form-check-label item_content" for="remembrances_mausoleums_1_2">
                       <img class="float-md-none float-end me-md-1" data-src="/img/icons/tools/remembrances/00172.png" loading="lazy" style="height: 70px; width: 70px"><a href="https://eldenring.wiki.fextralife.com/Remembrance+of+the+Full+Moon+Queen">Remembrance of the Full Moon Queen</a> (20,000 Runes)
                     </label>
-                    <a class="ms-2" href="/map.html?x=1856&amp;y=4823&amp;id=remembrances_mausoleums_1_2&amp;link=/checklists/remembrances_mausoleums.html%23item_1_2&amp;title=Remembrance of the Full Moon Queen">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1856&amp;y=4823&amp;id=remembrances_mausoleums_1_2&amp;link=/checklists/remembrances_mausoleums.html%23item_1_2&amp;title=Remembrance of the Full Moon Queen"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <ul class="list-group-flush">
@@ -301,9 +285,7 @@
                     <label class="form-check-label item_content" for="remembrances_mausoleums_1_3">
                       <img class="float-md-none float-end me-md-1" data-src="/img/icons/tools/remembrances/00164.png" loading="lazy" style="height: 70px; width: 70px"><a href="https://eldenring.wiki.fextralife.com/Remembrance+of+the+Starscourge">Remembrance of the Starscourge</a> (40,000 Runes)
                     </label>
-                    <a class="ms-2" href="/map.html?x=6364&amp;y=6758&amp;id=remembrances_mausoleums_1_3&amp;link=/checklists/remembrances_mausoleums.html%23item_1_3&amp;title=Remembrance of the Scarscourge">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6364&amp;y=6758&amp;id=remembrances_mausoleums_1_3&amp;link=/checklists/remembrances_mausoleums.html%23item_1_3&amp;title=Remembrance of the Scarscourge"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <ul class="list-group-flush">
@@ -330,9 +312,7 @@
                     <label class="form-check-label item_content" for="remembrances_mausoleums_1_8">
                       <img class="float-md-none float-end me-md-1" data-src="/img/icons/tools/remembrances/00166.png" loading="lazy" style="height: 70px; width: 70px"><a href="https://eldenring.wiki.fextralife.com/Remembrance+of+the+Blasphemous">Remembrance of the Blasphemous</a> (50,000 Runes)
                     </label>
-                    <a class="ms-2" href="/map.html?x=2292&amp;y=2960&amp;id=remembrances_mausoleums_1_8&amp;link=/checklists/remembrances_mausoleums.html%23item_1_8&amp;title=Remembrance of the Blasphemous">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2292&amp;y=2960&amp;id=remembrances_mausoleums_1_8&amp;link=/checklists/remembrances_mausoleums.html%23item_1_8&amp;title=Remembrance of the Blasphemous"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <ul class="list-group-flush">
@@ -359,9 +339,7 @@
                     <label class="form-check-label item_content" for="remembrances_mausoleums_1_10">
                       <img class="float-md-none float-end me-md-1" data-src="/img/icons/tools/remembrances/00165.png" loading="lazy" style="height: 70px; width: 70px"><a href="https://eldenring.wiki.fextralife.com/Remembrance+of+the+Omen+King">Remembrance of the Omen King</a> (30,000 Runes)
                     </label>
-                    <a class="ms-2" href="/map.html?x=4521&amp;y=3727&amp;id=remembrances_mausoleums_1_10&amp;link=/checklists/remembrances_mausoleums.html%23item_1_10&amp;title=Remembrance of the Omen King">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4521&amp;y=3727&amp;id=remembrances_mausoleums_1_10&amp;link=/checklists/remembrances_mausoleums.html%23item_1_10&amp;title=Remembrance of the Omen King"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <ul class="list-group-flush">
@@ -388,9 +366,7 @@
                     <label class="form-check-label item_content" for="remembrances_mausoleums_1_9">
                       <img class="float-md-none float-end me-md-1" data-src="/img/icons/tools/remembrances/00174.png" loading="lazy" style="height: 70px; width: 70px"><a href="https://eldenring.wiki.fextralife.com/Remembrance+of+the+Fire+Giant">Remembrance of the Fire Giant</a> (30,000 Runes)
                     </label>
-                    <a class="ms-2" href="/map.html?x=6355&amp;y=3160&amp;id=remembrances_mausoleums_1_9&amp;link=/checklists/remembrances_mausoleums.html%23item_1_9&amp;title=Remembrance of the Fire Giant">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6355&amp;y=3160&amp;id=remembrances_mausoleums_1_9&amp;link=/checklists/remembrances_mausoleums.html%23item_1_9&amp;title=Remembrance of the Fire Giant"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <ul class="list-group-flush">
@@ -417,9 +393,7 @@
                     <label class="form-check-label item_content" for="remembrances_mausoleums_1_14">
                       <img class="float-md-none float-end me-md-1" data-src="/img/icons/tools/remembrances/00167.png" loading="lazy" style="height: 70px; width: 70px"><a href="https://eldenring.wiki.fextralife.com/Remembrance+of+the+Rot+Goddess">Remembrance of the Rot Goddess</a> (50,000 Runes)
                     </label>
-                    <a class="ms-2" href="/map.html?x=5574&amp;y=885&amp;id=remembrances_mausoleums_1_14&amp;link=/checklists/remembrances_mausoleums.html%23item_1_14&amp;title=Remembrance of the Rot Goddess">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5574&amp;y=885&amp;id=remembrances_mausoleums_1_14&amp;link=/checklists/remembrances_mausoleums.html%23item_1_14&amp;title=Remembrance of the Rot Goddess"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <ul class="list-group-flush">
@@ -550,9 +524,7 @@
                     <label class="form-check-label item_content" for="remembrances_mausoleums_1_4">
                       <img class="float-md-none float-end me-md-1" data-src="/img/icons/tools/remembrances/00175.png" loading="lazy" style="height: 70px; width: 70px"><a href="https://eldenring.wiki.fextralife.com/Remembrance+of+the+Regal+Ancestor">Remembrance of the Regal Ancestor</a> (30,000 Runes)
                     </label>
-                    <a class="ms-2" href="/map.html?x=6224&amp;y=14147&amp;id=remembrances_mausoleums_1_4&amp;link=/checklists/remembrances_mausoleums.html%23item_1_4&amp;title=Remembrance of the Regal Ancestor">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6224&amp;y=14147&amp;id=remembrances_mausoleums_1_4&amp;link=/checklists/remembrances_mausoleums.html%23item_1_4&amp;title=Remembrance of the Regal Ancestor"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <ul class="list-group-flush">
@@ -579,9 +551,7 @@
                     <label class="form-check-label item_content" for="remembrances_mausoleums_1_15">
                       <img class="float-md-none float-end me-md-1" data-src="/img/icons/tools/remembrances/00168.png" loading="lazy" style="height: 70px; width: 70px"><a href="https://eldenring.wiki.fextralife.com/Remembrance+of+the+Blood+Lord">Remembrance of the Blood Lord</a> (30,000 Runes)
                     </label>
-                    <a class="ms-2" href="/map.html?x=6796&amp;y=14396&amp;id=remembrances_mausoleums_1_15&amp;link=/checklists/remembrances_mausoleums.html%23item_1_15&amp;title=Remembrance of the Blood Lord">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6796&amp;y=14396&amp;id=remembrances_mausoleums_1_15&amp;link=/checklists/remembrances_mausoleums.html%23item_1_15&amp;title=Remembrance of the Blood Lord"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <ul class="list-group-flush">
@@ -608,9 +578,7 @@
                     <label class="form-check-label item_content" for="remembrances_mausoleums_1_5">
                       <img class="float-md-none float-end me-md-1" data-src="/img/icons/tools/remembrances/00177.png" loading="lazy" style="height: 70px; width: 70px"><a href="https://eldenring.wiki.fextralife.com/Remembrance+of+the+Naturalborn">Remembrance of the Naturalborn</a> (30,000 Runes)
                     </label>
-                    <a class="ms-2" href="/map.html?x=2765&amp;y=13744&amp;id=remembrances_mausoleums_1_5&amp;link=/checklists/remembrances_mausoleums.html%23item_1_5&amp;title=Remembrance of the Naturalborn">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2765&amp;y=13744&amp;id=remembrances_mausoleums_1_5&amp;link=/checklists/remembrances_mausoleums.html%23item_1_5&amp;title=Remembrance of the Naturalborn"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <ul class="list-group-flush">
@@ -637,9 +605,7 @@
                     <label class="form-check-label item_content" for="remembrances_mausoleums_1_12">
                       <img class="float-md-none float-end me-md-1" data-src="/img/icons/tools/remembrances/00173.png" loading="lazy" style="height: 70px; width: 70px"><a href="https://eldenring.wiki.fextralife.com/Remembrance+of+the+Lichdragon">Remembrance of the Lichdragon</a> (30,000 Runes)
                     </label>
-                    <a class="ms-2" href="/map.html?x=5656&amp;y=10740&amp;id=remembrances_mausoleums_1_12&amp;link=/checklists/remembrances_mausoleums.html%23item_1_12&amp;title=Remembrance of the Lichdragon">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5656&amp;y=10740&amp;id=remembrances_mausoleums_1_12&amp;link=/checklists/remembrances_mausoleums.html%23item_1_12&amp;title=Remembrance of the Lichdragon"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <ul class="list-group-flush">
@@ -961,9 +927,7 @@
         <div class="card shadow-sm mb-3" id="remembrances_mausoleums_section_1">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#remembrances_mausoleums_1Col" data-bs-toggle="collapse" href="#remembrances_mausoleums_1Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#remembrances_mausoleums_1Col" data-bs-toggle="collapse" href="#remembrances_mausoleums_1Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Wandering Mausoleums</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="remembrances_mausoleums_totals_1"></span>
             </h4>
@@ -973,63 +937,49 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="remembrances_mausoleums_2_1" type="checkbox" value="">
                     <label class="form-check-label item_content" for="remembrances_mausoleums_2_1">Weeping Peninsula - In the western area past the Church of Pilgrimage. The skulls are on its feet.</label>
-                    <a class="ms-2" href="/map.html?target=remembrances_mausoleums_2_1&amp;id=remembrances_mausoleums_2_1&amp;link=/checklists/remembrances_mausoleums.html%23item_2_1&amp;title=Wandering Mausoleum">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=remembrances_mausoleums_2_1&amp;id=remembrances_mausoleums_2_1&amp;link=/checklists/remembrances_mausoleums.html%23item_2_1&amp;title=Wandering Mausoleum"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="remembrances_mausoleums_2_2" id="item_2_2">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="remembrances_mausoleums_2_2" type="checkbox" value="">
                     <label class="form-check-label item_content" for="remembrances_mausoleums_2_2">Liurnia of the Lakes - Northeast of Raya Lucaria, in the waters in front of Raya Lucaria Crystal Tunnel Grace. The skulls are on top.</label>
-                    <a class="ms-2" href="/map.html?target=remembrances_mausoleums_2_2&amp;id=remembrances_mausoleums_2_2&amp;link=/checklists/remembrances_mausoleums.html%23item_2_2&amp;title=Wandering Mausoleum">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=remembrances_mausoleums_2_2&amp;id=remembrances_mausoleums_2_2&amp;link=/checklists/remembrances_mausoleums.html%23item_2_2&amp;title=Wandering Mausoleum"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="remembrances_mausoleums_2_3" id="item_2_3">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="remembrances_mausoleums_2_3" type="checkbox" value="">
                     <label class="form-check-label item_content" for="remembrances_mausoleums_2_3">Liurnia of the Lakes - One of two found around the Mausoleum Compound Grace in Uld Palace Ruins, north of the Church of Vows. <b>IMPORTANT - These only duplicate a limited amount of Remembrances.</b> Watch out for its hops. The skulls are on its feet.</label>
-                    <a class="ms-2" href="/map.html?target=remembrances_mausoleums_2_3&amp;id=remembrances_mausoleums_2_3&amp;link=/checklists/remembrances_mausoleums.html%23item_2_3&amp;title=Wandering Mausoleum (no bell)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=remembrances_mausoleums_2_3&amp;id=remembrances_mausoleums_2_3&amp;link=/checklists/remembrances_mausoleums.html%23item_2_3&amp;title=Wandering Mausoleum (no bell)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="remembrances_mausoleums_2_7" id="item_2_7">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="remembrances_mausoleums_2_7" type="checkbox" value="">
                     <label class="form-check-label item_content" for="remembrances_mausoleums_2_7">Liurnia of the Lakes - One of two found around the Mausoleum Compound Grace in Uld Palace Ruins, north of the Church of Vows. <b>IMPORTANT - These only duplicate a limited amount of Remembrances.</b> Watch out for its hops. The skulls are on its feet.</label>
-                    <a class="ms-2" href="/map.html?target=remembrances_mausoleums_2_7&amp;id=remembrances_mausoleums_2_7&amp;link=/checklists/remembrances_mausoleums.html%23item_2_7&amp;title=Wandering Mausoleum (no bell)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=remembrances_mausoleums_2_7&amp;id=remembrances_mausoleums_2_7&amp;link=/checklists/remembrances_mausoleums.html%23item_2_7&amp;title=Wandering Mausoleum (no bell)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="remembrances_mausoleums_2_4" id="item_2_4">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="remembrances_mausoleums_2_4" type="checkbox" value="">
                     <label class="form-check-label item_content" for="remembrances_mausoleums_2_4">Mountaintop of the Giants - Just outside Castle Sol in the northern area. The skulls are on its feet.</label>
-                    <a class="ms-2" href="/map.html?target=remembrances_mausoleums_2_4&amp;id=remembrances_mausoleums_2_4&amp;link=/checklists/remembrances_mausoleums.html%23item_2_4&amp;title=Wandering Mausoleum">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=remembrances_mausoleums_2_4&amp;id=remembrances_mausoleums_2_4&amp;link=/checklists/remembrances_mausoleums.html%23item_2_4&amp;title=Wandering Mausoleum"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="remembrances_mausoleums_2_5" id="item_2_5">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="remembrances_mausoleums_2_5" type="checkbox" value="">
                     <label class="form-check-label item_content" for="remembrances_mausoleums_2_5">Consecrated Snowfield - Northwest of Ordina, next to the Apostate Derelict Grace. Watch out for its murder rain. The skulls are on its feet.</label>
-                    <a class="ms-2" href="/map.html?target=remembrances_mausoleums_2_5&amp;id=remembrances_mausoleums_2_5&amp;link=/checklists/remembrances_mausoleums.html%23item_2_5&amp;title=Wandering Mausoleum">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=remembrances_mausoleums_2_5&amp;id=remembrances_mausoleums_2_5&amp;link=/checklists/remembrances_mausoleums.html%23item_2_5&amp;title=Wandering Mausoleum"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="remembrances_mausoleums_2_6" id="item_2_6">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="remembrances_mausoleums_2_6" type="checkbox" value="">
                     <label class="form-check-label item_content" for="remembrances_mausoleums_2_6">Deeproot Depths - Near the The Nameless Eternal City Grace. The skulls are on top.</label>
-                    <a class="ms-2" href="/map.html?target=remembrances_mausoleums_2_6&amp;id=remembrances_mausoleums_2_6&amp;link=/checklists/remembrances_mausoleums.html%23item_2_6&amp;title=Wandering Mausoleum">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=remembrances_mausoleums_2_6&amp;id=remembrances_mausoleums_2_6&amp;link=/checklists/remembrances_mausoleums.html%23item_2_6&amp;title=Wandering Mausoleum"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>

--- a/docs/checklists/scadutree_fragments_revered_spirit_ashes.html
+++ b/docs/checklists/scadutree_fragments_revered_spirit_ashes.html
@@ -27,14 +27,10 @@
         <a class="navbar-brand me-auto ms-2" href="/index.html">Roundtable Guides</a>
         <form class="d-none d-sm-flex order-2 order-xl-3">
           <input aria-label="search" class="form-control me-2" name="search" placeholder="Search" type="search">
-          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit">
-            <i class="bi bi-search"></i>
-          </button>
+          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit"><i class="bi bi-search"></i></button>
         </form>
         <div class="d-sm-none order-2">
-          <a class="nav-link me-0" href="/search.html">
-            <i class="bi bi-search sb-icon-search"></i>
-          </a>
+          <a class="nav-link me-0" href="/search.html"><i class="bi bi-search sb-icon-search"></i></a>
         </div>
         <div class="collapse navbar-collapse order-3 order-xl-2 ms-xl-2" id="nav-collapse">
           <ul class="nav navbar-nav navbar-nav-scroll mr-auto">
@@ -179,14 +175,10 @@
               </ul>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/map.html">
-                <i class="bi bi-map"></i> Map
-              </a>
+              <a class="nav-link hide-buttons" href="/map.html"><i class="bi bi-map"></i> Map</a>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/options.html">
-                <i class="bi bi-gear-fill"></i> Options
-              </a>
+              <a class="nav-link hide-buttons" href="/options.html"><i class="bi bi-gear-fill"></i> Options</a>
             </li>
           </ul>
         </div>
@@ -206,9 +198,7 @@
       </div>
       <nav class="text-muted toc d-print-none">
         <strong class="d-block h5">
-          <a class="toc-button" data-bs-toggle="collapse" href="#toc_scadutree_fragment_revered_spirit_ash" role="button">
-            <i class="bi bi-plus-lg"></i>Table Of Contents
-          </a>
+          <a class="toc-button" data-bs-toggle="collapse" href="#toc_scadutree_fragment_revered_spirit_ash" role="button"><i class="bi bi-plus-lg"></i>Table Of Contents</a>
         </strong>
         <ul class="toc_page collapse" id="toc_scadutree_fragment_revered_spirit_ash">
           <li>
@@ -228,9 +218,7 @@
         <div class="card shadow-sm mb-3" id="scadutree_fragment_revered_spirit_ash_section_0">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#scadutree_fragment_revered_spirit_ash_0Col" data-bs-toggle="collapse" href="#scadutree_fragment_revered_spirit_ash_0Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#scadutree_fragment_revered_spirit_ash_0Col" data-bs-toggle="collapse" href="#scadutree_fragment_revered_spirit_ash_0Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <img class="me-1" data-src="/img/icons/bolstering/edited/03816.png" loading="lazy" style="height: 70px; width: 70px">
               <span class="d-print-inline">Scadutree Fragments</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="scadutree_fragment_revered_spirit_ash_totals_0"></span>
@@ -527,9 +515,7 @@
         <div class="card shadow-sm mb-3" id="scadutree_fragment_revered_spirit_ash_section_1">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#scadutree_fragment_revered_spirit_ash_1Col" data-bs-toggle="collapse" href="#scadutree_fragment_revered_spirit_ash_1Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#scadutree_fragment_revered_spirit_ash_1Col" data-bs-toggle="collapse" href="#scadutree_fragment_revered_spirit_ash_1Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <img class="me-1" data-src="/img/icons/bolstering/edited/03817.png" loading="lazy" style="height: 70px; width: 70px">
               <span class="d-print-inline">Revered Spirit Ashes</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="scadutree_fragment_revered_spirit_ash_totals_1"></span>

--- a/docs/checklists/scrollsand_prayerbooks.html
+++ b/docs/checklists/scrollsand_prayerbooks.html
@@ -27,14 +27,10 @@
         <a class="navbar-brand me-auto ms-2" href="/index.html">Roundtable Guides</a>
         <form class="d-none d-sm-flex order-2 order-xl-3">
           <input aria-label="search" class="form-control me-2" name="search" placeholder="Search" type="search">
-          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit">
-            <i class="bi bi-search"></i>
-          </button>
+          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit"><i class="bi bi-search"></i></button>
         </form>
         <div class="d-sm-none order-2">
-          <a class="nav-link me-0" href="/search.html">
-            <i class="bi bi-search sb-icon-search"></i>
-          </a>
+          <a class="nav-link me-0" href="/search.html"><i class="bi bi-search sb-icon-search"></i></a>
         </div>
         <div class="collapse navbar-collapse order-3 order-xl-2 ms-xl-2" id="nav-collapse">
           <ul class="nav navbar-nav navbar-nav-scroll mr-auto">
@@ -179,14 +175,10 @@
               </ul>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/map.html">
-                <i class="bi bi-map"></i> Map
-              </a>
+              <a class="nav-link hide-buttons" href="/map.html"><i class="bi bi-map"></i> Map</a>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/options.html">
-                <i class="bi bi-gear-fill"></i> Options
-              </a>
+              <a class="nav-link hide-buttons" href="/options.html"><i class="bi bi-gear-fill"></i> Options</a>
             </li>
           </ul>
         </div>
@@ -206,9 +198,7 @@
       </div>
       <nav class="text-muted toc d-print-none">
         <strong class="d-block h5">
-          <a class="toc-button" data-bs-toggle="collapse" href="#toc_scrolls_prayerbooks" role="button">
-            <i class="bi bi-plus-lg"></i>Table Of Contents
-          </a>
+          <a class="toc-button" data-bs-toggle="collapse" href="#toc_scrolls_prayerbooks" role="button"><i class="bi bi-plus-lg"></i>Table Of Contents</a>
         </strong>
         <ul class="toc_page collapse" id="toc_scrolls_prayerbooks">
           <li>
@@ -228,9 +218,7 @@
         <div class="card shadow-sm mb-3" id="scrolls_prayerbooks_section_0">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#scrolls_prayerbooks_0Col" data-bs-toggle="collapse" href="#scrolls_prayerbooks_0Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#scrolls_prayerbooks_0Col" data-bs-toggle="collapse" href="#scrolls_prayerbooks_0Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Scrolls</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="scrolls_prayerbooks_totals_0"></span>
             </h4>
@@ -242,9 +230,7 @@
                     <label class="form-check-label item_content" for="scrolls_prayerbooks_0_1">
                       <img class="float-md-none float-end me-md-1" data-src="/img/icons/keys/edited/00311.png" loading="lazy" style="height: 70px; width: 70px">Royal House Scroll - East of the Agheel Lake South Site of Grace, on a ruin, next to a mage enemy.
                     </label>
-                    <a class="ms-2" href="/map.html?target=scrolls_prayerbooks_0_1&amp;id=scrolls_prayerbooks_0_1&amp;link=/checklists/scrollsand_prayerbooks.html%23item_0_1&amp;title=Royal House Scroll">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=scrolls_prayerbooks_0_1&amp;id=scrolls_prayerbooks_0_1&amp;link=/checklists/scrollsand_prayerbooks.html%23item_0_1&amp;title=Royal House Scroll"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="scrolls_prayerbooks_0_2" id="item_0_2">
@@ -253,9 +239,7 @@
                     <label class="form-check-label item_content" for="scrolls_prayerbooks_0_2">
                       <img class="float-md-none float-end me-md-1" data-src="/img/icons/keys/edited/00310.png" loading="lazy" style="height: 70px; width: 70px">Academy Scroll - West of the Lake-Facing Cliffs Site of Grace, in a graveyard.
                     </label>
-                    <a class="ms-2" href="/map.html?target=scrolls_prayerbooks_0_2&amp;id=scrolls_prayerbooks_0_2&amp;link=/checklists/scrollsand_prayerbooks.html%23item_0_2&amp;title=Academy Scroll">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=scrolls_prayerbooks_0_2&amp;id=scrolls_prayerbooks_0_2&amp;link=/checklists/scrollsand_prayerbooks.html%23item_0_2&amp;title=Academy Scroll"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="scrolls_prayerbooks_0_3" id="item_0_3">
@@ -264,9 +248,7 @@
                     <label class="form-check-label item_content" for="scrolls_prayerbooks_0_3">
                       <img class="float-md-none float-end me-md-1" data-src="/img/icons/keys/edited/00310.png" loading="lazy" style="height: 70px; width: 70px">Conspectus Scroll - Near the Schoolhouse Classroom Site of Grace in Raya Lucaria; turn left as you leave the grace room headed into the building.
                     </label>
-                    <a class="ms-2" href="/map.html?target=scrolls_prayerbooks_0_3&amp;id=scrolls_prayerbooks_0_3&amp;link=/checklists/scrollsand_prayerbooks.html%23item_0_3&amp;title=Conspectus Scroll">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=scrolls_prayerbooks_0_3&amp;id=scrolls_prayerbooks_0_3&amp;link=/checklists/scrollsand_prayerbooks.html%23item_0_3&amp;title=Conspectus Scroll"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -276,9 +258,7 @@
         <div class="card shadow-sm mb-3" id="scrolls_prayerbooks_section_1">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#scrolls_prayerbooks_1Col" data-bs-toggle="collapse" href="#scrolls_prayerbooks_1Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#scrolls_prayerbooks_1Col" data-bs-toggle="collapse" href="#scrolls_prayerbooks_1Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Prayerbooks</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="scrolls_prayerbooks_totals_1"></span>
             </h4>
@@ -290,9 +270,7 @@
                     <label class="form-check-label item_content" for="scrolls_prayerbooks_1_1">
                       <img class="float-md-none float-end me-md-1" data-src="/img/icons/keys/edited/00319.png" loading="lazy" style="height: 70px; width: 70px">Assassin's Prayerbook - Behind an Imp Statue door that's behind another Imp Statue door in Roundtable Hold. Requires 3 Stonesword Keys total.
                     </label>
-                    <a class="ms-2" href="/map.html?target=scrolls_prayerbooks_1_1&amp;id=scrolls_prayerbooks_1_1&amp;link=/checklists/scrollsand_prayerbooks.html%23item_1_1&amp;title=Assassin's Prayerbook">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=scrolls_prayerbooks_1_1&amp;id=scrolls_prayerbooks_1_1&amp;link=/checklists/scrollsand_prayerbooks.html%23item_1_1&amp;title=Assassin's Prayerbook"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="scrolls_prayerbooks_1_2" id="item_1_2">
@@ -301,9 +279,7 @@
                     <label class="form-check-label item_content" for="scrolls_prayerbooks_1_2">
                       <img class="float-md-none float-end me-md-1" data-src="/img/icons/keys/edited/00317.png" loading="lazy" style="height: 70px; width: 70px">Godskin Prayerbook - Behind an Imp Statue door in Stormveil Castle. From the Liftside Chamber Site of Grace, exit into the courtyard and hug the right wall until you find a set of stairs going down on the wall on the other side.
                     </label>
-                    <a class="ms-2" href="/map.html?target=scrolls_prayerbooks_1_2&amp;id=scrolls_prayerbooks_1_2&amp;link=/checklists/scrollsand_prayerbooks.html%23item_1_2&amp;title=Godskin Prayerbook">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=scrolls_prayerbooks_1_2&amp;id=scrolls_prayerbooks_1_2&amp;link=/checklists/scrollsand_prayerbooks.html%23item_1_2&amp;title=Godskin Prayerbook"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="scrolls_prayerbooks_1_3" id="item_1_3">
@@ -312,9 +288,7 @@
                     <label class="form-check-label item_content" for="scrolls_prayerbooks_1_3">
                       <img class="float-md-none float-end me-md-1" data-src="/img/icons/keys/edited/00315.png" loading="lazy" style="height: 70px; width: 70px">Fire Monks' Prayerbook - In a Fire Monk camp in the southern edge of Liurnia, near the Fire Spur Me gesture.
                     </label>
-                    <a class="ms-2" href="/map.html?target=scrolls_prayerbooks_1_3&amp;id=scrolls_prayerbooks_1_3&amp;link=/checklists/scrollsand_prayerbooks.html%23item_1_3&amp;title=Fire Monks' Prayerbook">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=scrolls_prayerbooks_1_3&amp;id=scrolls_prayerbooks_1_3&amp;link=/checklists/scrollsand_prayerbooks.html%23item_1_3&amp;title=Fire Monks' Prayerbook"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="scrolls_prayerbooks_1_4" id="item_1_4">
@@ -323,9 +297,7 @@
                     <label class="form-check-label item_content" for="scrolls_prayerbooks_1_4">
                       <img class="float-md-none float-end me-md-1" data-src="/img/icons/keys/edited/00324.png" loading="lazy" style="height: 70px; width: 70px">Dragon Cult Prayerbook - Kill the Leyndell Knight patrolling south of the Artist's Shack Site of Grace in Liurnia.
                     </label>
-                    <a class="ms-2" href="/map.html?target=scrolls_prayerbooks_1_4&amp;id=scrolls_prayerbooks_1_4&amp;link=/checklists/scrollsand_prayerbooks.html%23item_1_4&amp;title=Dragon Cult Prayerbook">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=scrolls_prayerbooks_1_4&amp;id=scrolls_prayerbooks_1_4&amp;link=/checklists/scrollsand_prayerbooks.html%23item_1_4&amp;title=Dragon Cult Prayerbook"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="scrolls_prayerbooks_1_5" id="item_1_5">
@@ -334,9 +306,7 @@
                     <label class="form-check-label item_content" for="scrolls_prayerbooks_1_5">
                       <img class="float-md-none float-end me-md-1" data-src="/img/icons/keys/edited/00318.png" loading="lazy" style="height: 70px; width: 70px">Two Fingers' Prayerbook - In Leyndell, near the Fortified Manor, First Floor Site of Grace, in a room to the south, by a fireplace. Same room as the By My Sword gesture.
                     </label>
-                    <a class="ms-2" href="/map.html?target=scrolls_prayerbooks_1_5&amp;id=scrolls_prayerbooks_1_5&amp;link=/checklists/scrollsand_prayerbooks.html%23item_1_5&amp;title=Two Fingers' Prayerbook">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=scrolls_prayerbooks_1_5&amp;id=scrolls_prayerbooks_1_5&amp;link=/checklists/scrollsand_prayerbooks.html%23item_1_5&amp;title=Two Fingers' Prayerbook"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="scrolls_prayerbooks_1_8" id="item_1_8">
@@ -345,9 +315,7 @@
                     <label class="form-check-label item_content" for="scrolls_prayerbooks_1_8">
                       <img class="float-md-none float-end me-md-1" data-src="/img/icons/keys/edited/00322.png" loading="lazy" style="height: 70px; width: 70px">Golden Order Principia - In Leyndell, from the Erdtree Sanctuary Site of Grace, exit east and climb up to the second floor. Go through the door, jump down to the roof on the left, and go through the broken window. Climb a root to the chair hanging from the ceiling.
                     </label>
-                    <a class="ms-2" href="/map.html?target=scrolls_prayerbooks_1_8&amp;id=scrolls_prayerbooks_1_8&amp;link=/checklists/scrollsand_prayerbooks.html%23item_1_8&amp;title=Golden Order Principia">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=scrolls_prayerbooks_1_8&amp;id=scrolls_prayerbooks_1_8&amp;link=/checklists/scrollsand_prayerbooks.html%23item_1_8&amp;title=Golden Order Principia"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="scrolls_prayerbooks_1_6" id="item_1_6">
@@ -356,9 +324,7 @@
                     <label class="form-check-label item_content" for="scrolls_prayerbooks_1_6">
                       <img class="float-md-none float-end me-md-1" data-src="/img/icons/keys/edited/00316.png" loading="lazy" style="height: 70px; width: 70px">Giant's Prayerbook - In Mountaintops of the Giants, at the top of Guardian's Garrison, up a ladder behind Chief Guardian Arghanthy.
                     </label>
-                    <a class="ms-2" href="/map.html?target=scrolls_prayerbooks_1_6&amp;id=scrolls_prayerbooks_1_6&amp;link=/checklists/scrollsand_prayerbooks.html%23item_1_6&amp;title=Giant's Prayerbook">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=scrolls_prayerbooks_1_6&amp;id=scrolls_prayerbooks_1_6&amp;link=/checklists/scrollsand_prayerbooks.html%23item_1_6&amp;title=Giant's Prayerbook"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="scrolls_prayerbooks_1_7" id="item_1_7">
@@ -367,9 +333,7 @@
                     <label class="form-check-label item_content" for="scrolls_prayerbooks_1_7">
                       <img class="float-md-none float-end me-md-1" data-src="/img/icons/keys/edited/00325.png" loading="lazy" style="height: 70px; width: 70px">Ancient Dragon Prayerbook - Northwest of the Crumbling Beast Site of Grace in Crumbling Farum Azula, in the middle of the main hall.
                     </label>
-                    <a class="ms-2" href="/map.html?target=scrolls_prayerbooks_1_7&amp;id=scrolls_prayerbooks_1_7&amp;link=/checklists/scrollsand_prayerbooks.html%23item_1_7&amp;title=Ancient Dragon Prayerbook">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=scrolls_prayerbooks_1_7&amp;id=scrolls_prayerbooks_1_7&amp;link=/checklists/scrollsand_prayerbooks.html%23item_1_7&amp;title=Ancient Dragon Prayerbook"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>

--- a/docs/checklists/sitesof_grace.html
+++ b/docs/checklists/sitesof_grace.html
@@ -27,14 +27,10 @@
         <a class="navbar-brand me-auto ms-2" href="/index.html">Roundtable Guides</a>
         <form class="d-none d-sm-flex order-2 order-xl-3">
           <input aria-label="search" class="form-control me-2" name="search" placeholder="Search" type="search">
-          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit">
-            <i class="bi bi-search"></i>
-          </button>
+          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit"><i class="bi bi-search"></i></button>
         </form>
         <div class="d-sm-none order-2">
-          <a class="nav-link me-0" href="/search.html">
-            <i class="bi bi-search sb-icon-search"></i>
-          </a>
+          <a class="nav-link me-0" href="/search.html"><i class="bi bi-search sb-icon-search"></i></a>
         </div>
         <div class="collapse navbar-collapse order-3 order-xl-2 ms-xl-2" id="nav-collapse">
           <ul class="nav navbar-nav navbar-nav-scroll mr-auto">
@@ -179,14 +175,10 @@
               </ul>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/map.html">
-                <i class="bi bi-map"></i> Map
-              </a>
+              <a class="nav-link hide-buttons" href="/map.html"><i class="bi bi-map"></i> Map</a>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/options.html">
-                <i class="bi bi-gear-fill"></i> Options
-              </a>
+              <a class="nav-link hide-buttons" href="/options.html"><i class="bi bi-gear-fill"></i> Options</a>
             </li>
           </ul>
         </div>
@@ -206,9 +198,7 @@
       </div>
       <nav class="text-muted toc d-print-none">
         <strong class="d-block h5">
-          <a class="toc-button" data-bs-toggle="collapse" href="#toc_graces" role="button">
-            <i class="bi bi-plus-lg"></i>Table Of Contents
-          </a>
+          <a class="toc-button" data-bs-toggle="collapse" href="#toc_graces" role="button"><i class="bi bi-plus-lg"></i>Table Of Contents</a>
         </strong>
         <ul class="toc_page collapse" id="toc_graces">
           <li>
@@ -364,9 +354,7 @@
         <div class="card shadow-sm mb-3" id="graces_section_0">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_0Col" data-bs-toggle="collapse" href="#graces_0Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_0Col" data-bs-toggle="collapse" href="#graces_0Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Roundtable Hold</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="graces_totals_0"></span>
             </h4>
@@ -376,9 +364,7 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="graces_313" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_313">Table of Lost Grace</label>
-                    <a class="ms-2" href="/map.html?target=graces_313&amp;id=graces_313&amp;link=/checklists/sitesof_grace.html%23item_313&amp;title=Table of Lost Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_313&amp;id=graces_313&amp;link=/checklists/sitesof_grace.html%23item_313&amp;title=Table of Lost Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -388,9 +374,7 @@
         <div class="card shadow-sm mb-3" id="graces_section_1">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_1Col" data-bs-toggle="collapse" href="#graces_1Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_1Col" data-bs-toggle="collapse" href="#graces_1Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Limgrave</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="graces_totals_1"></span>
             </h4>
@@ -400,189 +384,147 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="graces_0" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_0">The First Step</label>
-                    <a class="ms-2" href="/map.html?target=graces_0&amp;id=graces_0&amp;link=/checklists/sitesof_grace.html%23item_0&amp;title=The First Step">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_0&amp;id=graces_0&amp;link=/checklists/sitesof_grace.html%23item_0&amp;title=The First Step"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_1" id="item_1">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="graces_1" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_1">Church of Elleh</label>
-                    <a class="ms-2" href="/map.html?target=graces_1&amp;id=graces_1&amp;link=/checklists/sitesof_grace.html%23item_1&amp;title=Church of Elleh">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_1&amp;id=graces_1&amp;link=/checklists/sitesof_grace.html%23item_1&amp;title=Church of Elleh"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_2" id="item_2">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="graces_2" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_2">Gatefront</label>
-                    <a class="ms-2" href="/map.html?target=graces_2&amp;id=graces_2&amp;link=/checklists/sitesof_grace.html%23item_2&amp;title=Gatefront">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_2&amp;id=graces_2&amp;link=/checklists/sitesof_grace.html%23item_2&amp;title=Gatefront"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_3" id="item_3">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="graces_3" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_3">Waypoint Ruins Cellar</label>
-                    <a class="ms-2" href="/map.html?target=graces_3&amp;id=graces_3&amp;link=/checklists/sitesof_grace.html%23item_3&amp;title=Waypoint Ruins Cellar">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_3&amp;id=graces_3&amp;link=/checklists/sitesof_grace.html%23item_3&amp;title=Waypoint Ruins Cellar"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_4" id="item_4">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="graces_4" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_4">Artist's Shack</label>
-                    <a class="ms-2" href="/map.html?target=graces_4&amp;id=graces_4&amp;link=/checklists/sitesof_grace.html%23item_4&amp;title=Artist's Shack">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_4&amp;id=graces_4&amp;link=/checklists/sitesof_grace.html%23item_4&amp;title=Artist's Shack"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_5" id="item_5">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="graces_5" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_5">Third Church of Marika</label>
-                    <a class="ms-2" href="/map.html?target=graces_5&amp;id=graces_5&amp;link=/checklists/sitesof_grace.html%23item_5&amp;title=Third Church of Marika">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_5&amp;id=graces_5&amp;link=/checklists/sitesof_grace.html%23item_5&amp;title=Third Church of Marika"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_6" id="item_6">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="graces_6" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_6">Fort Haight West</label>
-                    <a class="ms-2" href="/map.html?target=graces_6&amp;id=graces_6&amp;link=/checklists/sitesof_grace.html%23item_6&amp;title=Fort Haight West">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_6&amp;id=graces_6&amp;link=/checklists/sitesof_grace.html%23item_6&amp;title=Fort Haight West"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_7" id="item_7">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="graces_7" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_7">Agheel Lake South</label>
-                    <a class="ms-2" href="/map.html?target=graces_7&amp;id=graces_7&amp;link=/checklists/sitesof_grace.html%23item_7&amp;title=Agheel Lake South">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_7&amp;id=graces_7&amp;link=/checklists/sitesof_grace.html%23item_7&amp;title=Agheel Lake South"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_8" id="item_8">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="graces_8" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_8">Agheel Lake North</label>
-                    <a class="ms-2" href="/map.html?target=graces_8&amp;id=graces_8&amp;link=/checklists/sitesof_grace.html%23item_8&amp;title=Agheel Lake North">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_8&amp;id=graces_8&amp;link=/checklists/sitesof_grace.html%23item_8&amp;title=Agheel Lake North"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_9" id="item_9">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="graces_9" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_9">Church of Dragon Communion</label>
-                    <a class="ms-2" href="/map.html?target=graces_9&amp;id=graces_9&amp;link=/checklists/sitesof_grace.html%23item_9&amp;title=Church of Dragon Communion">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_9&amp;id=graces_9&amp;link=/checklists/sitesof_grace.html%23item_9&amp;title=Church of Dragon Communion"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_10" id="item_10">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="graces_10" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_10">Seaside Ruins</label>
-                    <a class="ms-2" href="/map.html?target=graces_10&amp;id=graces_10&amp;link=/checklists/sitesof_grace.html%23item_10&amp;title=Seaside Ruins">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_10&amp;id=graces_10&amp;link=/checklists/sitesof_grace.html%23item_10&amp;title=Seaside Ruins"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_11" id="item_11">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="graces_11" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_11">Mistwood Outskirts</label>
-                    <a class="ms-2" href="/map.html?target=graces_11&amp;id=graces_11&amp;link=/checklists/sitesof_grace.html%23item_11&amp;title=Mistwood Outskirts">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_11&amp;id=graces_11&amp;link=/checklists/sitesof_grace.html%23item_11&amp;title=Mistwood Outskirts"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_12" id="item_12">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="graces_12" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_12">Murkwater Coast</label>
-                    <a class="ms-2" href="/map.html?target=graces_12&amp;id=graces_12&amp;link=/checklists/sitesof_grace.html%23item_12&amp;title=Murkwater Coast">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_12&amp;id=graces_12&amp;link=/checklists/sitesof_grace.html%23item_12&amp;title=Murkwater Coast"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_13" id="item_13">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="graces_13" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_13">Summonwater Village Outskirts</label>
-                    <a class="ms-2" href="/map.html?target=graces_13&amp;id=graces_13&amp;link=/checklists/sitesof_grace.html%23item_13&amp;title=Summonwater Village Outskirts">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_13&amp;id=graces_13&amp;link=/checklists/sitesof_grace.html%23item_13&amp;title=Summonwater Village Outskirts"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_14" id="item_14">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="graces_14" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_14">Stormfoot Catacombs</label>
-                    <a class="ms-2" href="/map.html?target=graces_14&amp;id=graces_14&amp;link=/checklists/sitesof_grace.html%23item_14&amp;title=Stormfoot Catacombs">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_14&amp;id=graces_14&amp;link=/checklists/sitesof_grace.html%23item_14&amp;title=Stormfoot Catacombs"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_15" id="item_15">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="graces_15" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_15">Murkwater Catacombs</label>
-                    <a class="ms-2" href="/map.html?target=graces_15&amp;id=graces_15&amp;link=/checklists/sitesof_grace.html%23item_15&amp;title=Murkwater Catacombs">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_15&amp;id=graces_15&amp;link=/checklists/sitesof_grace.html%23item_15&amp;title=Murkwater Catacombs"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_16" id="item_16">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="graces_16" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_16">Groveside Cave</label>
-                    <a class="ms-2" href="/map.html?target=graces_16&amp;id=graces_16&amp;link=/checklists/sitesof_grace.html%23item_16&amp;title=Groveside Cave">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_16&amp;id=graces_16&amp;link=/checklists/sitesof_grace.html%23item_16&amp;title=Groveside Cave"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_17" id="item_17">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="graces_17" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_17">Coastal Cave</label>
-                    <a class="ms-2" href="/map.html?target=graces_17&amp;id=graces_17&amp;link=/checklists/sitesof_grace.html%23item_17&amp;title=Coastal Cave">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_17&amp;id=graces_17&amp;link=/checklists/sitesof_grace.html%23item_17&amp;title=Coastal Cave"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_18" id="item_18">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="graces_18" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_18">Murkwater Cave</label>
-                    <a class="ms-2" href="/map.html?target=graces_18&amp;id=graces_18&amp;link=/checklists/sitesof_grace.html%23item_18&amp;title=Murkwater Cave">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_18&amp;id=graces_18&amp;link=/checklists/sitesof_grace.html%23item_18&amp;title=Murkwater Cave"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_19" id="item_19">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="graces_19" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_19">Highroad Cave</label>
-                    <a class="ms-2" href="/map.html?target=graces_19&amp;id=graces_19&amp;link=/checklists/sitesof_grace.html%23item_19&amp;title=Highroad Cave">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_19&amp;id=graces_19&amp;link=/checklists/sitesof_grace.html%23item_19&amp;title=Highroad Cave"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_20" id="item_20">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="graces_20" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_20">Limgrave Tunnels</label>
-                    <a class="ms-2" href="/map.html?target=graces_20&amp;id=graces_20&amp;link=/checklists/sitesof_grace.html%23item_20&amp;title=Limgrave Tunnels">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_20&amp;id=graces_20&amp;link=/checklists/sitesof_grace.html%23item_20&amp;title=Limgrave Tunnels"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -592,9 +534,7 @@
         <div class="card shadow-sm mb-3" id="graces_section_2">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_2Col" data-bs-toggle="collapse" href="#graces_2Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_2Col" data-bs-toggle="collapse" href="#graces_2Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Stranded Graveyard</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="graces_totals_2"></span>
             </h4>
@@ -604,18 +544,14 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="2" id="graces_21" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_21">Cave of Knowledge</label>
-                    <a class="ms-2" href="/map.html?target=graces_21&amp;id=graces_21&amp;link=/checklists/sitesof_grace.html%23item_21&amp;title=Cave of Knowledge">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_21&amp;id=graces_21&amp;link=/checklists/sitesof_grace.html%23item_21&amp;title=Cave of Knowledge"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_22" id="item_22">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="2" id="graces_22" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_22">Stranded Graveyard</label>
-                    <a class="ms-2" href="/map.html?target=graces_22&amp;id=graces_22&amp;link=/checklists/sitesof_grace.html%23item_22&amp;title=Stranded Graveyard">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_22&amp;id=graces_22&amp;link=/checklists/sitesof_grace.html%23item_22&amp;title=Stranded Graveyard"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -625,9 +561,7 @@
         <div class="card shadow-sm mb-3" id="graces_section_3">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_3Col" data-bs-toggle="collapse" href="#graces_3Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_3Col" data-bs-toggle="collapse" href="#graces_3Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Stormhill</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="graces_totals_3"></span>
             </h4>
@@ -637,72 +571,56 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="graces_23" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_23">Stormhill Shack</label>
-                    <a class="ms-2" href="/map.html?target=graces_23&amp;id=graces_23&amp;link=/checklists/sitesof_grace.html%23item_23&amp;title=Stormhill Shack">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_23&amp;id=graces_23&amp;link=/checklists/sitesof_grace.html%23item_23&amp;title=Stormhill Shack"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_24" id="item_24">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="graces_24" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_24">Castleward Tunnel</label>
-                    <a class="ms-2" href="/map.html?target=graces_24&amp;id=graces_24&amp;link=/checklists/sitesof_grace.html%23item_24&amp;title=Castleward Tunnel">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_24&amp;id=graces_24&amp;link=/checklists/sitesof_grace.html%23item_24&amp;title=Castleward Tunnel"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_25" id="item_25">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="graces_25" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_25">Margit, the Fell Omen</label>
-                    <a class="ms-2" href="/map.html?target=graces_25&amp;id=graces_25&amp;link=/checklists/sitesof_grace.html%23item_25&amp;title=Margit, the Fell Omen">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_25&amp;id=graces_25&amp;link=/checklists/sitesof_grace.html%23item_25&amp;title=Margit, the Fell Omen"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_26" id="item_26">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="graces_26" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_26">Warmaster's Shack</label>
-                    <a class="ms-2" href="/map.html?target=graces_26&amp;id=graces_26&amp;link=/checklists/sitesof_grace.html%23item_26&amp;title=Warmaster's Shack">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_26&amp;id=graces_26&amp;link=/checklists/sitesof_grace.html%23item_26&amp;title=Warmaster's Shack"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_27" id="item_27">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="graces_27" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_27">Saintsbridge</label>
-                    <a class="ms-2" href="/map.html?target=graces_27&amp;id=graces_27&amp;link=/checklists/sitesof_grace.html%23item_27&amp;title=Saintsbridge">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_27&amp;id=graces_27&amp;link=/checklists/sitesof_grace.html%23item_27&amp;title=Saintsbridge"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_28" id="item_28">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="graces_28" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_28">Deathtouched Catacombs</label>
-                    <a class="ms-2" href="/map.html?target=graces_28&amp;id=graces_28&amp;link=/checklists/sitesof_grace.html%23item_28&amp;title=Deathtouched Catacombs">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_28&amp;id=graces_28&amp;link=/checklists/sitesof_grace.html%23item_28&amp;title=Deathtouched Catacombs"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_29" id="item_29">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="graces_29" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_29">Limgrave Tower Bridge</label>
-                    <a class="ms-2" href="/map.html?target=graces_29&amp;id=graces_29&amp;link=/checklists/sitesof_grace.html%23item_29&amp;title=Limgrave Tower Bridge">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_29&amp;id=graces_29&amp;link=/checklists/sitesof_grace.html%23item_29&amp;title=Limgrave Tower Bridge"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_30" id="item_30">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="graces_30" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_30">Divine Tower of Limgrave</label>
-                    <a class="ms-2" href="/map.html?target=graces_30&amp;id=graces_30&amp;link=/checklists/sitesof_grace.html%23item_30&amp;title=Divine Tower of Limgrave">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_30&amp;id=graces_30&amp;link=/checklists/sitesof_grace.html%23item_30&amp;title=Divine Tower of Limgrave"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -712,9 +630,7 @@
         <div class="card shadow-sm mb-3" id="graces_section_4">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_4Col" data-bs-toggle="collapse" href="#graces_4Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_4Col" data-bs-toggle="collapse" href="#graces_4Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Weeping Peninsula</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="graces_totals_4"></span>
             </h4>
@@ -724,162 +640,126 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="4" id="graces_31" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_31">Church of Pilgrimage</label>
-                    <a class="ms-2" href="/map.html?target=graces_31&amp;id=graces_31&amp;link=/checklists/sitesof_grace.html%23item_31&amp;title=Church of Pilgrimage">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_31&amp;id=graces_31&amp;link=/checklists/sitesof_grace.html%23item_31&amp;title=Church of Pilgrimage"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_32" id="item_32">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="4" id="graces_32" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_32">Castle Morne Rampart</label>
-                    <a class="ms-2" href="/map.html?target=graces_32&amp;id=graces_32&amp;link=/checklists/sitesof_grace.html%23item_32&amp;title=Castle Morne Rampart">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_32&amp;id=graces_32&amp;link=/checklists/sitesof_grace.html%23item_32&amp;title=Castle Morne Rampart"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_33" id="item_33">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="4" id="graces_33" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_33">Tombsward</label>
-                    <a class="ms-2" href="/map.html?target=graces_33&amp;id=graces_33&amp;link=/checklists/sitesof_grace.html%23item_33&amp;title=Tombsward">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_33&amp;id=graces_33&amp;link=/checklists/sitesof_grace.html%23item_33&amp;title=Tombsward"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_34" id="item_34">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="4" id="graces_34" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_34">South of the Lookout Tower</label>
-                    <a class="ms-2" href="/map.html?target=graces_34&amp;id=graces_34&amp;link=/checklists/sitesof_grace.html%23item_34&amp;title=South of the Lookout Tower">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_34&amp;id=graces_34&amp;link=/checklists/sitesof_grace.html%23item_34&amp;title=South of the Lookout Tower"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_35" id="item_35">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="4" id="graces_35" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_35">Ailing Village Outskirts</label>
-                    <a class="ms-2" href="/map.html?target=graces_35&amp;id=graces_35&amp;link=/checklists/sitesof_grace.html%23item_35&amp;title=Ailing Village Outskirts">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_35&amp;id=graces_35&amp;link=/checklists/sitesof_grace.html%23item_35&amp;title=Ailing Village Outskirts"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_36" id="item_36">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="4" id="graces_36" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_36">Beside The Crater-Pocked Glade</label>
-                    <a class="ms-2" href="/map.html?target=graces_36&amp;id=graces_36&amp;link=/checklists/sitesof_grace.html%23item_36&amp;title=Beside The Crater-Pocked Glade">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_36&amp;id=graces_36&amp;link=/checklists/sitesof_grace.html%23item_36&amp;title=Beside The Crater-Pocked Glade"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_37" id="item_37">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="4" id="graces_37" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_37">Isolated Merchant's Shack</label>
-                    <a class="ms-2" href="/map.html?target=graces_37&amp;id=graces_37&amp;link=/checklists/sitesof_grace.html%23item_37&amp;title=Isolated Merchant's Shack">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_37&amp;id=graces_37&amp;link=/checklists/sitesof_grace.html%23item_37&amp;title=Isolated Merchant's Shack"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_38" id="item_38">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="4" id="graces_38" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_38">Fourth Church of Marika</label>
-                    <a class="ms-2" href="/map.html?target=graces_38&amp;id=graces_38&amp;link=/checklists/sitesof_grace.html%23item_38&amp;title=Fourth Church of Marika">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_38&amp;id=graces_38&amp;link=/checklists/sitesof_grace.html%23item_38&amp;title=Fourth Church of Marika"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_39" id="item_39">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="4" id="graces_39" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_39">Bridge of Sacrifice</label>
-                    <a class="ms-2" href="/map.html?target=graces_39&amp;id=graces_39&amp;link=/checklists/sitesof_grace.html%23item_39&amp;title=Bridge of Sacrifice">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_39&amp;id=graces_39&amp;link=/checklists/sitesof_grace.html%23item_39&amp;title=Bridge of Sacrifice"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_40" id="item_40">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="4" id="graces_40" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_40">Castle Morne Lift</label>
-                    <a class="ms-2" href="/map.html?target=graces_40&amp;id=graces_40&amp;link=/checklists/sitesof_grace.html%23item_40&amp;title=Castle Morne Lift">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_40&amp;id=graces_40&amp;link=/checklists/sitesof_grace.html%23item_40&amp;title=Castle Morne Lift"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_41" id="item_41">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="4" id="graces_41" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_41">Behind The Castle</label>
-                    <a class="ms-2" href="/map.html?target=graces_41&amp;id=graces_41&amp;link=/checklists/sitesof_grace.html%23item_41&amp;title=Behind The Castle">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_41&amp;id=graces_41&amp;link=/checklists/sitesof_grace.html%23item_41&amp;title=Behind The Castle"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_42" id="item_42">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="4" id="graces_42" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_42">Beside the Rampart Gaol</label>
-                    <a class="ms-2" href="/map.html?target=graces_42&amp;id=graces_42&amp;link=/checklists/sitesof_grace.html%23item_42&amp;title=Beside the Rampart Gaol">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_42&amp;id=graces_42&amp;link=/checklists/sitesof_grace.html%23item_42&amp;title=Beside the Rampart Gaol"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_43" id="item_43">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="4" id="graces_43" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_43">Morne Moangrave</label>
-                    <a class="ms-2" href="/map.html?target=graces_43&amp;id=graces_43&amp;link=/checklists/sitesof_grace.html%23item_43&amp;title=Morne Moangrave">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_43&amp;id=graces_43&amp;link=/checklists/sitesof_grace.html%23item_43&amp;title=Morne Moangrave"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_44" id="item_44">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="4" id="graces_44" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_44">Impaler's Catacombs</label>
-                    <a class="ms-2" href="/map.html?target=graces_44&amp;id=graces_44&amp;link=/checklists/sitesof_grace.html%23item_44&amp;title=Impaler's Catacombs">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_44&amp;id=graces_44&amp;link=/checklists/sitesof_grace.html%23item_44&amp;title=Impaler's Catacombs"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_45" id="item_45">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="4" id="graces_45" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_45">Tombsward Catacombs</label>
-                    <a class="ms-2" href="/map.html?target=graces_45&amp;id=graces_45&amp;link=/checklists/sitesof_grace.html%23item_45&amp;title=Tombsward Catacombs">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_45&amp;id=graces_45&amp;link=/checklists/sitesof_grace.html%23item_45&amp;title=Tombsward Catacombs"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_46" id="item_46">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="4" id="graces_46" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_46">Earthbore Cave</label>
-                    <a class="ms-2" href="/map.html?target=graces_46&amp;id=graces_46&amp;link=/checklists/sitesof_grace.html%23item_46&amp;title=Earthbore Cave">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_46&amp;id=graces_46&amp;link=/checklists/sitesof_grace.html%23item_46&amp;title=Earthbore Cave"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_47" id="item_47">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="4" id="graces_47" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_47">Tombsward Cave</label>
-                    <a class="ms-2" href="/map.html?target=graces_47&amp;id=graces_47&amp;link=/checklists/sitesof_grace.html%23item_47&amp;title=Tombsward Cave">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_47&amp;id=graces_47&amp;link=/checklists/sitesof_grace.html%23item_47&amp;title=Tombsward Cave"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_48" id="item_48">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="4" id="graces_48" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_48">Morne Tunnel</label>
-                    <a class="ms-2" href="/map.html?target=graces_48&amp;id=graces_48&amp;link=/checklists/sitesof_grace.html%23item_48&amp;title=Morne Tunnel">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_48&amp;id=graces_48&amp;link=/checklists/sitesof_grace.html%23item_48&amp;title=Morne Tunnel"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -889,9 +769,7 @@
         <div class="card shadow-sm mb-3" id="graces_section_5">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_5Col" data-bs-toggle="collapse" href="#graces_5Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_5Col" data-bs-toggle="collapse" href="#graces_5Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Stormveil Castle</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="graces_totals_5"></span>
             </h4>
@@ -901,63 +779,49 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="graces_49" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_49">Stormveil Main Gate</label>
-                    <a class="ms-2" href="/map.html?target=graces_49&amp;id=graces_49&amp;link=/checklists/sitesof_grace.html%23item_49&amp;title=Stormveil Main Gate">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_49&amp;id=graces_49&amp;link=/checklists/sitesof_grace.html%23item_49&amp;title=Stormveil Main Gate"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_50" id="item_50">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="graces_50" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_50">Gateside Chamber</label>
-                    <a class="ms-2" href="/map.html?target=graces_50&amp;id=graces_50&amp;link=/checklists/sitesof_grace.html%23item_50&amp;title=Gateside Chamber">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_50&amp;id=graces_50&amp;link=/checklists/sitesof_grace.html%23item_50&amp;title=Gateside Chamber"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_51" id="item_51">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="graces_51" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_51">Stormveil Cliffside</label>
-                    <a class="ms-2" href="/map.html?target=graces_51&amp;id=graces_51&amp;link=/checklists/sitesof_grace.html%23item_51&amp;title=Stormveil Cliffside">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_51&amp;id=graces_51&amp;link=/checklists/sitesof_grace.html%23item_51&amp;title=Stormveil Cliffside"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_52" id="item_52">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="graces_52" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_52">Rampart Tower</label>
-                    <a class="ms-2" href="/map.html?target=graces_52&amp;id=graces_52&amp;link=/checklists/sitesof_grace.html%23item_52&amp;title=Rampart Tower">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_52&amp;id=graces_52&amp;link=/checklists/sitesof_grace.html%23item_52&amp;title=Rampart Tower"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_53" id="item_53">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="graces_53" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_53">Liftside Chamber</label>
-                    <a class="ms-2" href="/map.html?target=graces_53&amp;id=graces_53&amp;link=/checklists/sitesof_grace.html%23item_53&amp;title=Liftside Chamber">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_53&amp;id=graces_53&amp;link=/checklists/sitesof_grace.html%23item_53&amp;title=Liftside Chamber"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_54" id="item_54">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="graces_54" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_54">Secluded Cell</label>
-                    <a class="ms-2" href="/map.html?target=graces_54&amp;id=graces_54&amp;link=/checklists/sitesof_grace.html%23item_54&amp;title=Secluded Cell">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_54&amp;id=graces_54&amp;link=/checklists/sitesof_grace.html%23item_54&amp;title=Secluded Cell"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_55" id="item_55">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="graces_55" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_55">Godrick the Grafted</label>
-                    <a class="ms-2" href="/map.html?target=graces_55&amp;id=graces_55&amp;link=/checklists/sitesof_grace.html%23item_55&amp;title=Godrick the Grafted">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_55&amp;id=graces_55&amp;link=/checklists/sitesof_grace.html%23item_55&amp;title=Godrick the Grafted"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -967,9 +831,7 @@
         <div class="card shadow-sm mb-3" id="graces_section_6">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_6Col" data-bs-toggle="collapse" href="#graces_6Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_6Col" data-bs-toggle="collapse" href="#graces_6Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Liurnia of the Lakes</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="graces_totals_6"></span>
             </h4>
@@ -979,468 +841,364 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="graces_56" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_56">Lake-Facing Cliffs</label>
-                    <a class="ms-2" href="/map.html?target=graces_56&amp;id=graces_56&amp;link=/checklists/sitesof_grace.html%23item_56&amp;title=Lake-Facing Cliffs">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_56&amp;id=graces_56&amp;link=/checklists/sitesof_grace.html%23item_56&amp;title=Lake-Facing Cliffs"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_57" id="item_57">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="graces_57" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_57">Liurnia Lake Shore</label>
-                    <a class="ms-2" href="/map.html?target=graces_57&amp;id=graces_57&amp;link=/checklists/sitesof_grace.html%23item_57&amp;title=Liurnia Lake Shore">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_57&amp;id=graces_57&amp;link=/checklists/sitesof_grace.html%23item_57&amp;title=Liurnia Lake Shore"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_58" id="item_58">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="graces_58" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_58">Laskyar Ruins</label>
-                    <a class="ms-2" href="/map.html?target=graces_58&amp;id=graces_58&amp;link=/checklists/sitesof_grace.html%23item_58&amp;title=Laskyar Ruins">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_58&amp;id=graces_58&amp;link=/checklists/sitesof_grace.html%23item_58&amp;title=Laskyar Ruins"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_59" id="item_59">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="graces_59" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_59">Scenic Isle</label>
-                    <a class="ms-2" href="/map.html?target=graces_59&amp;id=graces_59&amp;link=/checklists/sitesof_grace.html%23item_59&amp;title=Scenic Isle">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_59&amp;id=graces_59&amp;link=/checklists/sitesof_grace.html%23item_59&amp;title=Scenic Isle"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_60" id="item_60">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="graces_60" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_60">Academy Gate Town</label>
-                    <a class="ms-2" href="/map.html?target=graces_60&amp;id=graces_60&amp;link=/checklists/sitesof_grace.html%23item_60&amp;title=Academy Gate Town">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_60&amp;id=graces_60&amp;link=/checklists/sitesof_grace.html%23item_60&amp;title=Academy Gate Town"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_61" id="item_61">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="graces_61" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_61">South Raya Lucaria Gate</label>
-                    <a class="ms-2" href="/map.html?target=graces_61&amp;id=graces_61&amp;link=/checklists/sitesof_grace.html%23item_61&amp;title=South Raya Lucaria Gate">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_61&amp;id=graces_61&amp;link=/checklists/sitesof_grace.html%23item_61&amp;title=South Raya Lucaria Gate"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_62" id="item_62">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="graces_62" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_62">Main Academy Gate</label>
-                    <a class="ms-2" href="/map.html?target=graces_62&amp;id=graces_62&amp;link=/checklists/sitesof_grace.html%23item_62&amp;title=Main Academy Gate">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_62&amp;id=graces_62&amp;link=/checklists/sitesof_grace.html%23item_62&amp;title=Main Academy Gate"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_63" id="item_63">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="graces_63" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_63">Liurnia Highway South</label>
-                    <a class="ms-2" href="/map.html?target=graces_63&amp;id=graces_63&amp;link=/checklists/sitesof_grace.html%23item_63&amp;title=Liurnia Highway South">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_63&amp;id=graces_63&amp;link=/checklists/sitesof_grace.html%23item_63&amp;title=Liurnia Highway South"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_64" id="item_64">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="graces_64" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_64">Liurnia Highway North</label>
-                    <a class="ms-2" href="/map.html?target=graces_64&amp;id=graces_64&amp;link=/checklists/sitesof_grace.html%23item_64&amp;title=Liurnia Highway North">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_64&amp;id=graces_64&amp;link=/checklists/sitesof_grace.html%23item_64&amp;title=Liurnia Highway North"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_65" id="item_65">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="graces_65" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_65">Gate Town Bridge</label>
-                    <a class="ms-2" href="/map.html?target=graces_65&amp;id=graces_65&amp;link=/checklists/sitesof_grace.html%23item_65&amp;title=Gate Town Bridge">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_65&amp;id=graces_65&amp;link=/checklists/sitesof_grace.html%23item_65&amp;title=Gate Town Bridge"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_66" id="item_66">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="graces_66" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_66">Artist's Shack</label>
-                    <a class="ms-2" href="/map.html?target=graces_66&amp;id=graces_66&amp;link=/checklists/sitesof_grace.html%23item_66&amp;title=Artist's Shack">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_66&amp;id=graces_66&amp;link=/checklists/sitesof_grace.html%23item_66&amp;title=Artist's Shack"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_67" id="item_67">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="graces_67" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_67">Eastern Liurnia Lake Shore</label>
-                    <a class="ms-2" href="/map.html?target=graces_67&amp;id=graces_67&amp;link=/checklists/sitesof_grace.html%23item_67&amp;title=Eastern Liurnia Lake Shore">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_67&amp;id=graces_67&amp;link=/checklists/sitesof_grace.html%23item_67&amp;title=Eastern Liurnia Lake Shore"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_68" id="item_68">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="graces_68" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_68">Jarburg</label>
-                    <a class="ms-2" href="/map.html?target=graces_68&amp;id=graces_68&amp;link=/checklists/sitesof_grace.html%23item_68&amp;title=Jarburg">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_68&amp;id=graces_68&amp;link=/checklists/sitesof_grace.html%23item_68&amp;title=Jarburg"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_69" id="item_69">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="graces_69" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_69">Ranni's Chamber</label>
-                    <a class="ms-2" href="/map.html?target=graces_69&amp;id=graces_69&amp;link=/checklists/sitesof_grace.html%23item_69&amp;title=Ranni's Chamber">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_69&amp;id=graces_69&amp;link=/checklists/sitesof_grace.html%23item_69&amp;title=Ranni's Chamber"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_70" id="item_70">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="graces_70" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_70">Eastern Tableland</label>
-                    <a class="ms-2" href="/map.html?target=graces_70&amp;id=graces_70&amp;link=/checklists/sitesof_grace.html%23item_70&amp;title=Eastern Tableland">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_70&amp;id=graces_70&amp;link=/checklists/sitesof_grace.html%23item_70&amp;title=Eastern Tableland"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_71" id="item_71">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="graces_71" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_71">Church of Vows</label>
-                    <a class="ms-2" href="/map.html?target=graces_71&amp;id=graces_71&amp;link=/checklists/sitesof_grace.html%23item_71&amp;title=Church of Vows">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_71&amp;id=graces_71&amp;link=/checklists/sitesof_grace.html%23item_71&amp;title=Church of Vows"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_72" id="item_72">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="graces_72" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_72">Ruined Labyrinth</label>
-                    <a class="ms-2" href="/map.html?target=graces_72&amp;id=graces_72&amp;link=/checklists/sitesof_grace.html%23item_72&amp;title=Ruined Labyrinth">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_72&amp;id=graces_72&amp;link=/checklists/sitesof_grace.html%23item_72&amp;title=Ruined Labyrinth"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_73" id="item_73">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="graces_73" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_73">Mausoleum Compound</label>
-                    <a class="ms-2" href="/map.html?target=graces_73&amp;id=graces_73&amp;link=/checklists/sitesof_grace.html%23item_73&amp;title=Mausoleum Compound">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_73&amp;id=graces_73&amp;link=/checklists/sitesof_grace.html%23item_73&amp;title=Mausoleum Compound"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_74" id="item_74">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="graces_74" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_74">Slumbering Wolf's Shack</label>
-                    <a class="ms-2" href="/map.html?target=graces_74&amp;id=graces_74&amp;link=/checklists/sitesof_grace.html%23item_74&amp;title=Slumbering Wolf's Shack">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_74&amp;id=graces_74&amp;link=/checklists/sitesof_grace.html%23item_74&amp;title=Slumbering Wolf's Shack"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_75" id="item_75">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="graces_75" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_75">Boilprawn Shack</label>
-                    <a class="ms-2" href="/map.html?target=graces_75&amp;id=graces_75&amp;link=/checklists/sitesof_grace.html%23item_75&amp;title=Boilprawn Shack">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_75&amp;id=graces_75&amp;link=/checklists/sitesof_grace.html%23item_75&amp;title=Boilprawn Shack"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_76" id="item_76">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="graces_76" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_76">Fallen Ruins of the Lake</label>
-                    <a class="ms-2" href="/map.html?target=graces_76&amp;id=graces_76&amp;link=/checklists/sitesof_grace.html%23item_76&amp;title=Fallen Ruins of the Lake">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_76&amp;id=graces_76&amp;link=/checklists/sitesof_grace.html%23item_76&amp;title=Fallen Ruins of the Lake"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_77" id="item_77">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="graces_77" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_77">Folly on the Lake</label>
-                    <a class="ms-2" href="/map.html?target=graces_77&amp;id=graces_77&amp;link=/checklists/sitesof_grace.html%23item_77&amp;title=Folly on the Lake">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_77&amp;id=graces_77&amp;link=/checklists/sitesof_grace.html%23item_77&amp;title=Folly on the Lake"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_78" id="item_78">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="graces_78" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_78">Village of the Albinaurics</label>
-                    <a class="ms-2" href="/map.html?target=graces_78&amp;id=graces_78&amp;link=/checklists/sitesof_grace.html%23item_78&amp;title=Village of the Albinaurics">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_78&amp;id=graces_78&amp;link=/checklists/sitesof_grace.html%23item_78&amp;title=Village of the Albinaurics"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_79" id="item_79">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="graces_79" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_79">Converted Tower</label>
-                    <a class="ms-2" href="/map.html?target=graces_79&amp;id=graces_79&amp;link=/checklists/sitesof_grace.html%23item_79&amp;title=Converted Tower">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_79&amp;id=graces_79&amp;link=/checklists/sitesof_grace.html%23item_79&amp;title=Converted Tower"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_80" id="item_80">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="graces_80" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_80">Revenger's Shack</label>
-                    <a class="ms-2" href="/map.html?target=graces_80&amp;id=graces_80&amp;link=/checklists/sitesof_grace.html%23item_80&amp;title=Revenger's Shack">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_80&amp;id=graces_80&amp;link=/checklists/sitesof_grace.html%23item_80&amp;title=Revenger's Shack"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_81" id="item_81">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="graces_81" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_81">Temple Quarter</label>
-                    <a class="ms-2" href="/map.html?target=graces_81&amp;id=graces_81&amp;link=/checklists/sitesof_grace.html%23item_81&amp;title=Temple Quarter">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_81&amp;id=graces_81&amp;link=/checklists/sitesof_grace.html%23item_81&amp;title=Temple Quarter"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_82" id="item_82">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="graces_82" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_82">Crystalline Woods</label>
-                    <a class="ms-2" href="/map.html?target=graces_82&amp;id=graces_82&amp;link=/checklists/sitesof_grace.html%23item_82&amp;title=Crystalline Woods">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_82&amp;id=graces_82&amp;link=/checklists/sitesof_grace.html%23item_82&amp;title=Crystalline Woods"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_83" id="item_83">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="graces_83" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_83">Foot of the Four Belfries</label>
-                    <a class="ms-2" href="/map.html?target=graces_83&amp;id=graces_83&amp;link=/checklists/sitesof_grace.html%23item_83&amp;title=Foot of the Four Belfries">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_83&amp;id=graces_83&amp;link=/checklists/sitesof_grace.html%23item_83&amp;title=Foot of the Four Belfries"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_84" id="item_84">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="graces_84" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_84">The Four Belfries</label>
-                    <a class="ms-2" href="/map.html?target=graces_84&amp;id=graces_84&amp;link=/checklists/sitesof_grace.html%23item_84&amp;title=The Four Belfries">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_84&amp;id=graces_84&amp;link=/checklists/sitesof_grace.html%23item_84&amp;title=The Four Belfries"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_85" id="item_85">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="graces_85" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_85">Sorcerer's Isle</label>
-                    <a class="ms-2" href="/map.html?target=graces_85&amp;id=graces_85&amp;link=/checklists/sitesof_grace.html%23item_85&amp;title=Sorcerer's Isle">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_85&amp;id=graces_85&amp;link=/checklists/sitesof_grace.html%23item_85&amp;title=Sorcerer's Isle"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_86" id="item_86">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="graces_86" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_86">East Gate Bridge Trestle</label>
-                    <a class="ms-2" href="/map.html?target=graces_86&amp;id=graces_86&amp;link=/checklists/sitesof_grace.html%23item_86&amp;title=East Gate Bridge Trestle">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_86&amp;id=graces_86&amp;link=/checklists/sitesof_grace.html%23item_86&amp;title=East Gate Bridge Trestle"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_87" id="item_87">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="graces_87" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_87">Gate Town North</label>
-                    <a class="ms-2" href="/map.html?target=graces_87&amp;id=graces_87&amp;link=/checklists/sitesof_grace.html%23item_87&amp;title=Gate Town North">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_87&amp;id=graces_87&amp;link=/checklists/sitesof_grace.html%23item_87&amp;title=Gate Town North"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_88" id="item_88">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="graces_88" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_88">Northern Liurnia Lake Shore</label>
-                    <a class="ms-2" href="/map.html?target=graces_88&amp;id=graces_88&amp;link=/checklists/sitesof_grace.html%23item_88&amp;title=Northern Liurnia Lake Shore">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_88&amp;id=graces_88&amp;link=/checklists/sitesof_grace.html%23item_88&amp;title=Northern Liurnia Lake Shore"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_89" id="item_89">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="graces_89" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_89">Road to the Manor</label>
-                    <a class="ms-2" href="/map.html?target=graces_89&amp;id=graces_89&amp;link=/checklists/sitesof_grace.html%23item_89&amp;title=Road to the Manor">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_89&amp;id=graces_89&amp;link=/checklists/sitesof_grace.html%23item_89&amp;title=Road to the Manor"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_90" id="item_90">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="graces_90" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_90">Main Caria Manor Gate</label>
-                    <a class="ms-2" href="/map.html?target=graces_90&amp;id=graces_90&amp;link=/checklists/sitesof_grace.html%23item_90&amp;title=Main Caria Manor Gate">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_90&amp;id=graces_90&amp;link=/checklists/sitesof_grace.html%23item_90&amp;title=Main Caria Manor Gate"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_91" id="item_91">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="graces_91" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_91">Manor Upper Level</label>
-                    <a class="ms-2" href="/map.html?target=graces_91&amp;id=graces_91&amp;link=/checklists/sitesof_grace.html%23item_91&amp;title=Manor Upper Level">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_91&amp;id=graces_91&amp;link=/checklists/sitesof_grace.html%23item_91&amp;title=Manor Upper Level"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_92" id="item_92">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="graces_92" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_92">Manor Lower Level</label>
-                    <a class="ms-2" href="/map.html?target=graces_92&amp;id=graces_92&amp;link=/checklists/sitesof_grace.html%23item_92&amp;title=Manor Lower Level">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_92&amp;id=graces_92&amp;link=/checklists/sitesof_grace.html%23item_92&amp;title=Manor Lower Level"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_93" id="item_93">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="graces_93" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_93">Royal Moongazing Grounds</label>
-                    <a class="ms-2" href="/map.html?target=graces_93&amp;id=graces_93&amp;link=/checklists/sitesof_grace.html%23item_93&amp;title=Royal Moongazing Grounds">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_93&amp;id=graces_93&amp;link=/checklists/sitesof_grace.html%23item_93&amp;title=Royal Moongazing Grounds"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_94" id="item_94">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="graces_94" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_94">Ranni's Rise</label>
-                    <a class="ms-2" href="/map.html?target=graces_94&amp;id=graces_94&amp;link=/checklists/sitesof_grace.html%23item_94&amp;title=Ranni's Rise">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_94&amp;id=graces_94&amp;link=/checklists/sitesof_grace.html%23item_94&amp;title=Ranni's Rise"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_95" id="item_95">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="graces_95" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_95">Behind Caria Manor</label>
-                    <a class="ms-2" href="/map.html?target=graces_95&amp;id=graces_95&amp;link=/checklists/sitesof_grace.html%23item_95&amp;title=Behind Caria Manor">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_95&amp;id=graces_95&amp;link=/checklists/sitesof_grace.html%23item_95&amp;title=Behind Caria Manor"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_96" id="item_96">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="graces_96" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_96">The Ravine</label>
-                    <a class="ms-2" href="/map.html?target=graces_96&amp;id=graces_96&amp;link=/checklists/sitesof_grace.html%23item_96&amp;title=The Ravine">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_96&amp;id=graces_96&amp;link=/checklists/sitesof_grace.html%23item_96&amp;title=The Ravine"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_97" id="item_97">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="graces_97" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_97">Ravine-Veiled Village</label>
-                    <a class="ms-2" href="/map.html?target=graces_97&amp;id=graces_97&amp;link=/checklists/sitesof_grace.html%23item_97&amp;title=Ravine-Veiled Village">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_97&amp;id=graces_97&amp;link=/checklists/sitesof_grace.html%23item_97&amp;title=Ravine-Veiled Village"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_98" id="item_98">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="graces_98" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_98">Cliffbottom Catacombs</label>
-                    <a class="ms-2" href="/map.html?target=graces_98&amp;id=graces_98&amp;link=/checklists/sitesof_grace.html%23item_98&amp;title=Cliffbottom Catacombs">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_98&amp;id=graces_98&amp;link=/checklists/sitesof_grace.html%23item_98&amp;title=Cliffbottom Catacombs"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_99" id="item_99">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="graces_99" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_99">Road's End Catacombs</label>
-                    <a class="ms-2" href="/map.html?target=graces_99&amp;id=graces_99&amp;link=/checklists/sitesof_grace.html%23item_99&amp;title=Road's End Catacombs">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_99&amp;id=graces_99&amp;link=/checklists/sitesof_grace.html%23item_99&amp;title=Road's End Catacombs"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_100" id="item_100">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="graces_100" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_100">Black Knife Catacombs</label>
-                    <a class="ms-2" href="/map.html?target=graces_100&amp;id=graces_100&amp;link=/checklists/sitesof_grace.html%23item_100&amp;title=Black Knife Catacombs">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_100&amp;id=graces_100&amp;link=/checklists/sitesof_grace.html%23item_100&amp;title=Black Knife Catacombs"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_101" id="item_101">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="graces_101" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_101">Stillwater Cave</label>
-                    <a class="ms-2" href="/map.html?target=graces_101&amp;id=graces_101&amp;link=/checklists/sitesof_grace.html%23item_101&amp;title=Stillwater Cave">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_101&amp;id=graces_101&amp;link=/checklists/sitesof_grace.html%23item_101&amp;title=Stillwater Cave"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_102" id="item_102">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="graces_102" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_102">Lakeside Crystal Cave</label>
-                    <a class="ms-2" href="/map.html?target=graces_102&amp;id=graces_102&amp;link=/checklists/sitesof_grace.html%23item_102&amp;title=Lakeside Crystal Cave">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_102&amp;id=graces_102&amp;link=/checklists/sitesof_grace.html%23item_102&amp;title=Lakeside Crystal Cave"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_103" id="item_103">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="graces_103" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_103">Academy Crystal Cave</label>
-                    <a class="ms-2" href="/map.html?target=graces_103&amp;id=graces_103&amp;link=/checklists/sitesof_grace.html%23item_103&amp;title=Academy Crystal Cave">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_103&amp;id=graces_103&amp;link=/checklists/sitesof_grace.html%23item_103&amp;title=Academy Crystal Cave"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_104" id="item_104">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="graces_104" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_104">Raya Lucaria Crystal Tunnel</label>
-                    <a class="ms-2" href="/map.html?target=graces_104&amp;id=graces_104&amp;link=/checklists/sitesof_grace.html%23item_104&amp;title=Raya Lucaria Crystal Tunnel">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_104&amp;id=graces_104&amp;link=/checklists/sitesof_grace.html%23item_104&amp;title=Raya Lucaria Crystal Tunnel"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_105" id="item_105">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="graces_105" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_105">Study Hall Entrance</label>
-                    <a class="ms-2" href="/map.html?target=graces_105&amp;id=graces_105&amp;link=/checklists/sitesof_grace.html%23item_105&amp;title=Study Hall Entrance">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_105&amp;id=graces_105&amp;link=/checklists/sitesof_grace.html%23item_105&amp;title=Study Hall Entrance"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_106" id="item_106">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="graces_106" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_106">Liurnia Tower Bridge</label>
-                    <a class="ms-2" href="/map.html?target=graces_106&amp;id=graces_106&amp;link=/checklists/sitesof_grace.html%23item_106&amp;title=Liurnia Tower Bridge">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_106&amp;id=graces_106&amp;link=/checklists/sitesof_grace.html%23item_106&amp;title=Liurnia Tower Bridge"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_107" id="item_107">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="graces_107" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_107">Divine Tower of Liurnia</label>
-                    <a class="ms-2" href="/map.html?target=graces_107&amp;id=graces_107&amp;link=/checklists/sitesof_grace.html%23item_107&amp;title=Divine Tower of Liurnia">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_107&amp;id=graces_107&amp;link=/checklists/sitesof_grace.html%23item_107&amp;title=Divine Tower of Liurnia"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -1450,9 +1208,7 @@
         <div class="card shadow-sm mb-3" id="graces_section_7">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_7Col" data-bs-toggle="collapse" href="#graces_7Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_7Col" data-bs-toggle="collapse" href="#graces_7Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Bellum Highway</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="graces_totals_7"></span>
             </h4>
@@ -1462,45 +1218,35 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="7" id="graces_108" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_108">East Raya Lucaria Gate</label>
-                    <a class="ms-2" href="/map.html?target=graces_108&amp;id=graces_108&amp;link=/checklists/sitesof_grace.html%23item_108&amp;title=East Raya Lucaria Gate">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_108&amp;id=graces_108&amp;link=/checklists/sitesof_grace.html%23item_108&amp;title=East Raya Lucaria Gate"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_109" id="item_109">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="7" id="graces_109" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_109">Bellum Church</label>
-                    <a class="ms-2" href="/map.html?target=graces_109&amp;id=graces_109&amp;link=/checklists/sitesof_grace.html%23item_109&amp;title=Bellum Church">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_109&amp;id=graces_109&amp;link=/checklists/sitesof_grace.html%23item_109&amp;title=Bellum Church"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_110" id="item_110">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="7" id="graces_110" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_110">Grand Lift of Dectus</label>
-                    <a class="ms-2" href="/map.html?target=graces_110&amp;id=graces_110&amp;link=/checklists/sitesof_grace.html%23item_110&amp;title=Grand Lift of Dectus">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_110&amp;id=graces_110&amp;link=/checklists/sitesof_grace.html%23item_110&amp;title=Grand Lift of Dectus"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_111" id="item_111">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="7" id="graces_111" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_111">Frenzied Flame Village Outskirts</label>
-                    <a class="ms-2" href="/map.html?target=graces_111&amp;id=graces_111&amp;link=/checklists/sitesof_grace.html%23item_111&amp;title=Frenzied Flame Village Outskirts">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_111&amp;id=graces_111&amp;link=/checklists/sitesof_grace.html%23item_111&amp;title=Frenzied Flame Village Outskirts"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_112" id="item_112">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="7" id="graces_112" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_112">Church of Inhibition</label>
-                    <a class="ms-2" href="/map.html?target=graces_112&amp;id=graces_112&amp;link=/checklists/sitesof_grace.html%23item_112&amp;title=Church of Inhibition">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_112&amp;id=graces_112&amp;link=/checklists/sitesof_grace.html%23item_112&amp;title=Church of Inhibition"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -1510,9 +1256,7 @@
         <div class="card shadow-sm mb-3" id="graces_section_8">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_8Col" data-bs-toggle="collapse" href="#graces_8Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_8Col" data-bs-toggle="collapse" href="#graces_8Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Ruin-Strewn Precipice</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="graces_totals_8"></span>
             </h4>
@@ -1522,27 +1266,21 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="8" id="graces_113" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_113">Ruin-Strewn Precipice</label>
-                    <a class="ms-2" href="/map.html?target=graces_113&amp;id=graces_113&amp;link=/checklists/sitesof_grace.html%23item_113&amp;title=Ruin-Strewn Precipice">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_113&amp;id=graces_113&amp;link=/checklists/sitesof_grace.html%23item_113&amp;title=Ruin-Strewn Precipice"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_114" id="item_114">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="8" id="graces_114" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_114">Ruin-Strewn Precipice Overlook</label>
-                    <a class="ms-2" href="/map.html?target=graces_114&amp;id=graces_114&amp;link=/checklists/sitesof_grace.html%23item_114&amp;title=Ruin-Strewn Precipice Overlook">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_114&amp;id=graces_114&amp;link=/checklists/sitesof_grace.html%23item_114&amp;title=Ruin-Strewn Precipice Overlook"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_115" id="item_115">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="8" id="graces_115" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_115">Magma Wyrm Makar</label>
-                    <a class="ms-2" href="/map.html?target=graces_115&amp;id=graces_115&amp;link=/checklists/sitesof_grace.html%23item_115&amp;title=Magma Wyrm Makar">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_115&amp;id=graces_115&amp;link=/checklists/sitesof_grace.html%23item_115&amp;title=Magma Wyrm Makar"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -1552,9 +1290,7 @@
         <div class="card shadow-sm mb-3" id="graces_section_9">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_9Col" data-bs-toggle="collapse" href="#graces_9Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_9Col" data-bs-toggle="collapse" href="#graces_9Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Moonlight Altar</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="graces_totals_9"></span>
             </h4>
@@ -1564,27 +1300,21 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="9" id="graces_116" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_116">Moonlight Altar</label>
-                    <a class="ms-2" href="/map.html?target=graces_116&amp;id=graces_116&amp;link=/checklists/sitesof_grace.html%23item_116&amp;title=Moonlight Altar">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_116&amp;id=graces_116&amp;link=/checklists/sitesof_grace.html%23item_116&amp;title=Moonlight Altar"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_117" id="item_117">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="9" id="graces_117" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_117">Cathedral of Manus Celes</label>
-                    <a class="ms-2" href="/map.html?target=graces_117&amp;id=graces_117&amp;link=/checklists/sitesof_grace.html%23item_117&amp;title=Cathedral of Manus Celes">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_117&amp;id=graces_117&amp;link=/checklists/sitesof_grace.html%23item_117&amp;title=Cathedral of Manus Celes"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_118" id="item_118">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="9" id="graces_118" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_118">Altar South</label>
-                    <a class="ms-2" href="/map.html?target=graces_118&amp;id=graces_118&amp;link=/checklists/sitesof_grace.html%23item_118&amp;title=Altar South">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_118&amp;id=graces_118&amp;link=/checklists/sitesof_grace.html%23item_118&amp;title=Altar South"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -1594,9 +1324,7 @@
         <div class="card shadow-sm mb-3" id="graces_section_10">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_10Col" data-bs-toggle="collapse" href="#graces_10Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_10Col" data-bs-toggle="collapse" href="#graces_10Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Academy of Raya Lucaria</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="graces_totals_10"></span>
             </h4>
@@ -1606,36 +1334,28 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="10" id="graces_119" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_119">Church of the Cuckoo</label>
-                    <a class="ms-2" href="/map.html?target=graces_119&amp;id=graces_119&amp;link=/checklists/sitesof_grace.html%23item_119&amp;title=Church of the Cuckoo">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_119&amp;id=graces_119&amp;link=/checklists/sitesof_grace.html%23item_119&amp;title=Church of the Cuckoo"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_120" id="item_120">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="10" id="graces_120" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_120">Schoolhouse Classroom</label>
-                    <a class="ms-2" href="/map.html?target=graces_120&amp;id=graces_120&amp;link=/checklists/sitesof_grace.html%23item_120&amp;title=Schoolhouse Classroom">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_120&amp;id=graces_120&amp;link=/checklists/sitesof_grace.html%23item_120&amp;title=Schoolhouse Classroom"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_121" id="item_121">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="10" id="graces_121" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_121">Debate Parlor</label>
-                    <a class="ms-2" href="/map.html?target=graces_121&amp;id=graces_121&amp;link=/checklists/sitesof_grace.html%23item_121&amp;title=Debate Parlor">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_121&amp;id=graces_121&amp;link=/checklists/sitesof_grace.html%23item_121&amp;title=Debate Parlor"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_122" id="item_122">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="10" id="graces_122" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_122">Raya Lucaria Grand Library</label>
-                    <a class="ms-2" href="/map.html?target=graces_122&amp;id=graces_122&amp;link=/checklists/sitesof_grace.html%23item_122&amp;title=Raya Lucaria Grand Library">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_122&amp;id=graces_122&amp;link=/checklists/sitesof_grace.html%23item_122&amp;title=Raya Lucaria Grand Library"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -1645,9 +1365,7 @@
         <div class="card shadow-sm mb-3" id="graces_section_11">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_11Col" data-bs-toggle="collapse" href="#graces_11Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_11Col" data-bs-toggle="collapse" href="#graces_11Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Altus Plateau</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="graces_totals_11"></span>
             </h4>
@@ -1657,171 +1375,133 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="11" id="graces_123" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_123">Abandoned Coffin</label>
-                    <a class="ms-2" href="/map.html?target=graces_123&amp;id=graces_123&amp;link=/checklists/sitesof_grace.html%23item_123&amp;title=Abandoned Coffin">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_123&amp;id=graces_123&amp;link=/checklists/sitesof_grace.html%23item_123&amp;title=Abandoned Coffin"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_124" id="item_124">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="11" id="graces_124" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_124">Erdtree-Gazing Hill</label>
-                    <a class="ms-2" href="/map.html?target=graces_124&amp;id=graces_124&amp;link=/checklists/sitesof_grace.html%23item_124&amp;title=Erdtree-Gazing Hill">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_124&amp;id=graces_124&amp;link=/checklists/sitesof_grace.html%23item_124&amp;title=Erdtree-Gazing Hill"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_125" id="item_125">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="11" id="graces_125" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_125">Altus Plateau</label>
-                    <a class="ms-2" href="/map.html?target=graces_125&amp;id=graces_125&amp;link=/checklists/sitesof_grace.html%23item_125&amp;title=Altus Plateau">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_125&amp;id=graces_125&amp;link=/checklists/sitesof_grace.html%23item_125&amp;title=Altus Plateau"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_126" id="item_126">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="11" id="graces_126" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_126">Altus Highway Junction</label>
-                    <a class="ms-2" href="/map.html?target=graces_126&amp;id=graces_126&amp;link=/checklists/sitesof_grace.html%23item_126&amp;title=Altus Highway Junction">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_126&amp;id=graces_126&amp;link=/checklists/sitesof_grace.html%23item_126&amp;title=Altus Highway Junction"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_127" id="item_127">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="11" id="graces_127" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_127">Forest-Spanning Greatbridge</label>
-                    <a class="ms-2" href="/map.html?target=graces_127&amp;id=graces_127&amp;link=/checklists/sitesof_grace.html%23item_127&amp;title=Forest-Spanning Greatbridge">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_127&amp;id=graces_127&amp;link=/checklists/sitesof_grace.html%23item_127&amp;title=Forest-Spanning Greatbridge"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_128" id="item_128">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="11" id="graces_128" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_128">Bower of Bounty</label>
-                    <a class="ms-2" href="/map.html?target=graces_128&amp;id=graces_128&amp;link=/checklists/sitesof_grace.html%23item_128&amp;title=Bower of Bounty">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_128&amp;id=graces_128&amp;link=/checklists/sitesof_grace.html%23item_128&amp;title=Bower of Bounty"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_129" id="item_129">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="11" id="graces_129" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_129">Windmill Village</label>
-                    <a class="ms-2" href="/map.html?target=graces_129&amp;id=graces_129&amp;link=/checklists/sitesof_grace.html%23item_129&amp;title=Windmill Village">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_129&amp;id=graces_129&amp;link=/checklists/sitesof_grace.html%23item_129&amp;title=Windmill Village"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_130" id="item_130">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="11" id="graces_130" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_130">Windmill Heights</label>
-                    <a class="ms-2" href="/map.html?target=graces_130&amp;id=graces_130&amp;link=/checklists/sitesof_grace.html%23item_130&amp;title=Windmill Heights">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_130&amp;id=graces_130&amp;link=/checklists/sitesof_grace.html%23item_130&amp;title=Windmill Heights"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_131" id="item_131">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="11" id="graces_131" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_131">Road of Iniquity Side Path</label>
-                    <a class="ms-2" href="/map.html?target=graces_131&amp;id=graces_131&amp;link=/checklists/sitesof_grace.html%23item_131&amp;title=Road of Iniquity Side Path">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_131&amp;id=graces_131&amp;link=/checklists/sitesof_grace.html%23item_131&amp;title=Road of Iniquity Side Path"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_132" id="item_132">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="11" id="graces_132" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_132">Rampartside Path</label>
-                    <a class="ms-2" href="/map.html?target=graces_132&amp;id=graces_132&amp;link=/checklists/sitesof_grace.html%23item_132&amp;title=Rampartside Path">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_132&amp;id=graces_132&amp;link=/checklists/sitesof_grace.html%23item_132&amp;title=Rampartside Path"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_133" id="item_133">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="11" id="graces_133" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_133">Shaded Castle Ramparts</label>
-                    <a class="ms-2" href="/map.html?target=graces_133&amp;id=graces_133&amp;link=/checklists/sitesof_grace.html%23item_133&amp;title=Shaded Castle Ramparts">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_133&amp;id=graces_133&amp;link=/checklists/sitesof_grace.html%23item_133&amp;title=Shaded Castle Ramparts"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_134" id="item_134">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="11" id="graces_134" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_134">Shaded Castle Inner Gate</label>
-                    <a class="ms-2" href="/map.html?target=graces_134&amp;id=graces_134&amp;link=/checklists/sitesof_grace.html%23item_134&amp;title=Shaded Castle Inner Gate">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_134&amp;id=graces_134&amp;link=/checklists/sitesof_grace.html%23item_134&amp;title=Shaded Castle Inner Gate"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_135" id="item_135">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="11" id="graces_135" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_135">Castellan's Hall</label>
-                    <a class="ms-2" href="/map.html?target=graces_135&amp;id=graces_135&amp;link=/checklists/sitesof_grace.html%23item_135&amp;title=Castellan's Hall">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_135&amp;id=graces_135&amp;link=/checklists/sitesof_grace.html%23item_135&amp;title=Castellan's Hall"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_136" id="item_136">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="11" id="graces_136" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_136">Unsightly Catacombs</label>
-                    <a class="ms-2" href="/map.html?target=graces_136&amp;id=graces_136&amp;link=/checklists/sitesof_grace.html%23item_136&amp;title=Unsightly Catacombs">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_136&amp;id=graces_136&amp;link=/checklists/sitesof_grace.html%23item_136&amp;title=Unsightly Catacombs"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_137" id="item_137">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="11" id="graces_137" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_137">Sainted Hero's Grave</label>
-                    <a class="ms-2" href="/map.html?target=graces_137&amp;id=graces_137&amp;link=/checklists/sitesof_grace.html%23item_137&amp;title=Sainted Hero's Grave">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_137&amp;id=graces_137&amp;link=/checklists/sitesof_grace.html%23item_137&amp;title=Sainted Hero's Grave"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_138" id="item_138">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="11" id="graces_138" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_138">Sage's Cave</label>
-                    <a class="ms-2" href="/map.html?target=graces_138&amp;id=graces_138&amp;link=/checklists/sitesof_grace.html%23item_138&amp;title=Sage's Cave">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_138&amp;id=graces_138&amp;link=/checklists/sitesof_grace.html%23item_138&amp;title=Sage's Cave"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_139" id="item_139">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="11" id="graces_139" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_139">Perfumer's Grotto</label>
-                    <a class="ms-2" href="/map.html?target=graces_139&amp;id=graces_139&amp;link=/checklists/sitesof_grace.html%23item_139&amp;title=Perfumer's Grotto">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_139&amp;id=graces_139&amp;link=/checklists/sitesof_grace.html%23item_139&amp;title=Perfumer's Grotto"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_140" id="item_140">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="11" id="graces_140" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_140">Old Altus Tunnel</label>
-                    <a class="ms-2" href="/map.html?target=graces_140&amp;id=graces_140&amp;link=/checklists/sitesof_grace.html%23item_140&amp;title=Old Altus Tunnel">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_140&amp;id=graces_140&amp;link=/checklists/sitesof_grace.html%23item_140&amp;title=Old Altus Tunnel"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_141" id="item_141">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="11" id="graces_141" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_141">Altus Tunnel</label>
-                    <a class="ms-2" href="/map.html?target=graces_141&amp;id=graces_141&amp;link=/checklists/sitesof_grace.html%23item_141&amp;title=Altus Tunnel">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_141&amp;id=graces_141&amp;link=/checklists/sitesof_grace.html%23item_141&amp;title=Altus Tunnel"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -1831,9 +1511,7 @@
         <div class="card shadow-sm mb-3" id="graces_section_12">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_12Col" data-bs-toggle="collapse" href="#graces_12Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_12Col" data-bs-toggle="collapse" href="#graces_12Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Mt. Gelmir</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="graces_totals_12"></span>
             </h4>
@@ -1843,108 +1521,84 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="12" id="graces_142" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_142">Bridge of Iniquity</label>
-                    <a class="ms-2" href="/map.html?target=graces_142&amp;id=graces_142&amp;link=/checklists/sitesof_grace.html%23item_142&amp;title=Bridge of Iniquity">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_142&amp;id=graces_142&amp;link=/checklists/sitesof_grace.html%23item_142&amp;title=Bridge of Iniquity"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_143" id="item_143">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="12" id="graces_143" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_143">First Mt. Gelmir Campsite</label>
-                    <a class="ms-2" href="/map.html?target=graces_143&amp;id=graces_143&amp;link=/checklists/sitesof_grace.html%23item_143&amp;title=First Mt. Gelmir Campsite">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_143&amp;id=graces_143&amp;link=/checklists/sitesof_grace.html%23item_143&amp;title=First Mt. Gelmir Campsite"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_144" id="item_144">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="12" id="graces_144" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_144">Ninth Mt. Gelmir Campsite</label>
-                    <a class="ms-2" href="/map.html?target=graces_144&amp;id=graces_144&amp;link=/checklists/sitesof_grace.html%23item_144&amp;title=Ninth Mt. Gelmir Campsite">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_144&amp;id=graces_144&amp;link=/checklists/sitesof_grace.html%23item_144&amp;title=Ninth Mt. Gelmir Campsite"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_145" id="item_145">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="12" id="graces_145" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_145">Road of Iniquity</label>
-                    <a class="ms-2" href="/map.html?target=graces_145&amp;id=graces_145&amp;link=/checklists/sitesof_grace.html%23item_145&amp;title=Road of Iniquity">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_145&amp;id=graces_145&amp;link=/checklists/sitesof_grace.html%23item_145&amp;title=Road of Iniquity"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_146" id="item_146">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="12" id="graces_146" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_146">Seethewater River</label>
-                    <a class="ms-2" href="/map.html?target=graces_146&amp;id=graces_146&amp;link=/checklists/sitesof_grace.html%23item_146&amp;title=Seethewater River">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_146&amp;id=graces_146&amp;link=/checklists/sitesof_grace.html%23item_146&amp;title=Seethewater River"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_147" id="item_147">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="12" id="graces_147" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_147">Seethewater Terminus</label>
-                    <a class="ms-2" href="/map.html?target=graces_147&amp;id=graces_147&amp;link=/checklists/sitesof_grace.html%23item_147&amp;title=Seethewater Terminus">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_147&amp;id=graces_147&amp;link=/checklists/sitesof_grace.html%23item_147&amp;title=Seethewater Terminus"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_148" id="item_148">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="12" id="graces_148" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_148">Craftsman's Shack</label>
-                    <a class="ms-2" href="/map.html?target=graces_148&amp;id=graces_148&amp;link=/checklists/sitesof_grace.html%23item_148&amp;title=Craftsman's Shack">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_148&amp;id=graces_148&amp;link=/checklists/sitesof_grace.html%23item_148&amp;title=Craftsman's Shack"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_149" id="item_149">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="12" id="graces_149" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_149">Primeval Sorcerer Azur</label>
-                    <a class="ms-2" href="/map.html?target=graces_149&amp;id=graces_149&amp;link=/checklists/sitesof_grace.html%23item_149&amp;title=Primeval Sorcerer Azur">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_149&amp;id=graces_149&amp;link=/checklists/sitesof_grace.html%23item_149&amp;title=Primeval Sorcerer Azur"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_150" id="item_150">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="12" id="graces_150" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_150">Wyndham Catacombs</label>
-                    <a class="ms-2" href="/map.html?target=graces_150&amp;id=graces_150&amp;link=/checklists/sitesof_grace.html%23item_150&amp;title=Wyndham Catacombs">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_150&amp;id=graces_150&amp;link=/checklists/sitesof_grace.html%23item_150&amp;title=Wyndham Catacombs"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_151" id="item_151">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="12" id="graces_151" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_151">Gelmir Hero's Grave</label>
-                    <a class="ms-2" href="/map.html?target=graces_151&amp;id=graces_151&amp;link=/checklists/sitesof_grace.html%23item_151&amp;title=Gelmir Hero's Grave">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_151&amp;id=graces_151&amp;link=/checklists/sitesof_grace.html%23item_151&amp;title=Gelmir Hero's Grave"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_152" id="item_152">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="12" id="graces_152" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_152">Seethewater Cave</label>
-                    <a class="ms-2" href="/map.html?target=graces_152&amp;id=graces_152&amp;link=/checklists/sitesof_grace.html%23item_152&amp;title=Seethewater Cave">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_152&amp;id=graces_152&amp;link=/checklists/sitesof_grace.html%23item_152&amp;title=Seethewater Cave"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_153" id="item_153">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="12" id="graces_153" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_153">Volcano Cave</label>
-                    <a class="ms-2" href="/map.html?target=graces_153&amp;id=graces_153&amp;link=/checklists/sitesof_grace.html%23item_153&amp;title=Volcano Cave">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_153&amp;id=graces_153&amp;link=/checklists/sitesof_grace.html%23item_153&amp;title=Volcano Cave"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -1954,9 +1608,7 @@
         <div class="card shadow-sm mb-3" id="graces_section_13">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_13Col" data-bs-toggle="collapse" href="#graces_13Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_13Col" data-bs-toggle="collapse" href="#graces_13Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Capital Outskirts</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="graces_totals_13"></span>
             </h4>
@@ -1966,90 +1618,70 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="13" id="graces_154" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_154">Outer Wall Phantom Tree</label>
-                    <a class="ms-2" href="/map.html?target=graces_154&amp;id=graces_154&amp;link=/checklists/sitesof_grace.html%23item_154&amp;title=Outer Wall Phantom Tree">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_154&amp;id=graces_154&amp;link=/checklists/sitesof_grace.html%23item_154&amp;title=Outer Wall Phantom Tree"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_155" id="item_155">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="13" id="graces_155" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_155">Minor Erdtree Church</label>
-                    <a class="ms-2" href="/map.html?target=graces_155&amp;id=graces_155&amp;link=/checklists/sitesof_grace.html%23item_155&amp;title=Minor Erdtree Church">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_155&amp;id=graces_155&amp;link=/checklists/sitesof_grace.html%23item_155&amp;title=Minor Erdtree Church"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_156" id="item_156">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="13" id="graces_156" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_156">Outer Wall Battleground</label>
-                    <a class="ms-2" href="/map.html?target=graces_156&amp;id=graces_156&amp;link=/checklists/sitesof_grace.html%23item_156&amp;title=Outer Wall Battleground">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_156&amp;id=graces_156&amp;link=/checklists/sitesof_grace.html%23item_156&amp;title=Outer Wall Battleground"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_157" id="item_157">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="13" id="graces_157" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_157">Hermit Merchant's Shack</label>
-                    <a class="ms-2" href="/map.html?target=graces_157&amp;id=graces_157&amp;link=/checklists/sitesof_grace.html%23item_157&amp;title=Hermit Merchant's Shack">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_157&amp;id=graces_157&amp;link=/checklists/sitesof_grace.html%23item_157&amp;title=Hermit Merchant's Shack"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_158" id="item_158">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="13" id="graces_158" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_158">Capital Rampart</label>
-                    <a class="ms-2" href="/map.html?target=graces_158&amp;id=graces_158&amp;link=/checklists/sitesof_grace.html%23item_158&amp;title=Capital Rampart">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_158&amp;id=graces_158&amp;link=/checklists/sitesof_grace.html%23item_158&amp;title=Capital Rampart"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_159" id="item_159">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="13" id="graces_159" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_159">Auriza Side Tomb</label>
-                    <a class="ms-2" href="/map.html?target=graces_159&amp;id=graces_159&amp;link=/checklists/sitesof_grace.html%23item_159&amp;title=Auriza Side Tomb">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_159&amp;id=graces_159&amp;link=/checklists/sitesof_grace.html%23item_159&amp;title=Auriza Side Tomb"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_160" id="item_160">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="13" id="graces_160" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_160">Auriza Hero's Grave</label>
-                    <a class="ms-2" href="/map.html?target=graces_160&amp;id=graces_160&amp;link=/checklists/sitesof_grace.html%23item_160&amp;title=Auriza Hero's Grave">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_160&amp;id=graces_160&amp;link=/checklists/sitesof_grace.html%23item_160&amp;title=Auriza Hero's Grave"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_161" id="item_161">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="13" id="graces_161" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_161">Sealed Tunnel</label>
-                    <a class="ms-2" href="/map.html?target=graces_161&amp;id=graces_161&amp;link=/checklists/sitesof_grace.html%23item_161&amp;title=Sealed Tunnel">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_161&amp;id=graces_161&amp;link=/checklists/sitesof_grace.html%23item_161&amp;title=Sealed Tunnel"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_162" id="item_162">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="13" id="graces_162" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_162">Divine Tower of West Altus: Gate</label>
-                    <a class="ms-2" href="/map.html?target=graces_162&amp;id=graces_162&amp;link=/checklists/sitesof_grace.html%23item_162&amp;title=Divine Tower of West Altus: Gate">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_162&amp;id=graces_162&amp;link=/checklists/sitesof_grace.html%23item_162&amp;title=Divine Tower of West Altus: Gate"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_163" id="item_163">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="13" id="graces_163" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_163">Divine Tower of West Altus</label>
-                    <a class="ms-2" href="/map.html?target=graces_163&amp;id=graces_163&amp;link=/checklists/sitesof_grace.html%23item_163&amp;title=Divine Tower of West Altus">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_163&amp;id=graces_163&amp;link=/checklists/sitesof_grace.html%23item_163&amp;title=Divine Tower of West Altus"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -2059,9 +1691,7 @@
         <div class="card shadow-sm mb-3" id="graces_section_14">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_14Col" data-bs-toggle="collapse" href="#graces_14Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_14Col" data-bs-toggle="collapse" href="#graces_14Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Volcano Manor</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="graces_totals_14"></span>
             </h4>
@@ -2071,72 +1701,56 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="14" id="graces_164" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_164">Volcano Manor</label>
-                    <a class="ms-2" href="/map.html?target=graces_164&amp;id=graces_164&amp;link=/checklists/sitesof_grace.html%23item_164&amp;title=Volcano Manor">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_164&amp;id=graces_164&amp;link=/checklists/sitesof_grace.html%23item_164&amp;title=Volcano Manor"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_165" id="item_165">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="14" id="graces_165" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_165">Prison Town Church</label>
-                    <a class="ms-2" href="/map.html?target=graces_165&amp;id=graces_165&amp;link=/checklists/sitesof_grace.html%23item_165&amp;title=Prison Town Church">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_165&amp;id=graces_165&amp;link=/checklists/sitesof_grace.html%23item_165&amp;title=Prison Town Church"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_166" id="item_166">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="14" id="graces_166" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_166">Temple of Eiglay</label>
-                    <a class="ms-2" href="/map.html?target=graces_166&amp;id=graces_166&amp;link=/checklists/sitesof_grace.html%23item_166&amp;title=Temple of Eiglay">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_166&amp;id=graces_166&amp;link=/checklists/sitesof_grace.html%23item_166&amp;title=Temple of Eiglay"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_167" id="item_167">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="14" id="graces_167" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_167">Guest Hall</label>
-                    <a class="ms-2" href="/map.html?target=graces_167&amp;id=graces_167&amp;link=/checklists/sitesof_grace.html%23item_167&amp;title=Guest Hall">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_167&amp;id=graces_167&amp;link=/checklists/sitesof_grace.html%23item_167&amp;title=Guest Hall"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_168" id="item_168">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="14" id="graces_168" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_168">Audience Pathway</label>
-                    <a class="ms-2" href="/map.html?target=graces_168&amp;id=graces_168&amp;link=/checklists/sitesof_grace.html%23item_168&amp;title=Audience Pathway">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_168&amp;id=graces_168&amp;link=/checklists/sitesof_grace.html%23item_168&amp;title=Audience Pathway"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_169" id="item_169">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="14" id="graces_169" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_169">Abductor Virgin</label>
-                    <a class="ms-2" href="/map.html?target=graces_169&amp;id=graces_169&amp;link=/checklists/sitesof_grace.html%23item_169&amp;title=Abductor Virgin">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_169&amp;id=graces_169&amp;link=/checklists/sitesof_grace.html%23item_169&amp;title=Abductor Virgin"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_170" id="item_170">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="14" id="graces_170" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_170">Subterranean Inquisition Chamber</label>
-                    <a class="ms-2" href="/map.html?target=graces_170&amp;id=graces_170&amp;link=/checklists/sitesof_grace.html%23item_170&amp;title=Subterranean Inquisition Chamber">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_170&amp;id=graces_170&amp;link=/checklists/sitesof_grace.html%23item_170&amp;title=Subterranean Inquisition Chamber"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_171" id="item_171">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="14" id="graces_171" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_171">Rykard, Lord of Blasphemy</label>
-                    <a class="ms-2" href="/map.html?target=graces_171&amp;id=graces_171&amp;link=/checklists/sitesof_grace.html%23item_171&amp;title=Rykard, Lord of Blasphemy">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_171&amp;id=graces_171&amp;link=/checklists/sitesof_grace.html%23item_171&amp;title=Rykard, Lord of Blasphemy"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -2146,9 +1760,7 @@
         <div class="card shadow-sm mb-3" id="graces_section_15">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_15Col" data-bs-toggle="collapse" href="#graces_15Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_15Col" data-bs-toggle="collapse" href="#graces_15Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Leyndell, Royal Capital</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="graces_totals_15"></span>
             </h4>
@@ -2158,81 +1770,63 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="15" id="graces_172" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_172">Erdtree Sanctuary</label>
-                    <a class="ms-2" href="/map.html?target=graces_172&amp;id=graces_172&amp;link=/checklists/sitesof_grace.html%23item_172&amp;title=Erdtree Sanctuary">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_172&amp;id=graces_172&amp;link=/checklists/sitesof_grace.html%23item_172&amp;title=Erdtree Sanctuary"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_173" id="item_173">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="15" id="graces_173" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_173">East Capital Rampart</label>
-                    <a class="ms-2" href="/map.html?target=graces_173&amp;id=graces_173&amp;link=/checklists/sitesof_grace.html%23item_173&amp;title=East Capital Rampart">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_173&amp;id=graces_173&amp;link=/checklists/sitesof_grace.html%23item_173&amp;title=East Capital Rampart"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_174" id="item_174">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="15" id="graces_174" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_174">Lower Capital Church</label>
-                    <a class="ms-2" href="/map.html?target=graces_174&amp;id=graces_174&amp;link=/checklists/sitesof_grace.html%23item_174&amp;title=Lower Capital Church">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_174&amp;id=graces_174&amp;link=/checklists/sitesof_grace.html%23item_174&amp;title=Lower Capital Church"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_175" id="item_175">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="15" id="graces_175" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_175">Avenue Balcony</label>
-                    <a class="ms-2" href="/map.html?target=graces_175&amp;id=graces_175&amp;link=/checklists/sitesof_grace.html%23item_175&amp;title=Avenue Balcony">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_175&amp;id=graces_175&amp;link=/checklists/sitesof_grace.html%23item_175&amp;title=Avenue Balcony"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_176" id="item_176">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="15" id="graces_176" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_176">West Capital Rampart</label>
-                    <a class="ms-2" href="/map.html?target=graces_176&amp;id=graces_176&amp;link=/checklists/sitesof_grace.html%23item_176&amp;title=West Capital Rampart">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_176&amp;id=graces_176&amp;link=/checklists/sitesof_grace.html%23item_176&amp;title=West Capital Rampart"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_177" id="item_177">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="15" id="graces_177" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_177">Queen's Bedchamber</label>
-                    <a class="ms-2" href="/map.html?target=graces_177&amp;id=graces_177&amp;link=/checklists/sitesof_grace.html%23item_177&amp;title=Queen's Bedchamber">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_177&amp;id=graces_177&amp;link=/checklists/sitesof_grace.html%23item_177&amp;title=Queen's Bedchamber"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_178" id="item_178">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="15" id="graces_178" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_178">Fortified Manor, First Floor</label>
-                    <a class="ms-2" href="/map.html?target=graces_178&amp;id=graces_178&amp;link=/checklists/sitesof_grace.html%23item_178&amp;title=Fortified Manor, First Floor">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_178&amp;id=graces_178&amp;link=/checklists/sitesof_grace.html%23item_178&amp;title=Fortified Manor, First Floor"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_179" id="item_179">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="15" id="graces_179" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_179">Divine Bridge</label>
-                    <a class="ms-2" href="/map.html?target=graces_179&amp;id=graces_179&amp;link=/checklists/sitesof_grace.html%23item_179&amp;title=Divine Bridge">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_179&amp;id=graces_179&amp;link=/checklists/sitesof_grace.html%23item_179&amp;title=Divine Bridge"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_180" id="item_180">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="15" id="graces_180" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_180">Elden Throne</label>
-                    <a class="ms-2" href="/map.html?target=graces_180&amp;id=graces_180&amp;link=/checklists/sitesof_grace.html%23item_180&amp;title=Elden Throne">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_180&amp;id=graces_180&amp;link=/checklists/sitesof_grace.html%23item_180&amp;title=Elden Throne"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -2242,9 +1836,7 @@
         <div class="card shadow-sm mb-3" id="graces_section_16">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_16Col" data-bs-toggle="collapse" href="#graces_16Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_16Col" data-bs-toggle="collapse" href="#graces_16Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Subterranean Shunning-Grounds</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="graces_totals_16"></span>
             </h4>
@@ -2254,45 +1846,35 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="16" id="graces_181" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_181">Underground Roadside</label>
-                    <a class="ms-2" href="/map.html?target=graces_181&amp;id=graces_181&amp;link=/checklists/sitesof_grace.html%23item_181&amp;title=Underground Roadside">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_181&amp;id=graces_181&amp;link=/checklists/sitesof_grace.html%23item_181&amp;title=Underground Roadside"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_182" id="item_182">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="16" id="graces_182" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_182">Forsaken Depths</label>
-                    <a class="ms-2" href="/map.html?target=graces_182&amp;id=graces_182&amp;link=/checklists/sitesof_grace.html%23item_182&amp;title=Forsaken Depths">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_182&amp;id=graces_182&amp;link=/checklists/sitesof_grace.html%23item_182&amp;title=Forsaken Depths"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_183" id="item_183">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="16" id="graces_183" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_183">Leyndell Catacombs</label>
-                    <a class="ms-2" href="/map.html?target=graces_183&amp;id=graces_183&amp;link=/checklists/sitesof_grace.html%23item_183&amp;title=Leyndell Catacombs">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_183&amp;id=graces_183&amp;link=/checklists/sitesof_grace.html%23item_183&amp;title=Leyndell Catacombs"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_184" id="item_184">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="16" id="graces_184" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_184">Frenzied Flame Proscription</label>
-                    <a class="ms-2" href="/map.html?target=graces_184&amp;id=graces_184&amp;link=/checklists/sitesof_grace.html%23item_184&amp;title=Frenzied Flame Proscription">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_184&amp;id=graces_184&amp;link=/checklists/sitesof_grace.html%23item_184&amp;title=Frenzied Flame Proscription"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_185" id="item_185">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="16" id="graces_185" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_185">Cathedral of the Forsaken</label>
-                    <a class="ms-2" href="/map.html?target=graces_185&amp;id=graces_185&amp;link=/checklists/sitesof_grace.html%23item_185&amp;title=Cathedral of the Forsaken">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_185&amp;id=graces_185&amp;link=/checklists/sitesof_grace.html%23item_185&amp;title=Cathedral of the Forsaken"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -2302,9 +1884,7 @@
         <div class="card shadow-sm mb-3" id="graces_section_17">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_17Col" data-bs-toggle="collapse" href="#graces_17Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_17Col" data-bs-toggle="collapse" href="#graces_17Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Leyndell, Ashen Capital</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="graces_totals_17"></span>
             </h4>
@@ -2314,54 +1894,42 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="17" id="graces_186" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_186">East Capital Rampart</label>
-                    <a class="ms-2" href="/map.html?target=graces_186&amp;id=graces_186&amp;link=/checklists/sitesof_grace.html%23item_186&amp;title=East Capital Rampart">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_186&amp;id=graces_186&amp;link=/checklists/sitesof_grace.html%23item_186&amp;title=East Capital Rampart"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_187" id="item_187">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="17" id="graces_187" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_187">Leyndell, Capital of Ash</label>
-                    <a class="ms-2" href="/map.html?target=graces_187&amp;id=graces_187&amp;link=/checklists/sitesof_grace.html%23item_187&amp;title=Leyndell, Capital of Ash">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_187&amp;id=graces_187&amp;link=/checklists/sitesof_grace.html%23item_187&amp;title=Leyndell, Capital of Ash"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_188" id="item_188">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="17" id="graces_188" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_188">Erdtree Sanctuary</label>
-                    <a class="ms-2" href="/map.html?target=graces_188&amp;id=graces_188&amp;link=/checklists/sitesof_grace.html%23item_188&amp;title=Erdtree Sanctuary">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_188&amp;id=graces_188&amp;link=/checklists/sitesof_grace.html%23item_188&amp;title=Erdtree Sanctuary"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_189" id="item_189">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="17" id="graces_189" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_189">Queen's Bedchamber</label>
-                    <a class="ms-2" href="/map.html?target=graces_189&amp;id=graces_189&amp;link=/checklists/sitesof_grace.html%23item_189&amp;title=Queen's Bedchamber">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_189&amp;id=graces_189&amp;link=/checklists/sitesof_grace.html%23item_189&amp;title=Queen's Bedchamber"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_190" id="item_190">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="17" id="graces_190" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_190">Divine Bridge</label>
-                    <a class="ms-2" href="/map.html?target=graces_190&amp;id=graces_190&amp;link=/checklists/sitesof_grace.html%23item_190&amp;title=Divine Bridge">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_190&amp;id=graces_190&amp;link=/checklists/sitesof_grace.html%23item_190&amp;title=Divine Bridge"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_191" id="item_191">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="17" id="graces_191" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_191">Elden Throne</label>
-                    <a class="ms-2" href="/map.html?target=graces_191&amp;id=graces_191&amp;link=/checklists/sitesof_grace.html%23item_191&amp;title=Elden Throne">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_191&amp;id=graces_191&amp;link=/checklists/sitesof_grace.html%23item_191&amp;title=Elden Throne"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -2371,9 +1939,7 @@
         <div class="card shadow-sm mb-3" id="graces_section_18">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_18Col" data-bs-toggle="collapse" href="#graces_18Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_18Col" data-bs-toggle="collapse" href="#graces_18Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Stone Platform</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="graces_totals_18"></span>
             </h4>
@@ -2383,9 +1949,7 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="18" id="graces_192" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_192">Fractured Marika</label>
-                    <a class="ms-2" href="/map.html?target=graces_192&amp;id=graces_192&amp;link=/checklists/sitesof_grace.html%23item_192&amp;title=Fractured Marika">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_192&amp;id=graces_192&amp;link=/checklists/sitesof_grace.html%23item_192&amp;title=Fractured Marika"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -2395,9 +1959,7 @@
         <div class="card shadow-sm mb-3" id="graces_section_19">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_19Col" data-bs-toggle="collapse" href="#graces_19Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_19Col" data-bs-toggle="collapse" href="#graces_19Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Caelid</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="graces_totals_19"></span>
             </h4>
@@ -2407,225 +1969,175 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="19" id="graces_193" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_193">Smoldering Church</label>
-                    <a class="ms-2" href="/map.html?target=graces_193&amp;id=graces_193&amp;link=/checklists/sitesof_grace.html%23item_193&amp;title=Smoldering Church">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_193&amp;id=graces_193&amp;link=/checklists/sitesof_grace.html%23item_193&amp;title=Smoldering Church"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_194" id="item_194">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="19" id="graces_194" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_194">Rotview Balcony</label>
-                    <a class="ms-2" href="/map.html?target=graces_194&amp;id=graces_194&amp;link=/checklists/sitesof_grace.html%23item_194&amp;title=Rotview Balcony">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_194&amp;id=graces_194&amp;link=/checklists/sitesof_grace.html%23item_194&amp;title=Rotview Balcony"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_195" id="item_195">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="19" id="graces_195" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_195">Caelem Ruins</label>
-                    <a class="ms-2" href="/map.html?target=graces_195&amp;id=graces_195&amp;link=/checklists/sitesof_grace.html%23item_195&amp;title=Caelem Ruins">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_195&amp;id=graces_195&amp;link=/checklists/sitesof_grace.html%23item_195&amp;title=Caelem Ruins"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_196" id="item_196">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="19" id="graces_196" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_196">Fort Gael North</label>
-                    <a class="ms-2" href="/map.html?target=graces_196&amp;id=graces_196&amp;link=/checklists/sitesof_grace.html%23item_196&amp;title=Fort Gael North">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_196&amp;id=graces_196&amp;link=/checklists/sitesof_grace.html%23item_196&amp;title=Fort Gael North"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_197" id="item_197">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="19" id="graces_197" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_197">Smoldering Wall</label>
-                    <a class="ms-2" href="/map.html?target=graces_197&amp;id=graces_197&amp;link=/checklists/sitesof_grace.html%23item_197&amp;title=Smoldering Wall">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_197&amp;id=graces_197&amp;link=/checklists/sitesof_grace.html%23item_197&amp;title=Smoldering Wall"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_198" id="item_198">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="19" id="graces_198" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_198">Caelid Highway South</label>
-                    <a class="ms-2" href="/map.html?target=graces_198&amp;id=graces_198&amp;link=/checklists/sitesof_grace.html%23item_198&amp;title=Caelid Highway South">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_198&amp;id=graces_198&amp;link=/checklists/sitesof_grace.html%23item_198&amp;title=Caelid Highway South"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_199" id="item_199">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="19" id="graces_199" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_199">Cathedral of Dragon Communion</label>
-                    <a class="ms-2" href="/map.html?target=graces_199&amp;id=graces_199&amp;link=/checklists/sitesof_grace.html%23item_199&amp;title=Cathedral of Dragon Communion">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_199&amp;id=graces_199&amp;link=/checklists/sitesof_grace.html%23item_199&amp;title=Cathedral of Dragon Communion"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_200" id="item_200">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="19" id="graces_200" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_200">Southern Aeonia Swamp Bank</label>
-                    <a class="ms-2" href="/map.html?target=graces_200&amp;id=graces_200&amp;link=/checklists/sitesof_grace.html%23item_200&amp;title=Southern Aeonia Swamp Bank">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_200&amp;id=graces_200&amp;link=/checklists/sitesof_grace.html%23item_200&amp;title=Southern Aeonia Swamp Bank"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_201" id="item_201">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="19" id="graces_201" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_201">Sellia Backstreets</label>
-                    <a class="ms-2" href="/map.html?target=graces_201&amp;id=graces_201&amp;link=/checklists/sitesof_grace.html%23item_201&amp;title=Sellia Backstreets">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_201&amp;id=graces_201&amp;link=/checklists/sitesof_grace.html%23item_201&amp;title=Sellia Backstreets"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_202" id="item_202">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="19" id="graces_202" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_202">Sellia Under-Stair</label>
-                    <a class="ms-2" href="/map.html?target=graces_202&amp;id=graces_202&amp;link=/checklists/sitesof_grace.html%23item_202&amp;title=Sellia Under-Stair">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_202&amp;id=graces_202&amp;link=/checklists/sitesof_grace.html%23item_202&amp;title=Sellia Under-Stair"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_203" id="item_203">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="19" id="graces_203" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_203">Chair-Crypt of Sellia</label>
-                    <a class="ms-2" href="/map.html?target=graces_203&amp;id=graces_203&amp;link=/checklists/sitesof_grace.html%23item_203&amp;title=Chair-Crypt of Sellia">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_203&amp;id=graces_203&amp;link=/checklists/sitesof_grace.html%23item_203&amp;title=Chair-Crypt of Sellia"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_204" id="item_204">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="19" id="graces_204" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_204">Church of the Plague</label>
-                    <a class="ms-2" href="/map.html?target=graces_204&amp;id=graces_204&amp;link=/checklists/sitesof_grace.html%23item_204&amp;title=Church of the Plague">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_204&amp;id=graces_204&amp;link=/checklists/sitesof_grace.html%23item_204&amp;title=Church of the Plague"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_205" id="item_205">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="19" id="graces_205" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_205">Deep Siofra Well</label>
-                    <a class="ms-2" href="/map.html?target=graces_205&amp;id=graces_205&amp;link=/checklists/sitesof_grace.html%23item_205&amp;title=Deep Siofra Well">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_205&amp;id=graces_205&amp;link=/checklists/sitesof_grace.html%23item_205&amp;title=Deep Siofra Well"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_206" id="item_206">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="19" id="graces_206" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_206">Impassable Greatbridge</label>
-                    <a class="ms-2" href="/map.html?target=graces_206&amp;id=graces_206&amp;link=/checklists/sitesof_grace.html%23item_206&amp;title=Impassable Greatbridge">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_206&amp;id=graces_206&amp;link=/checklists/sitesof_grace.html%23item_206&amp;title=Impassable Greatbridge"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_207" id="item_207">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="19" id="graces_207" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_207">Chamber Outside the Plaza</label>
-                    <a class="ms-2" href="/map.html?target=graces_207&amp;id=graces_207&amp;link=/checklists/sitesof_grace.html%23item_207&amp;title=Chamber Outside the Plaza">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_207&amp;id=graces_207&amp;link=/checklists/sitesof_grace.html%23item_207&amp;title=Chamber Outside the Plaza"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_208" id="item_208">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="19" id="graces_208" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_208">Redmane Castle Plaza</label>
-                    <a class="ms-2" href="/map.html?target=graces_208&amp;id=graces_208&amp;link=/checklists/sitesof_grace.html%23item_208&amp;title=Redmane Castle Plaza">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_208&amp;id=graces_208&amp;link=/checklists/sitesof_grace.html%23item_208&amp;title=Redmane Castle Plaza"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_209" id="item_209">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="19" id="graces_209" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_209">Starscourge Radahn</label>
-                    <a class="ms-2" href="/map.html?target=graces_209&amp;id=graces_209&amp;link=/checklists/sitesof_grace.html%23item_209&amp;title=Starscourge Radahn">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_209&amp;id=graces_209&amp;link=/checklists/sitesof_grace.html%23item_209&amp;title=Starscourge Radahn"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_210" id="item_210">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="19" id="graces_210" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_210">Minor Erdtree Catacombs</label>
-                    <a class="ms-2" href="/map.html?target=graces_210&amp;id=graces_210&amp;link=/checklists/sitesof_grace.html%23item_210&amp;title=Minor Erdtree Catacombs">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_210&amp;id=graces_210&amp;link=/checklists/sitesof_grace.html%23item_210&amp;title=Minor Erdtree Catacombs"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_211" id="item_211">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="19" id="graces_211" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_211">Caelid Catacombs</label>
-                    <a class="ms-2" href="/map.html?target=graces_211&amp;id=graces_211&amp;link=/checklists/sitesof_grace.html%23item_211&amp;title=Caelid Catacombs">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_211&amp;id=graces_211&amp;link=/checklists/sitesof_grace.html%23item_211&amp;title=Caelid Catacombs"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_212" id="item_212">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="19" id="graces_212" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_212">War-Dead Catacombs</label>
-                    <a class="ms-2" href="/map.html?target=graces_212&amp;id=graces_212&amp;link=/checklists/sitesof_grace.html%23item_212&amp;title=War-Dead Catacombs">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_212&amp;id=graces_212&amp;link=/checklists/sitesof_grace.html%23item_212&amp;title=War-Dead Catacombs"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_213" id="item_213">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="19" id="graces_213" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_213">Abandoned Cave</label>
-                    <a class="ms-2" href="/map.html?target=graces_213&amp;id=graces_213&amp;link=/checklists/sitesof_grace.html%23item_213&amp;title=Abandoned Cave">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_213&amp;id=graces_213&amp;link=/checklists/sitesof_grace.html%23item_213&amp;title=Abandoned Cave"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_214" id="item_214">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="19" id="graces_214" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_214">Gaol Cave</label>
-                    <a class="ms-2" href="/map.html?target=graces_214&amp;id=graces_214&amp;link=/checklists/sitesof_grace.html%23item_214&amp;title=Gaol Cave">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_214&amp;id=graces_214&amp;link=/checklists/sitesof_grace.html%23item_214&amp;title=Gaol Cave"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_215" id="item_215">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="19" id="graces_215" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_215">Gael Tunnel</label>
-                    <a class="ms-2" href="/map.html?target=graces_215&amp;id=graces_215&amp;link=/checklists/sitesof_grace.html%23item_215&amp;title=Gael Tunnel">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_215&amp;id=graces_215&amp;link=/checklists/sitesof_grace.html%23item_215&amp;title=Gael Tunnel"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_216" id="item_216">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="19" id="graces_216" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_216">Rear Gael Tunnel Entrance</label>
-                    <a class="ms-2" href="/map.html?target=graces_216&amp;id=graces_216&amp;link=/checklists/sitesof_grace.html%23item_216&amp;title=Rear Gael Tunnel Entrance">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_216&amp;id=graces_216&amp;link=/checklists/sitesof_grace.html%23item_216&amp;title=Rear Gael Tunnel Entrance"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_217" id="item_217">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="19" id="graces_217" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_217">Sellia Crystal Tunnel</label>
-                    <a class="ms-2" href="/map.html?target=graces_217&amp;id=graces_217&amp;link=/checklists/sitesof_grace.html%23item_217&amp;title=Sellia Crystal Tunnel">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_217&amp;id=graces_217&amp;link=/checklists/sitesof_grace.html%23item_217&amp;title=Sellia Crystal Tunnel"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -2635,9 +2147,7 @@
         <div class="card shadow-sm mb-3" id="graces_section_20">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_20Col" data-bs-toggle="collapse" href="#graces_20Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_20Col" data-bs-toggle="collapse" href="#graces_20Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Swamp of Aeonia</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="graces_totals_20"></span>
             </h4>
@@ -2647,36 +2157,28 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="20" id="graces_218" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_218">Aeonia Swamp Shore</label>
-                    <a class="ms-2" href="/map.html?target=graces_218&amp;id=graces_218&amp;link=/checklists/sitesof_grace.html%23item_218&amp;title=Aeonia Swamp Shore">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_218&amp;id=graces_218&amp;link=/checklists/sitesof_grace.html%23item_218&amp;title=Aeonia Swamp Shore"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_219" id="item_219">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="20" id="graces_219" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_219">Astray from Caelid Highway North</label>
-                    <a class="ms-2" href="/map.html?target=graces_219&amp;id=graces_219&amp;link=/checklists/sitesof_grace.html%23item_219&amp;title=Astray from Caelid Highway North">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_219&amp;id=graces_219&amp;link=/checklists/sitesof_grace.html%23item_219&amp;title=Astray from Caelid Highway North"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_220" id="item_220">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="20" id="graces_220" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_220">Heart of Aeonia</label>
-                    <a class="ms-2" href="/map.html?target=graces_220&amp;id=graces_220&amp;link=/checklists/sitesof_grace.html%23item_220&amp;title=Heart of Aeonia">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_220&amp;id=graces_220&amp;link=/checklists/sitesof_grace.html%23item_220&amp;title=Heart of Aeonia"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_221" id="item_221">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="20" id="graces_221" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_221">Inner Aeonia</label>
-                    <a class="ms-2" href="/map.html?target=graces_221&amp;id=graces_221&amp;link=/checklists/sitesof_grace.html%23item_221&amp;title=Inner Aeonia">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_221&amp;id=graces_221&amp;link=/checklists/sitesof_grace.html%23item_221&amp;title=Inner Aeonia"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -2686,9 +2188,7 @@
         <div class="card shadow-sm mb-3" id="graces_section_21">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_21Col" data-bs-toggle="collapse" href="#graces_21Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_21Col" data-bs-toggle="collapse" href="#graces_21Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Greyoll's Dragonbarrow</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="graces_totals_21"></span>
             </h4>
@@ -2698,108 +2198,84 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="21" id="graces_222" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_222">Dragonbarrow West</label>
-                    <a class="ms-2" href="/map.html?target=graces_222&amp;id=graces_222&amp;link=/checklists/sitesof_grace.html%23item_222&amp;title=Dragonbarrow West">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_222&amp;id=graces_222&amp;link=/checklists/sitesof_grace.html%23item_222&amp;title=Dragonbarrow West"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_223" id="item_223">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="21" id="graces_223" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_223">Isolated Merchant's Shack</label>
-                    <a class="ms-2" href="/map.html?target=graces_223&amp;id=graces_223&amp;link=/checklists/sitesof_grace.html%23item_223&amp;title=Isolated Merchant's Shack">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_223&amp;id=graces_223&amp;link=/checklists/sitesof_grace.html%23item_223&amp;title=Isolated Merchant's Shack"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_224" id="item_224">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="21" id="graces_224" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_224">Fort Faroth</label>
-                    <a class="ms-2" href="/map.html?target=graces_224&amp;id=graces_224&amp;link=/checklists/sitesof_grace.html%23item_224&amp;title=Fort Faroth">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_224&amp;id=graces_224&amp;link=/checklists/sitesof_grace.html%23item_224&amp;title=Fort Faroth"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_225" id="item_225">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="21" id="graces_225" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_225">Dragonbarrow Fork</label>
-                    <a class="ms-2" href="/map.html?target=graces_225&amp;id=graces_225&amp;link=/checklists/sitesof_grace.html%23item_225&amp;title=Dragonbarrow Fork">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_225&amp;id=graces_225&amp;link=/checklists/sitesof_grace.html%23item_225&amp;title=Dragonbarrow Fork"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_226" id="item_226">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="21" id="graces_226" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_226">Lenne's Rise</label>
-                    <a class="ms-2" href="/map.html?target=graces_226&amp;id=graces_226&amp;link=/checklists/sitesof_grace.html%23item_226&amp;title=Lenne's Rise">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_226&amp;id=graces_226&amp;link=/checklists/sitesof_grace.html%23item_226&amp;title=Lenne's Rise"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_227" id="item_227">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="21" id="graces_227" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_227">Farum Greatbridge</label>
-                    <a class="ms-2" href="/map.html?target=graces_227&amp;id=graces_227&amp;link=/checklists/sitesof_grace.html%23item_227&amp;title=Farum Greatbridge">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_227&amp;id=graces_227&amp;link=/checklists/sitesof_grace.html%23item_227&amp;title=Farum Greatbridge"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_228" id="item_228">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="21" id="graces_228" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_228">Bestial Sanctum</label>
-                    <a class="ms-2" href="/map.html?target=graces_228&amp;id=graces_228&amp;link=/checklists/sitesof_grace.html%23item_228&amp;title=Bestial Sanctum">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_228&amp;id=graces_228&amp;link=/checklists/sitesof_grace.html%23item_228&amp;title=Bestial Sanctum"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_229" id="item_229">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="21" id="graces_229" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_229">Sellia Hideaway</label>
-                    <a class="ms-2" href="/map.html?target=graces_229&amp;id=graces_229&amp;link=/checklists/sitesof_grace.html%23item_229&amp;title=Sellia Hideaway">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_229&amp;id=graces_229&amp;link=/checklists/sitesof_grace.html%23item_229&amp;title=Sellia Hideaway"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_230" id="item_230">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="21" id="graces_230" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_230">Dragonbarrow Cave</label>
-                    <a class="ms-2" href="/map.html?target=graces_230&amp;id=graces_230&amp;link=/checklists/sitesof_grace.html%23item_230&amp;title=Dragonbarrow Cave">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_230&amp;id=graces_230&amp;link=/checklists/sitesof_grace.html%23item_230&amp;title=Dragonbarrow Cave"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_231" id="item_231">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="21" id="graces_231" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_231">Divine Tower of Caelid: Center</label>
-                    <a class="ms-2" href="/map.html?target=graces_231&amp;id=graces_231&amp;link=/checklists/sitesof_grace.html%23item_231&amp;title=Divine Tower of Caelid: Center">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_231&amp;id=graces_231&amp;link=/checklists/sitesof_grace.html%23item_231&amp;title=Divine Tower of Caelid: Center"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_232" id="item_232">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="21" id="graces_232" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_232">Divine Tower of Caelid: Basement</label>
-                    <a class="ms-2" href="/map.html?target=graces_232&amp;id=graces_232&amp;link=/checklists/sitesof_grace.html%23item_232&amp;title=Divine Tower of Caelid: Basement">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_232&amp;id=graces_232&amp;link=/checklists/sitesof_grace.html%23item_232&amp;title=Divine Tower of Caelid: Basement"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_233" id="item_233">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="21" id="graces_233" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_233">Isolated Divine Tower</label>
-                    <a class="ms-2" href="/map.html?target=graces_233&amp;id=graces_233&amp;link=/checklists/sitesof_grace.html%23item_233&amp;title=Isolated Divine Tower">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_233&amp;id=graces_233&amp;link=/checklists/sitesof_grace.html%23item_233&amp;title=Isolated Divine Tower"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -2809,9 +2285,7 @@
         <div class="card shadow-sm mb-3" id="graces_section_22">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_22Col" data-bs-toggle="collapse" href="#graces_22Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_22Col" data-bs-toggle="collapse" href="#graces_22Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Forbidden Lands</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="graces_totals_22"></span>
             </h4>
@@ -2821,45 +2295,35 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="22" id="graces_234" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_234">Forbidden Lands</label>
-                    <a class="ms-2" href="/map.html?target=graces_234&amp;id=graces_234&amp;link=/checklists/sitesof_grace.html%23item_234&amp;title=Forbidden Lands">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_234&amp;id=graces_234&amp;link=/checklists/sitesof_grace.html%23item_234&amp;title=Forbidden Lands"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_235" id="item_235">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="22" id="graces_235" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_235">Grand Lift of Rold</label>
-                    <a class="ms-2" href="/map.html?target=graces_235&amp;id=graces_235&amp;link=/checklists/sitesof_grace.html%23item_235&amp;title=Grand Lift of Rold">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_235&amp;id=graces_235&amp;link=/checklists/sitesof_grace.html%23item_235&amp;title=Grand Lift of Rold"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_236" id="item_236">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="22" id="graces_236" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_236">Hidden Path to the Haligtree</label>
-                    <a class="ms-2" href="/map.html?target=graces_236&amp;id=graces_236&amp;link=/checklists/sitesof_grace.html%23item_236&amp;title=Hidden Path to the Haligtree">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_236&amp;id=graces_236&amp;link=/checklists/sitesof_grace.html%23item_236&amp;title=Hidden Path to the Haligtree"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_237" id="item_237">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="22" id="graces_237" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_237">Divine Tower of East Altus: Gate</label>
-                    <a class="ms-2" href="/map.html?target=graces_237&amp;id=graces_237&amp;link=/checklists/sitesof_grace.html%23item_237&amp;title=Divine Tower of East Altus: Gate">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_237&amp;id=graces_237&amp;link=/checklists/sitesof_grace.html%23item_237&amp;title=Divine Tower of East Altus: Gate"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_238" id="item_238">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="22" id="graces_238" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_238">Divine Tower of East Altus</label>
-                    <a class="ms-2" href="/map.html?target=graces_238&amp;id=graces_238&amp;link=/checklists/sitesof_grace.html%23item_238&amp;title=Divine Tower of East Altus">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_238&amp;id=graces_238&amp;link=/checklists/sitesof_grace.html%23item_238&amp;title=Divine Tower of East Altus"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -2869,9 +2333,7 @@
         <div class="card shadow-sm mb-3" id="graces_section_23">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_23Col" data-bs-toggle="collapse" href="#graces_23Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_23Col" data-bs-toggle="collapse" href="#graces_23Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Mountaintops of the Giants</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="graces_totals_23"></span>
             </h4>
@@ -2881,90 +2343,70 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="23" id="graces_239" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_239">Zamor Ruins</label>
-                    <a class="ms-2" href="/map.html?target=graces_239&amp;id=graces_239&amp;link=/checklists/sitesof_grace.html%23item_239&amp;title=Zamor Ruins">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_239&amp;id=graces_239&amp;link=/checklists/sitesof_grace.html%23item_239&amp;title=Zamor Ruins"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_240" id="item_240">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="23" id="graces_240" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_240">Ancient Snow Valley Ruins</label>
-                    <a class="ms-2" href="/map.html?target=graces_240&amp;id=graces_240&amp;link=/checklists/sitesof_grace.html%23item_240&amp;title=Ancient Snow Valley Ruins">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_240&amp;id=graces_240&amp;link=/checklists/sitesof_grace.html%23item_240&amp;title=Ancient Snow Valley Ruins"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_241" id="item_241">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="23" id="graces_241" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_241">Freezing Lake</label>
-                    <a class="ms-2" href="/map.html?target=graces_241&amp;id=graces_241&amp;link=/checklists/sitesof_grace.html%23item_241&amp;title=Freezing Lake">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_241&amp;id=graces_241&amp;link=/checklists/sitesof_grace.html%23item_241&amp;title=Freezing Lake"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_242" id="item_242">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="23" id="graces_242" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_242">First Church of Marika</label>
-                    <a class="ms-2" href="/map.html?target=graces_242&amp;id=graces_242&amp;link=/checklists/sitesof_grace.html%23item_242&amp;title=First Church of Marika">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_242&amp;id=graces_242&amp;link=/checklists/sitesof_grace.html%23item_242&amp;title=First Church of Marika"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_243" id="item_243">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="23" id="graces_243" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_243">Whiteridge Road</label>
-                    <a class="ms-2" href="/map.html?target=graces_243&amp;id=graces_243&amp;link=/checklists/sitesof_grace.html%23item_243&amp;title=Whiteridge Road">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_243&amp;id=graces_243&amp;link=/checklists/sitesof_grace.html%23item_243&amp;title=Whiteridge Road"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_244" id="item_244">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="23" id="graces_244" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_244">Snow Valley Ruins Overlook</label>
-                    <a class="ms-2" href="/map.html?target=graces_244&amp;id=graces_244&amp;link=/checklists/sitesof_grace.html%23item_244&amp;title=Snow Valley Ruins Overlook">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_244&amp;id=graces_244&amp;link=/checklists/sitesof_grace.html%23item_244&amp;title=Snow Valley Ruins Overlook"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_245" id="item_245">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="23" id="graces_245" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_245">Castle Sol Main Gate</label>
-                    <a class="ms-2" href="/map.html?target=graces_245&amp;id=graces_245&amp;link=/checklists/sitesof_grace.html%23item_245&amp;title=Castle Sol Main Gate">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_245&amp;id=graces_245&amp;link=/checklists/sitesof_grace.html%23item_245&amp;title=Castle Sol Main Gate"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_246" id="item_246">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="23" id="graces_246" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_246">Church of the Eclipse</label>
-                    <a class="ms-2" href="/map.html?target=graces_246&amp;id=graces_246&amp;link=/checklists/sitesof_grace.html%23item_246&amp;title=Church of the Eclipse">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_246&amp;id=graces_246&amp;link=/checklists/sitesof_grace.html%23item_246&amp;title=Church of the Eclipse"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_247" id="item_247">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="23" id="graces_247" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_247">Castle Sol Rooftop</label>
-                    <a class="ms-2" href="/map.html?target=graces_247&amp;id=graces_247&amp;link=/checklists/sitesof_grace.html%23item_247&amp;title=Castle Sol Rooftop">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_247&amp;id=graces_247&amp;link=/checklists/sitesof_grace.html%23item_247&amp;title=Castle Sol Rooftop"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_248" id="item_248">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="23" id="graces_248" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_248">Spiritcaller Cave</label>
-                    <a class="ms-2" href="/map.html?target=graces_248&amp;id=graces_248&amp;link=/checklists/sitesof_grace.html%23item_248&amp;title=Spiritcaller Cave">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_248&amp;id=graces_248&amp;link=/checklists/sitesof_grace.html%23item_248&amp;title=Spiritcaller Cave"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -2974,9 +2416,7 @@
         <div class="card shadow-sm mb-3" id="graces_section_24">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_24Col" data-bs-toggle="collapse" href="#graces_24Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_24Col" data-bs-toggle="collapse" href="#graces_24Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Flame Peak</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="graces_totals_24"></span>
             </h4>
@@ -2986,63 +2426,49 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="24" id="graces_249" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_249">Giants' Gravepost</label>
-                    <a class="ms-2" href="/map.html?target=graces_249&amp;id=graces_249&amp;link=/checklists/sitesof_grace.html%23item_249&amp;title=Giants' Gravepost">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_249&amp;id=graces_249&amp;link=/checklists/sitesof_grace.html%23item_249&amp;title=Giants' Gravepost"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_250" id="item_250">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="24" id="graces_250" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_250">Church of Repose</label>
-                    <a class="ms-2" href="/map.html?target=graces_250&amp;id=graces_250&amp;link=/checklists/sitesof_grace.html%23item_250&amp;title=Church of Repose">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_250&amp;id=graces_250&amp;link=/checklists/sitesof_grace.html%23item_250&amp;title=Church of Repose"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_251" id="item_251">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="24" id="graces_251" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_251">Foot of the Forge</label>
-                    <a class="ms-2" href="/map.html?target=graces_251&amp;id=graces_251&amp;link=/checklists/sitesof_grace.html%23item_251&amp;title=Foot of the Forge">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_251&amp;id=graces_251&amp;link=/checklists/sitesof_grace.html%23item_251&amp;title=Foot of the Forge"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_252" id="item_252">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="24" id="graces_252" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_252">Fire Giant</label>
-                    <a class="ms-2" href="/map.html?target=graces_252&amp;id=graces_252&amp;link=/checklists/sitesof_grace.html%23item_252&amp;title=Fire Giant">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_252&amp;id=graces_252&amp;link=/checklists/sitesof_grace.html%23item_252&amp;title=Fire Giant"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_253" id="item_253">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="24" id="graces_253" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_253">Forge of the Giants</label>
-                    <a class="ms-2" href="/map.html?target=graces_253&amp;id=graces_253&amp;link=/checklists/sitesof_grace.html%23item_253&amp;title=Forge of the Giants">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_253&amp;id=graces_253&amp;link=/checklists/sitesof_grace.html%23item_253&amp;title=Forge of the Giants"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_254" id="item_254">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="24" id="graces_254" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_254">Giants' Mountaintop Catacombs</label>
-                    <a class="ms-2" href="/map.html?target=graces_254&amp;id=graces_254&amp;link=/checklists/sitesof_grace.html%23item_254&amp;title=Giants' Mountaintop Catacombs">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_254&amp;id=graces_254&amp;link=/checklists/sitesof_grace.html%23item_254&amp;title=Giants' Mountaintop Catacombs"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_255" id="item_255">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="24" id="graces_255" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_255">Giant-Conquering Hero's Grave</label>
-                    <a class="ms-2" href="/map.html?target=graces_255&amp;id=graces_255&amp;link=/checklists/sitesof_grace.html%23item_255&amp;title=Giant-Conquering Hero's Grave">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_255&amp;id=graces_255&amp;link=/checklists/sitesof_grace.html%23item_255&amp;title=Giant-Conquering Hero's Grave"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -3052,9 +2478,7 @@
         <div class="card shadow-sm mb-3" id="graces_section_25">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_25Col" data-bs-toggle="collapse" href="#graces_25Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_25Col" data-bs-toggle="collapse" href="#graces_25Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Consecrated Snowfield</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="graces_totals_25"></span>
             </h4>
@@ -3064,63 +2488,49 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="25" id="graces_256" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_256">Consecrated Snowfield</label>
-                    <a class="ms-2" href="/map.html?target=graces_256&amp;id=graces_256&amp;link=/checklists/sitesof_grace.html%23item_256&amp;title=Consecrated Snowfield">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_256&amp;id=graces_256&amp;link=/checklists/sitesof_grace.html%23item_256&amp;title=Consecrated Snowfield"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_257" id="item_257">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="25" id="graces_257" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_257">Inner Consecrated Snowfield</label>
-                    <a class="ms-2" href="/map.html?target=graces_257&amp;id=graces_257&amp;link=/checklists/sitesof_grace.html%23item_257&amp;title=Inner Consecrated Snowfield">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_257&amp;id=graces_257&amp;link=/checklists/sitesof_grace.html%23item_257&amp;title=Inner Consecrated Snowfield"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_258" id="item_258">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="25" id="graces_258" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_258">Ordina, Liturgical Town</label>
-                    <a class="ms-2" href="/map.html?target=graces_258&amp;id=graces_258&amp;link=/checklists/sitesof_grace.html%23item_258&amp;title=Ordina, Liturgical Town">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_258&amp;id=graces_258&amp;link=/checklists/sitesof_grace.html%23item_258&amp;title=Ordina, Liturgical Town"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_259" id="item_259">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="25" id="graces_259" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_259">Apostate Derelict</label>
-                    <a class="ms-2" href="/map.html?target=graces_259&amp;id=graces_259&amp;link=/checklists/sitesof_grace.html%23item_259&amp;title=Apostate Derelict">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_259&amp;id=graces_259&amp;link=/checklists/sitesof_grace.html%23item_259&amp;title=Apostate Derelict"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_260" id="item_260">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="25" id="graces_260" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_260">Consecrated Snowfield Catacombs</label>
-                    <a class="ms-2" href="/map.html?target=graces_260&amp;id=graces_260&amp;link=/checklists/sitesof_grace.html%23item_260&amp;title=Consecrated Snowfield Catacombs">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_260&amp;id=graces_260&amp;link=/checklists/sitesof_grace.html%23item_260&amp;title=Consecrated Snowfield Catacombs"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_261" id="item_261">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="25" id="graces_261" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_261">Cave of the Forlorn</label>
-                    <a class="ms-2" href="/map.html?target=graces_261&amp;id=graces_261&amp;link=/checklists/sitesof_grace.html%23item_261&amp;title=Cave of the Forlorn">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_261&amp;id=graces_261&amp;link=/checklists/sitesof_grace.html%23item_261&amp;title=Cave of the Forlorn"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_262" id="item_262">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="25" id="graces_262" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_262">Yelough Anix Tunnel</label>
-                    <a class="ms-2" href="/map.html?target=graces_262&amp;id=graces_262&amp;link=/checklists/sitesof_grace.html%23item_262&amp;title=Yelough Anix Tunnel">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_262&amp;id=graces_262&amp;link=/checklists/sitesof_grace.html%23item_262&amp;title=Yelough Anix Tunnel"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -3130,9 +2540,7 @@
         <div class="card shadow-sm mb-3" id="graces_section_26">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_26Col" data-bs-toggle="collapse" href="#graces_26Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_26Col" data-bs-toggle="collapse" href="#graces_26Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Miquella's Haligtree</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="graces_totals_26"></span>
             </h4>
@@ -3142,36 +2550,28 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="26" id="graces_263" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_263">Haligtree Canopy</label>
-                    <a class="ms-2" href="/map.html?target=graces_263&amp;id=graces_263&amp;link=/checklists/sitesof_grace.html%23item_263&amp;title=Haligtree Canopy">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_263&amp;id=graces_263&amp;link=/checklists/sitesof_grace.html%23item_263&amp;title=Haligtree Canopy"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_264" id="item_264">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="26" id="graces_264" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_264">Haligtree Town</label>
-                    <a class="ms-2" href="/map.html?target=graces_264&amp;id=graces_264&amp;link=/checklists/sitesof_grace.html%23item_264&amp;title=Haligtree Town">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_264&amp;id=graces_264&amp;link=/checklists/sitesof_grace.html%23item_264&amp;title=Haligtree Town"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_265" id="item_265">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="26" id="graces_265" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_265">Haligtree Town Plaza</label>
-                    <a class="ms-2" href="/map.html?target=graces_265&amp;id=graces_265&amp;link=/checklists/sitesof_grace.html%23item_265&amp;title=Haligtree Town Plaza">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_265&amp;id=graces_265&amp;link=/checklists/sitesof_grace.html%23item_265&amp;title=Haligtree Town Plaza"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_266" id="item_266">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="26" id="graces_266" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_266">Haligtree Promenade</label>
-                    <a class="ms-2" href="/map.html?target=graces_266&amp;id=graces_266&amp;link=/checklists/sitesof_grace.html%23item_266&amp;title=Haligtree Promenade">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_266&amp;id=graces_266&amp;link=/checklists/sitesof_grace.html%23item_266&amp;title=Haligtree Promenade"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -3181,9 +2581,7 @@
         <div class="card shadow-sm mb-3" id="graces_section_27">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_27Col" data-bs-toggle="collapse" href="#graces_27Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_27Col" data-bs-toggle="collapse" href="#graces_27Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Elphael, Brace of the Haligtree</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="graces_totals_27"></span>
             </h4>
@@ -3193,45 +2591,35 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="27" id="graces_267" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_267">Prayer Room</label>
-                    <a class="ms-2" href="/map.html?target=graces_267&amp;id=graces_267&amp;link=/checklists/sitesof_grace.html%23item_267&amp;title=Prayer Room">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_267&amp;id=graces_267&amp;link=/checklists/sitesof_grace.html%23item_267&amp;title=Prayer Room"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_268" id="item_268">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="27" id="graces_268" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_268">Elphael Inner Wall</label>
-                    <a class="ms-2" href="/map.html?target=graces_268&amp;id=graces_268&amp;link=/checklists/sitesof_grace.html%23item_268&amp;title=Elphael Inner Wall">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_268&amp;id=graces_268&amp;link=/checklists/sitesof_grace.html%23item_268&amp;title=Elphael Inner Wall"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_269" id="item_269">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="27" id="graces_269" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_269">Drainage Channel</label>
-                    <a class="ms-2" href="/map.html?target=graces_269&amp;id=graces_269&amp;link=/checklists/sitesof_grace.html%23item_269&amp;title=Drainage Channel">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_269&amp;id=graces_269&amp;link=/checklists/sitesof_grace.html%23item_269&amp;title=Drainage Channel"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_270" id="item_270">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="27" id="graces_270" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_270">Haligtree Roots</label>
-                    <a class="ms-2" href="/map.html?target=graces_270&amp;id=graces_270&amp;link=/checklists/sitesof_grace.html%23item_270&amp;title=Haligtree Roots">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_270&amp;id=graces_270&amp;link=/checklists/sitesof_grace.html%23item_270&amp;title=Haligtree Roots"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_271" id="item_271">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="27" id="graces_271" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_271">Malenia, Goddess of Rot</label>
-                    <a class="ms-2" href="/map.html?target=graces_271&amp;id=graces_271&amp;link=/checklists/sitesof_grace.html%23item_271&amp;title=Malenia, Goddess of Rot">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_271&amp;id=graces_271&amp;link=/checklists/sitesof_grace.html%23item_271&amp;title=Malenia, Goddess of Rot"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -3241,9 +2629,7 @@
         <div class="card shadow-sm mb-3" id="graces_section_28">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_28Col" data-bs-toggle="collapse" href="#graces_28Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_28Col" data-bs-toggle="collapse" href="#graces_28Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Ainsel River</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="graces_totals_28"></span>
             </h4>
@@ -3253,45 +2639,35 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="28" id="graces_272" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_272">Ainsel River Well Depths</label>
-                    <a class="ms-2" href="/map.html?target=graces_272&amp;id=graces_272&amp;link=/checklists/sitesof_grace.html%23item_272&amp;title=Ainsel River Well Depths">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_272&amp;id=graces_272&amp;link=/checklists/sitesof_grace.html%23item_272&amp;title=Ainsel River Well Depths"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_273" id="item_273">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="28" id="graces_273" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_273">Ainsel River Sluice Gate</label>
-                    <a class="ms-2" href="/map.html?target=graces_273&amp;id=graces_273&amp;link=/checklists/sitesof_grace.html%23item_273&amp;title=Ainsel River Sluice Gate">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_273&amp;id=graces_273&amp;link=/checklists/sitesof_grace.html%23item_273&amp;title=Ainsel River Sluice Gate"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_274" id="item_274">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="28" id="graces_274" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_274">Ainsel River Downstream</label>
-                    <a class="ms-2" href="/map.html?target=graces_274&amp;id=graces_274&amp;link=/checklists/sitesof_grace.html%23item_274&amp;title=Ainsel River Downstream">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_274&amp;id=graces_274&amp;link=/checklists/sitesof_grace.html%23item_274&amp;title=Ainsel River Downstream"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_275" id="item_275">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="28" id="graces_275" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_275">Dragonkin Soldier of Nokstella</label>
-                    <a class="ms-2" href="/map.html?target=graces_275&amp;id=graces_275&amp;link=/checklists/sitesof_grace.html%23item_275&amp;title=Dragonkin Soldier of Nokstella">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_275&amp;id=graces_275&amp;link=/checklists/sitesof_grace.html%23item_275&amp;title=Dragonkin Soldier of Nokstella"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_276" id="item_276">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="28" id="graces_276" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_276">Astel, Naturalborn of the Void</label>
-                    <a class="ms-2" href="/map.html?target=graces_276&amp;id=graces_276&amp;link=/checklists/sitesof_grace.html%23item_276&amp;title=Astel, Naturalborn of the Void">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_276&amp;id=graces_276&amp;link=/checklists/sitesof_grace.html%23item_276&amp;title=Astel, Naturalborn of the Void"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -3301,9 +2677,7 @@
         <div class="card shadow-sm mb-3" id="graces_section_29">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_29Col" data-bs-toggle="collapse" href="#graces_29Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_29Col" data-bs-toggle="collapse" href="#graces_29Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Ainsel River Main</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="graces_totals_29"></span>
             </h4>
@@ -3313,27 +2687,21 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="29" id="graces_277" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_277">Ainsel River Main</label>
-                    <a class="ms-2" href="/map.html?target=graces_277&amp;id=graces_277&amp;link=/checklists/sitesof_grace.html%23item_277&amp;title=Ainsel River Main">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_277&amp;id=graces_277&amp;link=/checklists/sitesof_grace.html%23item_277&amp;title=Ainsel River Main"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_278" id="item_278">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="29" id="graces_278" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_278">Nokstella, Eternal City</label>
-                    <a class="ms-2" href="/map.html?target=graces_278&amp;id=graces_278&amp;link=/checklists/sitesof_grace.html%23item_278&amp;title=Nokstella, Eternal City">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_278&amp;id=graces_278&amp;link=/checklists/sitesof_grace.html%23item_278&amp;title=Nokstella, Eternal City"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_279" id="item_279">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="29" id="graces_279" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_279">Nokstella Waterfall Basin</label>
-                    <a class="ms-2" href="/map.html?target=graces_279&amp;id=graces_279&amp;link=/checklists/sitesof_grace.html%23item_279&amp;title=Nokstella Waterfall Basin">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_279&amp;id=graces_279&amp;link=/checklists/sitesof_grace.html%23item_279&amp;title=Nokstella Waterfall Basin"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -3343,9 +2711,7 @@
         <div class="card shadow-sm mb-3" id="graces_section_30">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_30Col" data-bs-toggle="collapse" href="#graces_30Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_30Col" data-bs-toggle="collapse" href="#graces_30Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Lake of Rot</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="graces_totals_30"></span>
             </h4>
@@ -3355,18 +2721,14 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="30" id="graces_280" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_280">Lake of Rot Shoreside</label>
-                    <a class="ms-2" href="/map.html?target=graces_280&amp;id=graces_280&amp;link=/checklists/sitesof_grace.html%23item_280&amp;title=Lake of Rot Shoreside">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_280&amp;id=graces_280&amp;link=/checklists/sitesof_grace.html%23item_280&amp;title=Lake of Rot Shoreside"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_281" id="item_281">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="30" id="graces_281" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_281">Grand Cloister</label>
-                    <a class="ms-2" href="/map.html?target=graces_281&amp;id=graces_281&amp;link=/checklists/sitesof_grace.html%23item_281&amp;title=Grand Cloister">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_281&amp;id=graces_281&amp;link=/checklists/sitesof_grace.html%23item_281&amp;title=Grand Cloister"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -3376,9 +2738,7 @@
         <div class="card shadow-sm mb-3" id="graces_section_31">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_31Col" data-bs-toggle="collapse" href="#graces_31Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_31Col" data-bs-toggle="collapse" href="#graces_31Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Nokron, Eternal City</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="graces_totals_31"></span>
             </h4>
@@ -3388,54 +2748,42 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="31" id="graces_282" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_282">Nokron, Eternal City</label>
-                    <a class="ms-2" href="/map.html?target=graces_282&amp;id=graces_282&amp;link=/checklists/sitesof_grace.html%23item_282&amp;title=Nokron, Eternal City">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_282&amp;id=graces_282&amp;link=/checklists/sitesof_grace.html%23item_282&amp;title=Nokron, Eternal City"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_283" id="item_283">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="31" id="graces_283" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_283">Mimic Tear</label>
-                    <a class="ms-2" href="/map.html?target=graces_283&amp;id=graces_283&amp;link=/checklists/sitesof_grace.html%23item_283&amp;title=Mimic Tear">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_283&amp;id=graces_283&amp;link=/checklists/sitesof_grace.html%23item_283&amp;title=Mimic Tear"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_284" id="item_284">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="31" id="graces_284" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_284">Ancestral Woods</label>
-                    <a class="ms-2" href="/map.html?target=graces_284&amp;id=graces_284&amp;link=/checklists/sitesof_grace.html%23item_284&amp;title=Ancestral Woods">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_284&amp;id=graces_284&amp;link=/checklists/sitesof_grace.html%23item_284&amp;title=Ancestral Woods"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_285" id="item_285">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="31" id="graces_285" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_285">Night's Sacred Ground</label>
-                    <a class="ms-2" href="/map.html?target=graces_285&amp;id=graces_285&amp;link=/checklists/sitesof_grace.html%23item_285&amp;title=Night's Sacred Ground">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_285&amp;id=graces_285&amp;link=/checklists/sitesof_grace.html%23item_285&amp;title=Night's Sacred Ground"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_286" id="item_286">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="31" id="graces_286" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_286">Aqueduct-Facing Cliffs</label>
-                    <a class="ms-2" href="/map.html?target=graces_286&amp;id=graces_286&amp;link=/checklists/sitesof_grace.html%23item_286&amp;title=Aqueduct-Facing Cliffs">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_286&amp;id=graces_286&amp;link=/checklists/sitesof_grace.html%23item_286&amp;title=Aqueduct-Facing Cliffs"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_287" id="item_287">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="31" id="graces_287" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_287">Great Waterfall Basin</label>
-                    <a class="ms-2" href="/map.html?target=graces_287&amp;id=graces_287&amp;link=/checklists/sitesof_grace.html%23item_287&amp;title=Great Waterfall Basin">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_287&amp;id=graces_287&amp;link=/checklists/sitesof_grace.html%23item_287&amp;title=Great Waterfall Basin"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -3445,9 +2793,7 @@
         <div class="card shadow-sm mb-3" id="graces_section_32">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_32Col" data-bs-toggle="collapse" href="#graces_32Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_32Col" data-bs-toggle="collapse" href="#graces_32Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Siofra River</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="graces_totals_32"></span>
             </h4>
@@ -3457,36 +2803,28 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="32" id="graces_288" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_288">Siofra River Well Depths</label>
-                    <a class="ms-2" href="/map.html?target=graces_288&amp;id=graces_288&amp;link=/checklists/sitesof_grace.html%23item_288&amp;title=Siofra River Well Depths">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_288&amp;id=graces_288&amp;link=/checklists/sitesof_grace.html%23item_288&amp;title=Siofra River Well Depths"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_289" id="item_289">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="32" id="graces_289" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_289">Siofra River Bank</label>
-                    <a class="ms-2" href="/map.html?target=graces_289&amp;id=graces_289&amp;link=/checklists/sitesof_grace.html%23item_289&amp;title=Siofra River Bank">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_289&amp;id=graces_289&amp;link=/checklists/sitesof_grace.html%23item_289&amp;title=Siofra River Bank"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_290" id="item_290">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="32" id="graces_290" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_290">Worshippers' Woods</label>
-                    <a class="ms-2" href="/map.html?target=graces_290&amp;id=graces_290&amp;link=/checklists/sitesof_grace.html%23item_290&amp;title=Worshippers' Woods">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_290&amp;id=graces_290&amp;link=/checklists/sitesof_grace.html%23item_290&amp;title=Worshippers' Woods"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_291" id="item_291">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="32" id="graces_291" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_291">Below the Well</label>
-                    <a class="ms-2" href="/map.html?target=graces_291&amp;id=graces_291&amp;link=/checklists/sitesof_grace.html%23item_291&amp;title=Below the Well">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_291&amp;id=graces_291&amp;link=/checklists/sitesof_grace.html%23item_291&amp;title=Below the Well"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -3496,9 +2834,7 @@
         <div class="card shadow-sm mb-3" id="graces_section_33">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_33Col" data-bs-toggle="collapse" href="#graces_33Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_33Col" data-bs-toggle="collapse" href="#graces_33Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Mohgwyn Palace</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="graces_totals_33"></span>
             </h4>
@@ -3508,36 +2844,28 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="33" id="graces_292" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_292">Palace Approach Ledge-Road</label>
-                    <a class="ms-2" href="/map.html?target=graces_292&amp;id=graces_292&amp;link=/checklists/sitesof_grace.html%23item_292&amp;title=Palace Approach Ledge-Road">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_292&amp;id=graces_292&amp;link=/checklists/sitesof_grace.html%23item_292&amp;title=Palace Approach Ledge-Road"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_293" id="item_293">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="33" id="graces_293" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_293">Dynasty Mausoleum Entrance</label>
-                    <a class="ms-2" href="/map.html?target=graces_293&amp;id=graces_293&amp;link=/checklists/sitesof_grace.html%23item_293&amp;title=Dynasty Mausoleum Entrance">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_293&amp;id=graces_293&amp;link=/checklists/sitesof_grace.html%23item_293&amp;title=Dynasty Mausoleum Entrance"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_294" id="item_294">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="33" id="graces_294" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_294">Dynasty Mausoleum Midpoint</label>
-                    <a class="ms-2" href="/map.html?target=graces_294&amp;id=graces_294&amp;link=/checklists/sitesof_grace.html%23item_294&amp;title=Dynasty Mausoleum Midpoint">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_294&amp;id=graces_294&amp;link=/checklists/sitesof_grace.html%23item_294&amp;title=Dynasty Mausoleum Midpoint"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_295" id="item_295">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="33" id="graces_295" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_295">Cocoon of the Empyrean</label>
-                    <a class="ms-2" href="/map.html?target=graces_295&amp;id=graces_295&amp;link=/checklists/sitesof_grace.html%23item_295&amp;title=Cocoon of the Empyrean">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_295&amp;id=graces_295&amp;link=/checklists/sitesof_grace.html%23item_295&amp;title=Cocoon of the Empyrean"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -3547,9 +2875,7 @@
         <div class="card shadow-sm mb-3" id="graces_section_34">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_34Col" data-bs-toggle="collapse" href="#graces_34Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_34Col" data-bs-toggle="collapse" href="#graces_34Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Deeproot Depths</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="graces_totals_34"></span>
             </h4>
@@ -3559,54 +2885,42 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="34" id="graces_296" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_296">Root-Facing Cliffs</label>
-                    <a class="ms-2" href="/map.html?target=graces_296&amp;id=graces_296&amp;link=/checklists/sitesof_grace.html%23item_296&amp;title=Root-Facing Cliffs">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_296&amp;id=graces_296&amp;link=/checklists/sitesof_grace.html%23item_296&amp;title=Root-Facing Cliffs"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_297" id="item_297">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="34" id="graces_297" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_297">Great Waterfall Crest</label>
-                    <a class="ms-2" href="/map.html?target=graces_297&amp;id=graces_297&amp;link=/checklists/sitesof_grace.html%23item_297&amp;title=Great Waterfall Crest">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_297&amp;id=graces_297&amp;link=/checklists/sitesof_grace.html%23item_297&amp;title=Great Waterfall Crest"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_298" id="item_298">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="34" id="graces_298" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_298">Deeproot Depths</label>
-                    <a class="ms-2" href="/map.html?target=graces_298&amp;id=graces_298&amp;link=/checklists/sitesof_grace.html%23item_298&amp;title=Deeproot Depths">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_298&amp;id=graces_298&amp;link=/checklists/sitesof_grace.html%23item_298&amp;title=Deeproot Depths"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_299" id="item_299">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="34" id="graces_299" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_299">The Nameless Eternal City</label>
-                    <a class="ms-2" href="/map.html?target=graces_299&amp;id=graces_299&amp;link=/checklists/sitesof_grace.html%23item_299&amp;title=The Nameless Eternal City">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_299&amp;id=graces_299&amp;link=/checklists/sitesof_grace.html%23item_299&amp;title=The Nameless Eternal City"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_300" id="item_300">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="34" id="graces_300" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_300">Across the Roots</label>
-                    <a class="ms-2" href="/map.html?target=graces_300&amp;id=graces_300&amp;link=/checklists/sitesof_grace.html%23item_300&amp;title=Across the Roots">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_300&amp;id=graces_300&amp;link=/checklists/sitesof_grace.html%23item_300&amp;title=Across the Roots"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_301" id="item_301">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="34" id="graces_301" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_301">Prince of Death's Throne</label>
-                    <a class="ms-2" href="/map.html?target=graces_301&amp;id=graces_301&amp;link=/checklists/sitesof_grace.html%23item_301&amp;title=Prince of Death's Throne">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_301&amp;id=graces_301&amp;link=/checklists/sitesof_grace.html%23item_301&amp;title=Prince of Death's Throne"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -3616,9 +2930,7 @@
         <div class="card shadow-sm mb-3" id="graces_section_35">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_35Col" data-bs-toggle="collapse" href="#graces_35Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#graces_35Col" data-bs-toggle="collapse" href="#graces_35Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Crumbling Farum Azula</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="graces_totals_35"></span>
             </h4>
@@ -3628,99 +2940,77 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="35" id="graces_302" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_302">Crumbling Beast Grave</label>
-                    <a class="ms-2" href="/map.html?target=graces_302&amp;id=graces_302&amp;link=/checklists/sitesof_grace.html%23item_302&amp;title=Crumbling Beast Grave">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_302&amp;id=graces_302&amp;link=/checklists/sitesof_grace.html%23item_302&amp;title=Crumbling Beast Grave"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_303" id="item_303">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="35" id="graces_303" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_303">Crumbling Beast Grave Depths</label>
-                    <a class="ms-2" href="/map.html?target=graces_303&amp;id=graces_303&amp;link=/checklists/sitesof_grace.html%23item_303&amp;title=Crumbling Beast Grave Depths">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_303&amp;id=graces_303&amp;link=/checklists/sitesof_grace.html%23item_303&amp;title=Crumbling Beast Grave Depths"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_304" id="item_304">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="35" id="graces_304" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_304">Tempest-Facing Balcony</label>
-                    <a class="ms-2" href="/map.html?target=graces_304&amp;id=graces_304&amp;link=/checklists/sitesof_grace.html%23item_304&amp;title=Tempest-Facing Balcony">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_304&amp;id=graces_304&amp;link=/checklists/sitesof_grace.html%23item_304&amp;title=Tempest-Facing Balcony"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_305" id="item_305">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="35" id="graces_305" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_305">Dragon Temple</label>
-                    <a class="ms-2" href="/map.html?target=graces_305&amp;id=graces_305&amp;link=/checklists/sitesof_grace.html%23item_305&amp;title=Dragon Temple">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_305&amp;id=graces_305&amp;link=/checklists/sitesof_grace.html%23item_305&amp;title=Dragon Temple"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_306" id="item_306">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="35" id="graces_306" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_306">Dragon Temple Transept</label>
-                    <a class="ms-2" href="/map.html?target=graces_306&amp;id=graces_306&amp;link=/checklists/sitesof_grace.html%23item_306&amp;title=Dragon Temple Transept">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_306&amp;id=graces_306&amp;link=/checklists/sitesof_grace.html%23item_306&amp;title=Dragon Temple Transept"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_307" id="item_307">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="35" id="graces_307" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_307">Dragon Temple Altar</label>
-                    <a class="ms-2" href="/map.html?target=graces_307&amp;id=graces_307&amp;link=/checklists/sitesof_grace.html%23item_307&amp;title=Dragon Temple Altar">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_307&amp;id=graces_307&amp;link=/checklists/sitesof_grace.html%23item_307&amp;title=Dragon Temple Altar"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_308" id="item_308">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="35" id="graces_308" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_308">Dragon Temple Lift</label>
-                    <a class="ms-2" href="/map.html?target=graces_308&amp;id=graces_308&amp;link=/checklists/sitesof_grace.html%23item_308&amp;title=Dragon Temple Lift">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_308&amp;id=graces_308&amp;link=/checklists/sitesof_grace.html%23item_308&amp;title=Dragon Temple Lift"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_309" id="item_309">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="35" id="graces_309" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_309">Dragon Temple Rooftop</label>
-                    <a class="ms-2" href="/map.html?target=graces_309&amp;id=graces_309&amp;link=/checklists/sitesof_grace.html%23item_309&amp;title=Dragon Temple Rooftop">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_309&amp;id=graces_309&amp;link=/checklists/sitesof_grace.html%23item_309&amp;title=Dragon Temple Rooftop"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_310" id="item_310">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="35" id="graces_310" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_310">Beside the Great Bridge</label>
-                    <a class="ms-2" href="/map.html?target=graces_310&amp;id=graces_310&amp;link=/checklists/sitesof_grace.html%23item_310&amp;title=Beside the Great Bridge">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_310&amp;id=graces_310&amp;link=/checklists/sitesof_grace.html%23item_310&amp;title=Beside the Great Bridge"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_311" id="item_311">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="35" id="graces_311" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_311">Dragonlord Placidusax</label>
-                    <a class="ms-2" href="/map.html?target=graces_311&amp;id=graces_311&amp;link=/checklists/sitesof_grace.html%23item_311&amp;title=Dragonlord Placidusax">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_311&amp;id=graces_311&amp;link=/checklists/sitesof_grace.html%23item_311&amp;title=Dragonlord Placidusax"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="graces_312" id="item_312">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="35" id="graces_312" type="checkbox" value="">
                     <label class="form-check-label item_content" for="graces_312">Maliketh, the Black Blade</label>
-                    <a class="ms-2" href="/map.html?target=graces_312&amp;id=graces_312&amp;link=/checklists/sitesof_grace.html%23item_312&amp;title=Maliketh, the Black Blade">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=graces_312&amp;id=graces_312&amp;link=/checklists/sitesof_grace.html%23item_312&amp;title=Maliketh, the Black Blade"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>

--- a/docs/checklists/sorceries.html
+++ b/docs/checklists/sorceries.html
@@ -27,14 +27,10 @@
         <a class="navbar-brand me-auto ms-2" href="/index.html">Roundtable Guides</a>
         <form class="d-none d-sm-flex order-2 order-xl-3">
           <input aria-label="search" class="form-control me-2" name="search" placeholder="Search" type="search">
-          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit">
-            <i class="bi bi-search"></i>
-          </button>
+          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit"><i class="bi bi-search"></i></button>
         </form>
         <div class="d-sm-none order-2">
-          <a class="nav-link me-0" href="/search.html">
-            <i class="bi bi-search sb-icon-search"></i>
-          </a>
+          <a class="nav-link me-0" href="/search.html"><i class="bi bi-search sb-icon-search"></i></a>
         </div>
         <div class="collapse navbar-collapse order-3 order-xl-2 ms-xl-2" id="nav-collapse">
           <ul class="nav navbar-nav navbar-nav-scroll mr-auto">
@@ -179,14 +175,10 @@
               </ul>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/map.html">
-                <i class="bi bi-map"></i> Map
-              </a>
+              <a class="nav-link hide-buttons" href="/map.html"><i class="bi bi-map"></i> Map</a>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/options.html">
-                <i class="bi bi-gear-fill"></i> Options
-              </a>
+              <a class="nav-link hide-buttons" href="/options.html"><i class="bi bi-gear-fill"></i> Options</a>
             </li>
           </ul>
         </div>
@@ -206,9 +198,7 @@
       </div>
       <nav class="text-muted toc d-print-none">
         <strong class="d-block h5">
-          <a class="toc-button" data-bs-toggle="collapse" href="#toc_sorceries" role="button">
-            <i class="bi bi-plus-lg"></i>Table Of Contents
-          </a>
+          <a class="toc-button" data-bs-toggle="collapse" href="#toc_sorceries" role="button"><i class="bi bi-plus-lg"></i>Table Of Contents</a>
         </strong>
         <ul class="toc_page collapse" id="toc_sorceries">
           <li>
@@ -276,9 +266,7 @@
         <div class="card shadow-sm mb-3" id="sorceries_section_0">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#sorceries_0Col" data-bs-toggle="collapse" href="#sorceries_0Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#sorceries_0Col" data-bs-toggle="collapse" href="#sorceries_0Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Limgrave</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="sorceries_totals_0"></span>
             </h4>
@@ -290,9 +278,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -321,9 +307,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="sorceries_1_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_1_3&amp;id=sorceries_1_3&amp;link=/checklists/sorceries.html%23item_1_3&amp;title=Crystal Barrage">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_1_3&amp;id=sorceries_1_3&amp;link=/checklists/sorceries.html%23item_1_3&amp;title=Crystal Barrage"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -356,9 +340,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="sorceries_1_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_1_4&amp;id=sorceries_1_4&amp;link=/checklists/sorceries.html%23item_1_4&amp;title=Glintstone Arc">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_1_4&amp;id=sorceries_1_4&amp;link=/checklists/sorceries.html%23item_1_4&amp;title=Glintstone Arc"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -391,9 +373,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="sorceries_1_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_1_5&amp;id=sorceries_1_5&amp;link=/checklists/sorceries.html%23item_1_5&amp;title=Glintstone Pebble">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_1_5&amp;id=sorceries_1_5&amp;link=/checklists/sorceries.html%23item_1_5&amp;title=Glintstone Pebble"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -426,9 +406,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="sorceries_1_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_1_6&amp;id=sorceries_1_6&amp;link=/checklists/sorceries.html%23item_1_6&amp;title=Glintstone Stars">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_1_6&amp;id=sorceries_1_6&amp;link=/checklists/sorceries.html%23item_1_6&amp;title=Glintstone Stars"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -461,9 +439,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="sorceries_1_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_1_7&amp;id=sorceries_1_7&amp;link=/checklists/sorceries.html%23item_1_7&amp;title=Scholar's Armament">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_1_7&amp;id=sorceries_1_7&amp;link=/checklists/sorceries.html%23item_1_7&amp;title=Scholar's Armament"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -496,9 +472,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="sorceries_1_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_1_8&amp;id=sorceries_1_8&amp;link=/checklists/sorceries.html%23item_1_8&amp;title=Scholar's Shield">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_1_8&amp;id=sorceries_1_8&amp;link=/checklists/sorceries.html%23item_1_8&amp;title=Scholar's Shield"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -531,9 +505,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="sorceries_1_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_1_9&amp;id=sorceries_1_9&amp;link=/checklists/sorceries.html%23item_1_9&amp;title=Carian Slicer">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_1_9&amp;id=sorceries_1_9&amp;link=/checklists/sorceries.html%23item_1_9&amp;title=Carian Slicer"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -566,9 +538,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="sorceries_1_10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_1_10&amp;id=sorceries_1_10&amp;link=/checklists/sorceries.html%23item_1_10&amp;title=Glintblade Phalanx">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_1_10&amp;id=sorceries_1_10&amp;link=/checklists/sorceries.html%23item_1_10&amp;title=Glintblade Phalanx"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -602,9 +572,7 @@
         <div class="card shadow-sm mb-3" id="sorceries_section_1">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#sorceries_1Col" data-bs-toggle="collapse" href="#sorceries_1Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#sorceries_1Col" data-bs-toggle="collapse" href="#sorceries_1Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Weeping Peninsula</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="sorceries_totals_1"></span>
             </h4>
@@ -616,9 +584,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -647,9 +613,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="sorceries_2_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_2_1&amp;id=sorceries_2_1&amp;link=/checklists/sorceries.html%23item_2_1&amp;title=Ambush Shard">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_2_1&amp;id=sorceries_2_1&amp;link=/checklists/sorceries.html%23item_2_1&amp;title=Ambush Shard"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -682,9 +646,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="sorceries_2_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_2_2&amp;id=sorceries_2_2&amp;link=/checklists/sorceries.html%23item_2_2&amp;title=Crystal Burst">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_2_2&amp;id=sorceries_2_2&amp;link=/checklists/sorceries.html%23item_2_2&amp;title=Crystal Burst"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -718,9 +680,7 @@
         <div class="card shadow-sm mb-3" id="sorceries_section_2">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#sorceries_2Col" data-bs-toggle="collapse" href="#sorceries_2Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#sorceries_2Col" data-bs-toggle="collapse" href="#sorceries_2Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Stormveil</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="sorceries_totals_2"></span>
             </h4>
@@ -732,9 +692,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -763,9 +721,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="sorceries_3_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_3_1&amp;id=sorceries_3_1&amp;link=/checklists/sorceries.html%23item_3_1&amp;title=Rancorcall">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_3_1&amp;id=sorceries_3_1&amp;link=/checklists/sorceries.html%23item_3_1&amp;title=Rancorcall"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -799,9 +755,7 @@
         <div class="card shadow-sm mb-3" id="sorceries_section_3">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#sorceries_3Col" data-bs-toggle="collapse" href="#sorceries_3Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#sorceries_3Col" data-bs-toggle="collapse" href="#sorceries_3Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Liurnia Lake Part 1</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="sorceries_totals_3"></span>
             </h4>
@@ -813,9 +767,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -844,9 +796,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="sorceries_4_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_4_1&amp;id=sorceries_4_1&amp;link=/checklists/sorceries.html%23item_4_1&amp;title=Starlight">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_4_1&amp;id=sorceries_4_1&amp;link=/checklists/sorceries.html%23item_4_1&amp;title=Starlight"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -879,9 +829,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="sorceries_4_18" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_4_18&amp;id=sorceries_4_18&amp;link=/checklists/sorceries.html%23item_4_18&amp;title=Great Glintstone Shard">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_4_18&amp;id=sorceries_4_18&amp;link=/checklists/sorceries.html%23item_4_18&amp;title=Great Glintstone Shard"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -914,9 +862,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="sorceries_4_19" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_4_19&amp;id=sorceries_4_19&amp;link=/checklists/sorceries.html%23item_4_19&amp;title=Swift Glintstone Shard">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_4_19&amp;id=sorceries_4_19&amp;link=/checklists/sorceries.html%23item_4_19&amp;title=Swift Glintstone Shard"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -949,9 +895,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="sorceries_4_20" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_4_20&amp;id=sorceries_4_20&amp;link=/checklists/sorceries.html%23item_4_20&amp;title=Carian Greatsword">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_4_20&amp;id=sorceries_4_20&amp;link=/checklists/sorceries.html%23item_4_20&amp;title=Carian Greatsword"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -984,9 +928,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="sorceries_4_21" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_4_21&amp;id=sorceries_4_21&amp;link=/checklists/sorceries.html%23item_4_21&amp;title=Magic Glintblade">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_4_21&amp;id=sorceries_4_21&amp;link=/checklists/sorceries.html%23item_4_21&amp;title=Magic Glintblade"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1019,9 +961,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="sorceries_4_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_4_4&amp;id=sorceries_4_4&amp;link=/checklists/sorceries.html%23item_4_4&amp;title=Ancient Death Rancor">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_4_4&amp;id=sorceries_4_4&amp;link=/checklists/sorceries.html%23item_4_4&amp;title=Ancient Death Rancor"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1054,9 +994,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="sorceries_4_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_4_5&amp;id=sorceries_4_5&amp;link=/checklists/sorceries.html%23item_4_5&amp;title=Briars of Sin">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_4_5&amp;id=sorceries_4_5&amp;link=/checklists/sorceries.html%23item_4_5&amp;title=Briars of Sin"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1089,9 +1027,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="sorceries_4_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_4_6&amp;id=sorceries_4_6&amp;link=/checklists/sorceries.html%23item_4_6&amp;title=Greatblade Phalanx">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_4_6&amp;id=sorceries_4_6&amp;link=/checklists/sorceries.html%23item_4_6&amp;title=Greatblade Phalanx"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1124,9 +1060,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="sorceries_4_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_4_7&amp;id=sorceries_4_7&amp;link=/checklists/sorceries.html%23item_4_7&amp;title=Magic Downpour">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_4_7&amp;id=sorceries_4_7&amp;link=/checklists/sorceries.html%23item_4_7&amp;title=Magic Downpour"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1159,9 +1093,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="sorceries_4_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_4_8&amp;id=sorceries_4_8&amp;link=/checklists/sorceries.html%23item_4_8&amp;title=Meteorite">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_4_8&amp;id=sorceries_4_8&amp;link=/checklists/sorceries.html%23item_4_8&amp;title=Meteorite"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1194,9 +1126,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="sorceries_4_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_4_9&amp;id=sorceries_4_9&amp;link=/checklists/sorceries.html%23item_4_9&amp;title=Shatter Earth">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_4_9&amp;id=sorceries_4_9&amp;link=/checklists/sorceries.html%23item_4_9&amp;title=Shatter Earth"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1229,9 +1159,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="sorceries_4_22" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_4_22&amp;id=sorceries_4_22&amp;link=/checklists/sorceries.html%23item_4_22&amp;title=Crystal Release">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_4_22&amp;id=sorceries_4_22&amp;link=/checklists/sorceries.html%23item_4_22&amp;title=Crystal Release"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1264,9 +1192,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="sorceries_4_23" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_4_23&amp;id=sorceries_4_23&amp;link=/checklists/sorceries.html%23item_4_23&amp;title=Terra Magica">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_4_23&amp;id=sorceries_4_23&amp;link=/checklists/sorceries.html%23item_4_23&amp;title=Terra Magica"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1299,9 +1225,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="sorceries_4_11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_4_11&amp;id=sorceries_4_11&amp;link=/checklists/sorceries.html%23item_4_11&amp;title=Carian Piercer">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_4_11&amp;id=sorceries_4_11&amp;link=/checklists/sorceries.html%23item_4_11&amp;title=Carian Piercer"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1334,9 +1258,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="sorceries_4_12" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_4_12&amp;id=sorceries_4_12&amp;link=/checklists/sorceries.html%23item_4_12&amp;title=Loretta's Greatbow">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_4_12&amp;id=sorceries_4_12&amp;link=/checklists/sorceries.html%23item_4_12&amp;title=Loretta's Greatbow"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1369,9 +1291,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="sorceries_4_13" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_4_13&amp;id=sorceries_4_13&amp;link=/checklists/sorceries.html%23item_4_13&amp;title=Frozen Armament">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_4_13&amp;id=sorceries_4_13&amp;link=/checklists/sorceries.html%23item_4_13&amp;title=Frozen Armament"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1404,9 +1324,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="sorceries_4_24" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_4_24&amp;id=sorceries_4_24&amp;link=/checklists/sorceries.html%23item_4_24&amp;title=Carian Phalanx">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_4_24&amp;id=sorceries_4_24&amp;link=/checklists/sorceries.html%23item_4_24&amp;title=Carian Phalanx"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1439,9 +1357,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="sorceries_4_25" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_4_25&amp;id=sorceries_4_25&amp;link=/checklists/sorceries.html%23item_4_25&amp;title=Carian Retaliation">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_4_25&amp;id=sorceries_4_25&amp;link=/checklists/sorceries.html%23item_4_25&amp;title=Carian Retaliation"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1474,9 +1390,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="sorceries_4_26" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_4_26&amp;id=sorceries_4_26&amp;link=/checklists/sorceries.html%23item_4_26&amp;title=Freezing Mist">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_4_26&amp;id=sorceries_4_26&amp;link=/checklists/sorceries.html%23item_4_26&amp;title=Freezing Mist"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1509,9 +1423,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="sorceries_4_27" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_4_27&amp;id=sorceries_4_27&amp;link=/checklists/sorceries.html%23item_4_27&amp;title=Glintstone Icecrag">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_4_27&amp;id=sorceries_4_27&amp;link=/checklists/sorceries.html%23item_4_27&amp;title=Glintstone Icecrag"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1544,9 +1456,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="sorceries_4_28" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_4_28&amp;id=sorceries_4_28&amp;link=/checklists/sorceries.html%23item_4_28&amp;title=Cannon of Haima">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_4_28&amp;id=sorceries_4_28&amp;link=/checklists/sorceries.html%23item_4_28&amp;title=Cannon of Haima"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1579,9 +1489,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="sorceries_4_29" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_4_29&amp;id=sorceries_4_29&amp;link=/checklists/sorceries.html%23item_4_29&amp;title=Gavel of Haima">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_4_29&amp;id=sorceries_4_29&amp;link=/checklists/sorceries.html%23item_4_29&amp;title=Gavel of Haima"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1614,9 +1522,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="sorceries_4_16" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_4_16&amp;id=sorceries_4_16&amp;link=/checklists/sorceries.html%23item_4_16&amp;title=Thops's Barrier">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_4_16&amp;id=sorceries_4_16&amp;link=/checklists/sorceries.html%23item_4_16&amp;title=Thops's Barrier"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1649,9 +1555,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="sorceries_4_17" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_4_17&amp;id=sorceries_4_17&amp;link=/checklists/sorceries.html%23item_4_17&amp;title=Shard Spiral">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_4_17&amp;id=sorceries_4_17&amp;link=/checklists/sorceries.html%23item_4_17&amp;title=Shard Spiral"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1685,9 +1589,7 @@
         <div class="card shadow-sm mb-3" id="sorceries_section_4">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#sorceries_4Col" data-bs-toggle="collapse" href="#sorceries_4Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#sorceries_4Col" data-bs-toggle="collapse" href="#sorceries_4Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Liurnia Lake Part 2: After Ranni's Questline</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="sorceries_totals_4"></span>
             </h4>
@@ -1699,9 +1601,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -1730,9 +1630,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="sorceries_5_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_5_1&amp;id=sorceries_5_1&amp;link=/checklists/sorceries.html%23item_5_1&amp;title=Adula's Moonblade">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_5_1&amp;id=sorceries_5_1&amp;link=/checklists/sorceries.html%23item_5_1&amp;title=Adula's Moonblade"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1765,9 +1663,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="sorceries_5_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_5_2&amp;id=sorceries_5_2&amp;link=/checklists/sorceries.html%23item_5_2&amp;title=Lucidity">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_5_2&amp;id=sorceries_5_2&amp;link=/checklists/sorceries.html%23item_5_2&amp;title=Lucidity"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1800,9 +1696,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="sorceries_5_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_5_3&amp;id=sorceries_5_3&amp;link=/checklists/sorceries.html%23item_5_3&amp;title=Ranni's Dark Moon">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_5_3&amp;id=sorceries_5_3&amp;link=/checklists/sorceries.html%23item_5_3&amp;title=Ranni's Dark Moon"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1836,9 +1730,7 @@
         <div class="card shadow-sm mb-3" id="sorceries_section_5">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#sorceries_5Col" data-bs-toggle="collapse" href="#sorceries_5Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#sorceries_5Col" data-bs-toggle="collapse" href="#sorceries_5Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Raya Lucaria</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="sorceries_totals_5"></span>
             </h4>
@@ -1850,9 +1742,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -1881,9 +1771,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="sorceries_6_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_6_1&amp;id=sorceries_6_1&amp;link=/checklists/sorceries.html%23item_6_1&amp;title=Gravity Well">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_6_1&amp;id=sorceries_6_1&amp;link=/checklists/sorceries.html%23item_6_1&amp;title=Gravity Well"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1916,9 +1804,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="sorceries_6_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_6_6&amp;id=sorceries_6_6&amp;link=/checklists/sorceries.html%23item_6_6&amp;title=Glintstone Cometshard">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_6_6&amp;id=sorceries_6_6&amp;link=/checklists/sorceries.html%23item_6_6&amp;title=Glintstone Cometshard"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1951,9 +1837,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="sorceries_6_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_6_7&amp;id=sorceries_6_7&amp;link=/checklists/sorceries.html%23item_6_7&amp;title=Star Shower">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_6_7&amp;id=sorceries_6_7&amp;link=/checklists/sorceries.html%23item_6_7&amp;title=Star Shower"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1986,9 +1870,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="sorceries_6_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_6_3&amp;id=sorceries_6_3&amp;link=/checklists/sorceries.html%23item_6_3&amp;title=Comet">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_6_3&amp;id=sorceries_6_3&amp;link=/checklists/sorceries.html%23item_6_3&amp;title=Comet"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2021,9 +1903,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="sorceries_6_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_6_4&amp;id=sorceries_6_4&amp;link=/checklists/sorceries.html%23item_6_4&amp;title=Shattering Crystal">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_6_4&amp;id=sorceries_6_4&amp;link=/checklists/sorceries.html%23item_6_4&amp;title=Shattering Crystal"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2056,9 +1936,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="sorceries_6_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_6_5&amp;id=sorceries_6_5&amp;link=/checklists/sorceries.html%23item_6_5&amp;title=Rennala's Full Moon">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_6_5&amp;id=sorceries_6_5&amp;link=/checklists/sorceries.html%23item_6_5&amp;title=Rennala's Full Moon"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2092,9 +1970,7 @@
         <div class="card shadow-sm mb-3" id="sorceries_section_6">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#sorceries_6Col" data-bs-toggle="collapse" href="#sorceries_6Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#sorceries_6Col" data-bs-toggle="collapse" href="#sorceries_6Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Siofra River Well Underground</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="sorceries_totals_6"></span>
             </h4>
@@ -2106,9 +1982,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -2137,9 +2011,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="sorceries_7_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_7_1&amp;id=sorceries_7_1&amp;link=/checklists/sorceries.html%23item_7_1&amp;title=Oracle Bubbles">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_7_1&amp;id=sorceries_7_1&amp;link=/checklists/sorceries.html%23item_7_1&amp;title=Oracle Bubbles"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2172,9 +2044,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="sorceries_7_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_7_2&amp;id=sorceries_7_2&amp;link=/checklists/sorceries.html%23item_7_2&amp;title=Great Oracular Bubble">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_7_2&amp;id=sorceries_7_2&amp;link=/checklists/sorceries.html%23item_7_2&amp;title=Great Oracular Bubble"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2208,9 +2078,7 @@
         <div class="card shadow-sm mb-3" id="sorceries_section_7">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#sorceries_7Col" data-bs-toggle="collapse" href="#sorceries_7Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#sorceries_7Col" data-bs-toggle="collapse" href="#sorceries_7Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Caelid</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="sorceries_totals_7"></span>
             </h4>
@@ -2222,9 +2090,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -2253,9 +2119,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="sorceries_8_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_8_1&amp;id=sorceries_8_1&amp;link=/checklists/sorceries.html%23item_8_1&amp;title=Rock Sling">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_8_1&amp;id=sorceries_8_1&amp;link=/checklists/sorceries.html%23item_8_1&amp;title=Rock Sling"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2288,9 +2152,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="sorceries_8_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_8_2&amp;id=sorceries_8_2&amp;link=/checklists/sorceries.html%23item_8_2&amp;title=Rock Blaster">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_8_2&amp;id=sorceries_8_2&amp;link=/checklists/sorceries.html%23item_8_2&amp;title=Rock Blaster"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2323,9 +2185,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="sorceries_8_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_8_3&amp;id=sorceries_8_3&amp;link=/checklists/sorceries.html%23item_8_3&amp;title=Night Comet">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_8_3&amp;id=sorceries_8_3&amp;link=/checklists/sorceries.html%23item_8_3&amp;title=Night Comet"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2358,9 +2218,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="sorceries_8_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_8_4&amp;id=sorceries_8_4&amp;link=/checklists/sorceries.html%23item_8_4&amp;title=Crystal Torrent">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_8_4&amp;id=sorceries_8_4&amp;link=/checklists/sorceries.html%23item_8_4&amp;title=Crystal Torrent"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2393,9 +2251,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="sorceries_8_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_8_5&amp;id=sorceries_8_5&amp;link=/checklists/sorceries.html%23item_8_5&amp;title=Eternal Darkness">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_8_5&amp;id=sorceries_8_5&amp;link=/checklists/sorceries.html%23item_8_5&amp;title=Eternal Darkness"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2428,9 +2284,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="sorceries_8_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_8_9&amp;id=sorceries_8_9&amp;link=/checklists/sorceries.html%23item_8_9&amp;title=Night Maiden's Mist">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_8_9&amp;id=sorceries_8_9&amp;link=/checklists/sorceries.html%23item_8_9&amp;title=Night Maiden's Mist"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2463,9 +2317,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="sorceries_8_10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_8_10&amp;id=sorceries_8_10&amp;link=/checklists/sorceries.html%23item_8_10&amp;title=Night Shard">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_8_10&amp;id=sorceries_8_10&amp;link=/checklists/sorceries.html%23item_8_10&amp;title=Night Shard"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2498,9 +2350,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="sorceries_8_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_8_7&amp;id=sorceries_8_7&amp;link=/checklists/sorceries.html%23item_8_7&amp;title=Collapsing Stars">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_8_7&amp;id=sorceries_8_7&amp;link=/checklists/sorceries.html%23item_8_7&amp;title=Collapsing Stars"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2533,9 +2383,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="sorceries_8_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_8_8&amp;id=sorceries_8_8&amp;link=/checklists/sorceries.html%23item_8_8&amp;title=Stars of Ruin">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_8_8&amp;id=sorceries_8_8&amp;link=/checklists/sorceries.html%23item_8_8&amp;title=Stars of Ruin"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2569,9 +2417,7 @@
         <div class="card shadow-sm mb-3" id="sorceries_section_8">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#sorceries_8Col" data-bs-toggle="collapse" href="#sorceries_8Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#sorceries_8Col" data-bs-toggle="collapse" href="#sorceries_8Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Mt. Gelmir</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="sorceries_totals_8"></span>
             </h4>
@@ -2583,9 +2429,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -2614,9 +2458,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="sorceries_9_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_9_1&amp;id=sorceries_9_1&amp;link=/checklists/sorceries.html%23item_9_1&amp;title=Magma Shot">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_9_1&amp;id=sorceries_9_1&amp;link=/checklists/sorceries.html%23item_9_1&amp;title=Magma Shot"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2649,9 +2491,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="sorceries_9_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_9_2&amp;id=sorceries_9_2&amp;link=/checklists/sorceries.html%23item_9_2&amp;title=Tibia's Summons">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_9_2&amp;id=sorceries_9_2&amp;link=/checklists/sorceries.html%23item_9_2&amp;title=Tibia's Summons"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2684,9 +2524,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="sorceries_9_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_9_3&amp;id=sorceries_9_3&amp;link=/checklists/sorceries.html%23item_9_3&amp;title=Roiling Magma">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_9_3&amp;id=sorceries_9_3&amp;link=/checklists/sorceries.html%23item_9_3&amp;title=Roiling Magma"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2719,9 +2557,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="sorceries_9_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_9_4&amp;id=sorceries_9_4&amp;link=/checklists/sorceries.html%23item_9_4&amp;title=Comet Azur">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_9_4&amp;id=sorceries_9_4&amp;link=/checklists/sorceries.html%23item_9_4&amp;title=Comet Azur"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2754,9 +2590,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="sorceries_9_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_9_5&amp;id=sorceries_9_5&amp;link=/checklists/sorceries.html%23item_9_5&amp;title=Gelmir's Fury">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_9_5&amp;id=sorceries_9_5&amp;link=/checklists/sorceries.html%23item_9_5&amp;title=Gelmir's Fury"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2789,9 +2623,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="sorceries_9_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_9_6&amp;id=sorceries_9_6&amp;link=/checklists/sorceries.html%23item_9_6&amp;title=Rykard's Rancor">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_9_6&amp;id=sorceries_9_6&amp;link=/checklists/sorceries.html%23item_9_6&amp;title=Rykard's Rancor"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2825,9 +2657,7 @@
         <div class="card shadow-sm mb-3" id="sorceries_section_9">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#sorceries_9Col" data-bs-toggle="collapse" href="#sorceries_9Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#sorceries_9Col" data-bs-toggle="collapse" href="#sorceries_9Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Altus Plateau</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="sorceries_totals_9"></span>
             </h4>
@@ -2839,9 +2669,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -2870,9 +2698,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="sorceries_10_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_10_2&amp;id=sorceries_10_2&amp;link=/checklists/sorceries.html%23item_10_2&amp;title=Unseen Blade">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_10_2&amp;id=sorceries_10_2&amp;link=/checklists/sorceries.html%23item_10_2&amp;title=Unseen Blade"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2905,9 +2731,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="sorceries_10_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_10_3&amp;id=sorceries_10_3&amp;link=/checklists/sorceries.html%23item_10_3&amp;title=Unseen Form">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_10_3&amp;id=sorceries_10_3&amp;link=/checklists/sorceries.html%23item_10_3&amp;title=Unseen Form"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2941,9 +2765,7 @@
         <div class="card shadow-sm mb-3" id="sorceries_section_10">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#sorceries_10Col" data-bs-toggle="collapse" href="#sorceries_10Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#sorceries_10Col" data-bs-toggle="collapse" href="#sorceries_10Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Deeproot Depths</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="sorceries_totals_10"></span>
             </h4>
@@ -2955,9 +2777,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -2986,9 +2806,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="10" id="sorceries_11_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_11_1&amp;id=sorceries_11_1&amp;link=/checklists/sorceries.html%23item_11_1&amp;title=Fia's Mist">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_11_1&amp;id=sorceries_11_1&amp;link=/checklists/sorceries.html%23item_11_1&amp;title=Fia's Mist"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3022,9 +2840,7 @@
         <div class="card shadow-sm mb-3" id="sorceries_section_11">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#sorceries_11Col" data-bs-toggle="collapse" href="#sorceries_11Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#sorceries_11Col" data-bs-toggle="collapse" href="#sorceries_11Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Mountaintops of the Giants</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="sorceries_totals_11"></span>
             </h4>
@@ -3036,9 +2852,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -3067,9 +2881,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="11" id="sorceries_12_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_12_1&amp;id=sorceries_12_1&amp;link=/checklists/sorceries.html%23item_12_1&amp;title=Zamor Ice Storms">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_12_1&amp;id=sorceries_12_1&amp;link=/checklists/sorceries.html%23item_12_1&amp;title=Zamor Ice Storms"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3102,9 +2914,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="11" id="sorceries_12_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_12_2&amp;id=sorceries_12_2&amp;link=/checklists/sorceries.html%23item_12_2&amp;title=Briars of Punishment">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_12_2&amp;id=sorceries_12_2&amp;link=/checklists/sorceries.html%23item_12_2&amp;title=Briars of Punishment"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3137,9 +2947,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="11" id="sorceries_12_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_12_3&amp;id=sorceries_12_3&amp;link=/checklists/sorceries.html%23item_12_3&amp;title=Founding Rain of Stars">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_12_3&amp;id=sorceries_12_3&amp;link=/checklists/sorceries.html%23item_12_3&amp;title=Founding Rain of Stars"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3172,9 +2980,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="11" id="sorceries_12_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_12_4&amp;id=sorceries_12_4&amp;link=/checklists/sorceries.html%23item_12_4&amp;title=Explosive Ghostflame">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_12_4&amp;id=sorceries_12_4&amp;link=/checklists/sorceries.html%23item_12_4&amp;title=Explosive Ghostflame"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3207,9 +3013,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="11" id="sorceries_12_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_12_5&amp;id=sorceries_12_5&amp;link=/checklists/sorceries.html%23item_12_5&amp;title=Meteorite of Astel">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_12_5&amp;id=sorceries_12_5&amp;link=/checklists/sorceries.html%23item_12_5&amp;title=Meteorite of Astel"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3243,9 +3047,7 @@
         <div class="card shadow-sm mb-3" id="sorceries_section_12">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#sorceries_12Col" data-bs-toggle="collapse" href="#sorceries_12Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#sorceries_12Col" data-bs-toggle="collapse" href="#sorceries_12Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Miquella's Haligtree</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="sorceries_totals_12"></span>
             </h4>
@@ -3257,9 +3059,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -3288,9 +3088,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="sorceries_13_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_13_1&amp;id=sorceries_13_1&amp;link=/checklists/sorceries.html%23item_13_1&amp;title=Loretta's Mastery">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_13_1&amp;id=sorceries_13_1&amp;link=/checklists/sorceries.html%23item_13_1&amp;title=Loretta's Mastery"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3324,9 +3122,7 @@
         <div class="card shadow-sm mb-3" id="sorceries_section_13">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#sorceries_13Col" data-bs-toggle="collapse" href="#sorceries_13Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#sorceries_13Col" data-bs-toggle="collapse" href="#sorceries_13Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Realm of Shadow</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="sorceries_totals_13"></span>
             </h4>
@@ -3338,9 +3134,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -3369,9 +3163,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="13" id="sorceries_20_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_20_1&amp;id=sorceries_20_1&amp;link=/checklists/sorceries.html%23item_20_1&amp;title=Miriam's Vanishing">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_20_1&amp;id=sorceries_20_1&amp;link=/checklists/sorceries.html%23item_20_1&amp;title=Miriam's Vanishing"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3404,9 +3196,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="13" id="sorceries_20_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_20_2&amp;id=sorceries_20_2&amp;link=/checklists/sorceries.html%23item_20_2&amp;title=Glintblade Trio">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_20_2&amp;id=sorceries_20_2&amp;link=/checklists/sorceries.html%23item_20_2&amp;title=Glintblade Trio"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3439,9 +3229,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="13" id="sorceries_20_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_20_3&amp;id=sorceries_20_3&amp;link=/checklists/sorceries.html%23item_20_3&amp;title=Rellana's Twin Moons">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_20_3&amp;id=sorceries_20_3&amp;link=/checklists/sorceries.html%23item_20_3&amp;title=Rellana's Twin Moons"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3474,9 +3262,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="13" id="sorceries_20_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_20_4&amp;id=sorceries_20_4&amp;link=/checklists/sorceries.html%23item_20_4&amp;title=Glintstone Nail">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_20_4&amp;id=sorceries_20_4&amp;link=/checklists/sorceries.html%23item_20_4&amp;title=Glintstone Nail"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3509,9 +3295,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="13" id="sorceries_20_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_20_5&amp;id=sorceries_20_5&amp;link=/checklists/sorceries.html%23item_20_5&amp;title=Glintstone Nails">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_20_5&amp;id=sorceries_20_5&amp;link=/checklists/sorceries.html%23item_20_5&amp;title=Glintstone Nails"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3544,9 +3328,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="13" id="sorceries_20_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_20_6&amp;id=sorceries_20_6&amp;link=/checklists/sorceries.html%23item_20_6&amp;title=Blades of Stone">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_20_6&amp;id=sorceries_20_6&amp;link=/checklists/sorceries.html%23item_20_6&amp;title=Blades of Stone"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3579,9 +3361,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="13" id="sorceries_20_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_20_7&amp;id=sorceries_20_7&amp;link=/checklists/sorceries.html%23item_20_7&amp;title=Gravitational Missile">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_20_7&amp;id=sorceries_20_7&amp;link=/checklists/sorceries.html%23item_20_7&amp;title=Gravitational Missile"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3614,9 +3394,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="13" id="sorceries_20_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_20_8&amp;id=sorceries_20_8&amp;link=/checklists/sorceries.html%23item_20_8&amp;title=Mantle of Thorns">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_20_8&amp;id=sorceries_20_8&amp;link=/checklists/sorceries.html%23item_20_8&amp;title=Mantle of Thorns"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3649,9 +3427,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="13" id="sorceries_20_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_20_9&amp;id=sorceries_20_9&amp;link=/checklists/sorceries.html%23item_20_9&amp;title=Impenetrable Thorns">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_20_9&amp;id=sorceries_20_9&amp;link=/checklists/sorceries.html%23item_20_9&amp;title=Impenetrable Thorns"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3684,9 +3460,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="13" id="sorceries_20_10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_20_10&amp;id=sorceries_20_10&amp;link=/checklists/sorceries.html%23item_20_10&amp;title=Rings of Spectral Light">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_20_10&amp;id=sorceries_20_10&amp;link=/checklists/sorceries.html%23item_20_10&amp;title=Rings of Spectral Light"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3719,9 +3493,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="13" id="sorceries_20_11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_20_11&amp;id=sorceries_20_11&amp;link=/checklists/sorceries.html%23item_20_11&amp;title=Vortex of Putrescence">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_20_11&amp;id=sorceries_20_11&amp;link=/checklists/sorceries.html%23item_20_11&amp;title=Vortex of Putrescence"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3754,9 +3526,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="13" id="sorceries_20_12" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_20_12&amp;id=sorceries_20_12&amp;link=/checklists/sorceries.html%23item_20_12&amp;title=Mass of Putrescence">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_20_12&amp;id=sorceries_20_12&amp;link=/checklists/sorceries.html%23item_20_12&amp;title=Mass of Putrescence"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3789,9 +3559,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="13" id="sorceries_20_13" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_20_13&amp;id=sorceries_20_13&amp;link=/checklists/sorceries.html%23item_20_13&amp;title=Fleeting Microcosm">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_20_13&amp;id=sorceries_20_13&amp;link=/checklists/sorceries.html%23item_20_13&amp;title=Fleeting Microcosm"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3824,9 +3592,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="13" id="sorceries_20_14" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=sorceries_20_14&amp;id=sorceries_20_14&amp;link=/checklists/sorceries.html%23item_20_14&amp;title=Cherishing Fingers">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=sorceries_20_14&amp;id=sorceries_20_14&amp;link=/checklists/sorceries.html%23item_20_14&amp;title=Cherishing Fingers"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">

--- a/docs/checklists/spirit_ashes.html
+++ b/docs/checklists/spirit_ashes.html
@@ -27,14 +27,10 @@
         <a class="navbar-brand me-auto ms-2" href="/index.html">Roundtable Guides</a>
         <form class="d-none d-sm-flex order-2 order-xl-3">
           <input aria-label="search" class="form-control me-2" name="search" placeholder="Search" type="search">
-          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit">
-            <i class="bi bi-search"></i>
-          </button>
+          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit"><i class="bi bi-search"></i></button>
         </form>
         <div class="d-sm-none order-2">
-          <a class="nav-link me-0" href="/search.html">
-            <i class="bi bi-search sb-icon-search"></i>
-          </a>
+          <a class="nav-link me-0" href="/search.html"><i class="bi bi-search sb-icon-search"></i></a>
         </div>
         <div class="collapse navbar-collapse order-3 order-xl-2 ms-xl-2" id="nav-collapse">
           <ul class="nav navbar-nav navbar-nav-scroll mr-auto">
@@ -179,14 +175,10 @@
               </ul>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/map.html">
-                <i class="bi bi-map"></i> Map
-              </a>
+              <a class="nav-link hide-buttons" href="/map.html"><i class="bi bi-map"></i> Map</a>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/options.html">
-                <i class="bi bi-gear-fill"></i> Options
-              </a>
+              <a class="nav-link hide-buttons" href="/options.html"><i class="bi bi-gear-fill"></i> Options</a>
             </li>
           </ul>
         </div>
@@ -206,9 +198,7 @@
       </div>
       <nav class="text-muted toc d-print-none">
         <strong class="d-block h5">
-          <a class="toc-button" data-bs-toggle="collapse" href="#toc_spirit_ashes" role="button">
-            <i class="bi bi-plus-lg"></i>Table Of Contents
-          </a>
+          <a class="toc-button" data-bs-toggle="collapse" href="#toc_spirit_ashes" role="button"><i class="bi bi-plus-lg"></i>Table Of Contents</a>
         </strong>
         <ul class="toc_page collapse" id="toc_spirit_ashes">
           <li>
@@ -284,9 +274,7 @@
         <div class="card shadow-sm mb-3" id="spirit_ashes_section_0">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#spirit_ashes_0Col" data-bs-toggle="collapse" href="#spirit_ashes_0Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#spirit_ashes_0Col" data-bs-toggle="collapse" href="#spirit_ashes_0Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Limgrave</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="spirit_ashes_totals_0"></span>
             </h4>
@@ -298,9 +286,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -324,9 +310,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="spirit_ashes_2_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_2_1&amp;id=spirit_ashes_2_1&amp;link=/checklists/spirit_ashes.html%23item_2_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Banished+Knight+Engvall+Ashes&quot;&gt;Banished Knight Engvall Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_2_1&amp;id=spirit_ashes_2_1&amp;link=/checklists/spirit_ashes.html%23item_2_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Banished+Knight+Engvall+Ashes&quot;&gt;Banished Knight Engvall Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -355,9 +339,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="spirit_ashes_2_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_2_2&amp;id=spirit_ashes_2_2&amp;link=/checklists/spirit_ashes.html%23item_2_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Banished+Knight+Oleg+Ashes&quot;&gt;Banished Knight Oleg Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_2_2&amp;id=spirit_ashes_2_2&amp;link=/checklists/spirit_ashes.html%23item_2_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Banished+Knight+Oleg+Ashes&quot;&gt;Banished Knight Oleg Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -386,9 +368,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="spirit_ashes_2_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_2_3&amp;id=spirit_ashes_2_3&amp;link=/checklists/spirit_ashes.html%23item_2_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Godrick+Soldier+Ashes&quot;&gt;Godrick Soldier Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_2_3&amp;id=spirit_ashes_2_3&amp;link=/checklists/spirit_ashes.html%23item_2_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Godrick+Soldier+Ashes&quot;&gt;Godrick Soldier Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -417,9 +397,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="spirit_ashes_2_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_2_4&amp;id=spirit_ashes_2_4&amp;link=/checklists/spirit_ashes.html%23item_2_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Lone+Wolf+Ashes&quot;&gt;Lone Wolf Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_2_4&amp;id=spirit_ashes_2_4&amp;link=/checklists/spirit_ashes.html%23item_2_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Lone+Wolf+Ashes&quot;&gt;Lone Wolf Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -448,9 +426,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="spirit_ashes_2_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_2_5&amp;id=spirit_ashes_2_5&amp;link=/checklists/spirit_ashes.html%23item_2_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Noble+Sorcerer+Ashes&quot;&gt;Noble Sorcerer Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_2_5&amp;id=spirit_ashes_2_5&amp;link=/checklists/spirit_ashes.html%23item_2_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Noble+Sorcerer+Ashes&quot;&gt;Noble Sorcerer Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -479,9 +455,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="spirit_ashes_2_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_2_6&amp;id=spirit_ashes_2_6&amp;link=/checklists/spirit_ashes.html%23item_2_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Skeletal+Militiaman+Ashes&quot;&gt;Skeletal Militiaman Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_2_6&amp;id=spirit_ashes_2_6&amp;link=/checklists/spirit_ashes.html%23item_2_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Skeletal+Militiaman+Ashes&quot;&gt;Skeletal Militiaman Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -510,9 +484,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="spirit_ashes_2_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_2_7&amp;id=spirit_ashes_2_7&amp;link=/checklists/spirit_ashes.html%23item_2_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Spirit+Jellyfish+Ashes&quot;&gt;Spirit Jellyfish Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_2_7&amp;id=spirit_ashes_2_7&amp;link=/checklists/spirit_ashes.html%23item_2_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Spirit+Jellyfish+Ashes&quot;&gt;Spirit Jellyfish Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -541,9 +513,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="spirit_ashes_2_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_2_8&amp;id=spirit_ashes_2_8&amp;link=/checklists/spirit_ashes.html%23item_2_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Stormhawk+Deenh&quot;&gt;Stormhawk Deenh&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_2_8&amp;id=spirit_ashes_2_8&amp;link=/checklists/spirit_ashes.html%23item_2_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Stormhawk+Deenh&quot;&gt;Stormhawk Deenh&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -572,9 +542,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="spirit_ashes_2_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_2_9&amp;id=spirit_ashes_2_9&amp;link=/checklists/spirit_ashes.html%23item_2_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Wandering+Noble+Ashes&quot;&gt;Wandering Noble Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_2_9&amp;id=spirit_ashes_2_9&amp;link=/checklists/spirit_ashes.html%23item_2_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Wandering+Noble+Ashes&quot;&gt;Wandering Noble Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -604,9 +572,7 @@
         <div class="card shadow-sm mb-3" id="spirit_ashes_section_1">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#spirit_ashes_1Col" data-bs-toggle="collapse" href="#spirit_ashes_1Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#spirit_ashes_1Col" data-bs-toggle="collapse" href="#spirit_ashes_1Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Weeping Peninsula</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="spirit_ashes_totals_1"></span>
             </h4>
@@ -618,9 +584,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -644,9 +608,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="spirit_ashes_1_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_1_1&amp;id=spirit_ashes_1_1&amp;link=/checklists/spirit_ashes.html%23item_1_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Demi-Human+Ashes&quot;&gt;Demi-Human Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_1_1&amp;id=spirit_ashes_1_1&amp;link=/checklists/spirit_ashes.html%23item_1_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Demi-Human+Ashes&quot;&gt;Demi-Human Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -675,9 +637,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="spirit_ashes_1_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_1_2&amp;id=spirit_ashes_1_2&amp;link=/checklists/spirit_ashes.html%23item_1_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Lhutel+the+Headless&quot;&gt;Lhutel the Headless&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_1_2&amp;id=spirit_ashes_1_2&amp;link=/checklists/spirit_ashes.html%23item_1_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Lhutel+the+Headless&quot;&gt;Lhutel the Headless&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -706,9 +666,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="spirit_ashes_1_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_1_3&amp;id=spirit_ashes_1_3&amp;link=/checklists/spirit_ashes.html%23item_1_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Warhawk+Ashes&quot;&gt;Warhawk Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_1_3&amp;id=spirit_ashes_1_3&amp;link=/checklists/spirit_ashes.html%23item_1_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Warhawk+Ashes&quot;&gt;Warhawk Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -738,9 +696,7 @@
         <div class="card shadow-sm mb-3" id="spirit_ashes_section_2">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#spirit_ashes_2Col" data-bs-toggle="collapse" href="#spirit_ashes_2Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#spirit_ashes_2Col" data-bs-toggle="collapse" href="#spirit_ashes_2Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Liurnia of the Lakes</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="spirit_ashes_totals_2"></span>
             </h4>
@@ -752,9 +708,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -778,9 +732,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="spirit_ashes_3_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_3_1&amp;id=spirit_ashes_3_1&amp;link=/checklists/spirit_ashes.html%23item_3_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Albinauric+Ashes&quot;&gt;Albinauric Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_3_1&amp;id=spirit_ashes_3_1&amp;link=/checklists/spirit_ashes.html%23item_3_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Albinauric+Ashes&quot;&gt;Albinauric Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -809,9 +761,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="spirit_ashes_3_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_3_2&amp;id=spirit_ashes_3_2&amp;link=/checklists/spirit_ashes.html%23item_3_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Avionette+Soldier+Ashes&quot;&gt;Avionette Soldier Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_3_2&amp;id=spirit_ashes_3_2&amp;link=/checklists/spirit_ashes.html%23item_3_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Avionette+Soldier+Ashes&quot;&gt;Avionette Soldier Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -840,9 +790,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="spirit_ashes_3_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_3_3&amp;id=spirit_ashes_3_3&amp;link=/checklists/spirit_ashes.html%23item_3_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Black+Knife+Tiche+Ashes&quot;&gt;Black Knife Tiche Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_3_3&amp;id=spirit_ashes_3_3&amp;link=/checklists/spirit_ashes.html%23item_3_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Black+Knife+Tiche+Ashes&quot;&gt;Black Knife Tiche Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -871,9 +819,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="spirit_ashes_3_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_3_4&amp;id=spirit_ashes_3_4&amp;link=/checklists/spirit_ashes.html%23item_3_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dolores+the+Sleeping+Arrow+Puppet&quot;&gt;Dolores the Sleeping Arrow Puppet&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_3_4&amp;id=spirit_ashes_3_4&amp;link=/checklists/spirit_ashes.html%23item_3_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dolores+the+Sleeping+Arrow+Puppet&quot;&gt;Dolores the Sleeping Arrow Puppet&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -902,9 +848,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="spirit_ashes_3_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_3_5&amp;id=spirit_ashes_3_5&amp;link=/checklists/spirit_ashes.html%23item_3_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dung+Eater+Puppet&quot;&gt;Dung Eater Puppet&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_3_5&amp;id=spirit_ashes_3_5&amp;link=/checklists/spirit_ashes.html%23item_3_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dung+Eater+Puppet&quot;&gt;Dung Eater Puppet&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -933,9 +877,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="spirit_ashes_3_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_3_6&amp;id=spirit_ashes_3_6&amp;link=/checklists/spirit_ashes.html%23item_3_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Fanged+Imp+Ashes&quot;&gt;Fanged Imp Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_3_6&amp;id=spirit_ashes_3_6&amp;link=/checklists/spirit_ashes.html%23item_3_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Fanged+Imp+Ashes&quot;&gt;Fanged Imp Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -964,9 +906,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="spirit_ashes_3_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_3_7&amp;id=spirit_ashes_3_7&amp;link=/checklists/spirit_ashes.html%23item_3_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Finger+Maiden+Therolina+Puppet&quot;&gt;Finger Maiden Therolina Puppet&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_3_7&amp;id=spirit_ashes_3_7&amp;link=/checklists/spirit_ashes.html%23item_3_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Finger+Maiden+Therolina+Puppet&quot;&gt;Finger Maiden Therolina Puppet&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -995,9 +935,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="spirit_ashes_3_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_3_8&amp;id=spirit_ashes_3_8&amp;link=/checklists/spirit_ashes.html%23item_3_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Glintstone+Sorcerer+Ashes&quot;&gt;Glintstone Sorcerer Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_3_8&amp;id=spirit_ashes_3_8&amp;link=/checklists/spirit_ashes.html%23item_3_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Glintstone+Sorcerer+Ashes&quot;&gt;Glintstone Sorcerer Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1026,9 +964,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="spirit_ashes_3_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_3_9&amp;id=spirit_ashes_3_9&amp;link=/checklists/spirit_ashes.html%23item_3_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Jarwight+Puppet&quot;&gt;Jarwight Puppet&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_3_9&amp;id=spirit_ashes_3_9&amp;link=/checklists/spirit_ashes.html%23item_3_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Jarwight+Puppet&quot;&gt;Jarwight Puppet&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1057,9 +993,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="spirit_ashes_3_10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_3_10&amp;id=spirit_ashes_3_10&amp;link=/checklists/spirit_ashes.html%23item_3_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Kaiden+Sellsword+Ashes&quot;&gt;Kaiden Sellsword Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_3_10&amp;id=spirit_ashes_3_10&amp;link=/checklists/spirit_ashes.html%23item_3_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Kaiden+Sellsword+Ashes&quot;&gt;Kaiden Sellsword Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1088,9 +1022,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="spirit_ashes_3_11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_3_11&amp;id=spirit_ashes_3_11&amp;link=/checklists/spirit_ashes.html%23item_3_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Land+Squirt+Ashes&quot;&gt;Land Squirt Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_3_11&amp;id=spirit_ashes_3_11&amp;link=/checklists/spirit_ashes.html%23item_3_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Land+Squirt+Ashes&quot;&gt;Land Squirt Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1119,9 +1051,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="spirit_ashes_3_12" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_3_12&amp;id=spirit_ashes_3_12&amp;link=/checklists/spirit_ashes.html%23item_3_12&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Latenna+the+Albinauric&quot;&gt;Latenna the Albinauric&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_3_12&amp;id=spirit_ashes_3_12&amp;link=/checklists/spirit_ashes.html%23item_3_12&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Latenna+the+Albinauric&quot;&gt;Latenna the Albinauric&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1150,9 +1080,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="spirit_ashes_3_13" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_3_13&amp;id=spirit_ashes_3_13&amp;link=/checklists/spirit_ashes.html%23item_3_13&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Marionette+Soldier+Ashes&quot;&gt;Marionette Soldier Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_3_13&amp;id=spirit_ashes_3_13&amp;link=/checklists/spirit_ashes.html%23item_3_13&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Marionette+Soldier+Ashes&quot;&gt;Marionette Soldier Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1181,9 +1109,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="spirit_ashes_3_14" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_3_14&amp;id=spirit_ashes_3_14&amp;link=/checklists/spirit_ashes.html%23item_3_14&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Nepheli+Loux+Puppet&quot;&gt;Nepheli Loux Puppet&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_3_14&amp;id=spirit_ashes_3_14&amp;link=/checklists/spirit_ashes.html%23item_3_14&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Nepheli+Loux+Puppet&quot;&gt;Nepheli Loux Puppet&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1212,9 +1138,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="spirit_ashes_3_15" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_3_15&amp;id=spirit_ashes_3_15&amp;link=/checklists/spirit_ashes.html%23item_3_15&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Page+Ashes&quot;&gt;Page Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_3_15&amp;id=spirit_ashes_3_15&amp;link=/checklists/spirit_ashes.html%23item_3_15&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Page+Ashes&quot;&gt;Page Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1243,9 +1167,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="spirit_ashes_3_16" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_3_16&amp;id=spirit_ashes_3_16&amp;link=/checklists/spirit_ashes.html%23item_3_16&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Raya+Lucaria+Soldier+Ashes&quot;&gt;Raya Lucaria Soldier Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_3_16&amp;id=spirit_ashes_3_16&amp;link=/checklists/spirit_ashes.html%23item_3_16&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Raya+Lucaria+Soldier+Ashes&quot;&gt;Raya Lucaria Soldier Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1274,9 +1196,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="spirit_ashes_3_17" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_3_17&amp;id=spirit_ashes_3_17&amp;link=/checklists/spirit_ashes.html%23item_3_17&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Skeletal+Bandit+Ashes&quot;&gt;Skeletal Bandit Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_3_17&amp;id=spirit_ashes_3_17&amp;link=/checklists/spirit_ashes.html%23item_3_17&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Skeletal+Bandit+Ashes&quot;&gt;Skeletal Bandit Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1305,9 +1225,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="spirit_ashes_3_18" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_3_18&amp;id=spirit_ashes_3_18&amp;link=/checklists/spirit_ashes.html%23item_3_18&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Twinsage+Sorcerer+Ashes&quot;&gt;Twinsage Sorcerer Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_3_18&amp;id=spirit_ashes_3_18&amp;link=/checklists/spirit_ashes.html%23item_3_18&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Twinsage+Sorcerer+Ashes&quot;&gt;Twinsage Sorcerer Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1337,9 +1255,7 @@
         <div class="card shadow-sm mb-3" id="spirit_ashes_section_3">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#spirit_ashes_3Col" data-bs-toggle="collapse" href="#spirit_ashes_3Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#spirit_ashes_3Col" data-bs-toggle="collapse" href="#spirit_ashes_3Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Caelid</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="spirit_ashes_totals_3"></span>
             </h4>
@@ -1351,9 +1267,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -1377,9 +1291,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="spirit_ashes_4_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_4_1&amp;id=spirit_ashes_4_1&amp;link=/checklists/spirit_ashes.html%23item_4_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Battlemage+Hugues+Ashes&quot;&gt;Battlemage Hugues Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_4_1&amp;id=spirit_ashes_4_1&amp;link=/checklists/spirit_ashes.html%23item_4_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Battlemage+Hugues+Ashes&quot;&gt;Battlemage Hugues Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1408,9 +1320,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="spirit_ashes_4_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_4_2&amp;id=spirit_ashes_4_2&amp;link=/checklists/spirit_ashes.html%23item_4_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Crystalian+Ashes&quot;&gt;Crystalian Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_4_2&amp;id=spirit_ashes_4_2&amp;link=/checklists/spirit_ashes.html%23item_4_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Crystalian+Ashes&quot;&gt;Crystalian Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1439,9 +1349,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="spirit_ashes_4_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_4_3&amp;id=spirit_ashes_4_3&amp;link=/checklists/spirit_ashes.html%23item_4_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Kindred+of+Rot+Ashes&quot;&gt;Kindred of Rot Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_4_3&amp;id=spirit_ashes_4_3&amp;link=/checklists/spirit_ashes.html%23item_4_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Kindred+of+Rot+Ashes&quot;&gt;Kindred of Rot Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1470,9 +1378,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="spirit_ashes_4_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_4_4&amp;id=spirit_ashes_4_4&amp;link=/checklists/spirit_ashes.html%23item_4_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Mad+Pumpkin+Head+Ashes&quot;&gt;Mad Pumpkin Head Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_4_4&amp;id=spirit_ashes_4_4&amp;link=/checklists/spirit_ashes.html%23item_4_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Mad+Pumpkin+Head+Ashes&quot;&gt;Mad Pumpkin Head Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1501,9 +1407,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="spirit_ashes_4_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_4_5&amp;id=spirit_ashes_4_5&amp;link=/checklists/spirit_ashes.html%23item_4_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Miranda+Sprout+Ashes&quot;&gt;Miranda Sprout Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_4_5&amp;id=spirit_ashes_4_5&amp;link=/checklists/spirit_ashes.html%23item_4_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Miranda+Sprout+Ashes&quot;&gt;Miranda Sprout Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1532,9 +1436,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="spirit_ashes_4_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_4_6&amp;id=spirit_ashes_4_6&amp;link=/checklists/spirit_ashes.html%23item_4_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Putrid+Corpse+Ashes&quot;&gt;Putrid Corpse Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_4_6&amp;id=spirit_ashes_4_6&amp;link=/checklists/spirit_ashes.html%23item_4_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Putrid+Corpse+Ashes&quot;&gt;Putrid Corpse Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1563,9 +1465,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="spirit_ashes_4_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_4_7&amp;id=spirit_ashes_4_7&amp;link=/checklists/spirit_ashes.html%23item_4_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Radahn+Soldier+Ashes&quot;&gt;Radahn Soldier Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_4_7&amp;id=spirit_ashes_4_7&amp;link=/checklists/spirit_ashes.html%23item_4_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Radahn+Soldier+Ashes&quot;&gt;Radahn Soldier Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1594,9 +1494,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="spirit_ashes_4_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_4_8&amp;id=spirit_ashes_4_8&amp;link=/checklists/spirit_ashes.html%23item_4_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Redmane+Knight+Ogha+Ashes&quot;&gt;Redmane Knight Ogha Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_4_8&amp;id=spirit_ashes_4_8&amp;link=/checklists/spirit_ashes.html%23item_4_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Redmane+Knight+Ogha+Ashes&quot;&gt;Redmane Knight Ogha Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1625,9 +1523,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="spirit_ashes_4_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_4_9&amp;id=spirit_ashes_4_9&amp;link=/checklists/spirit_ashes.html%23item_4_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Rotten+Stray+Ashes&quot;&gt;Rotten Stray Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_4_9&amp;id=spirit_ashes_4_9&amp;link=/checklists/spirit_ashes.html%23item_4_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Rotten+Stray+Ashes&quot;&gt;Rotten Stray Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1657,9 +1553,7 @@
         <div class="card shadow-sm mb-3" id="spirit_ashes_section_4">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#spirit_ashes_4Col" data-bs-toggle="collapse" href="#spirit_ashes_4Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#spirit_ashes_4Col" data-bs-toggle="collapse" href="#spirit_ashes_4Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Altus Plateau</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="spirit_ashes_totals_4"></span>
             </h4>
@@ -1671,9 +1565,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -1697,9 +1589,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="spirit_ashes_5_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_5_1&amp;id=spirit_ashes_5_1&amp;link=/checklists/spirit_ashes.html%23item_5_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Giant+Rat+Ashes&quot;&gt;Giant Rat Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_5_1&amp;id=spirit_ashes_5_1&amp;link=/checklists/spirit_ashes.html%23item_5_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Giant+Rat+Ashes&quot;&gt;Giant Rat Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1728,9 +1618,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="spirit_ashes_5_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_5_2&amp;id=spirit_ashes_5_2&amp;link=/checklists/spirit_ashes.html%23item_5_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Leyndell+Soldier+Ashes&quot;&gt;Leyndell Soldier Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_5_2&amp;id=spirit_ashes_5_2&amp;link=/checklists/spirit_ashes.html%23item_5_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Leyndell+Soldier+Ashes&quot;&gt;Leyndell Soldier Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1759,9 +1647,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="spirit_ashes_5_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_5_3&amp;id=spirit_ashes_5_3&amp;link=/checklists/spirit_ashes.html%23item_5_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Winged+Misbegotten+Ashes&quot;&gt;Winged Misbegotten Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_5_3&amp;id=spirit_ashes_5_3&amp;link=/checklists/spirit_ashes.html%23item_5_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Winged+Misbegotten+Ashes&quot;&gt;Winged Misbegotten Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1790,9 +1676,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="spirit_ashes_7_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_7_1&amp;id=spirit_ashes_7_1&amp;link=/checklists/spirit_ashes.html%23item_7_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ancient+Dragon+Knight+Kristoff+Ashes&quot;&gt;Ancient Dragon Knight Kristoff Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_7_1&amp;id=spirit_ashes_7_1&amp;link=/checklists/spirit_ashes.html%23item_7_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ancient+Dragon+Knight+Kristoff+Ashes&quot;&gt;Ancient Dragon Knight Kristoff Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1822,9 +1706,7 @@
         <div class="card shadow-sm mb-3" id="spirit_ashes_section_5">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#spirit_ashes_5Col" data-bs-toggle="collapse" href="#spirit_ashes_5Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#spirit_ashes_5Col" data-bs-toggle="collapse" href="#spirit_ashes_5Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Mt. Gelmir</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="spirit_ashes_totals_5"></span>
             </h4>
@@ -1836,9 +1718,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -1862,9 +1742,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="spirit_ashes_6_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_6_1&amp;id=spirit_ashes_6_1&amp;link=/checklists/spirit_ashes.html%23item_6_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Bloodhound+Knight+Floh&quot;&gt;Bloodhound Knight Floh&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_6_1&amp;id=spirit_ashes_6_1&amp;link=/checklists/spirit_ashes.html%23item_6_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Bloodhound+Knight+Floh&quot;&gt;Bloodhound Knight Floh&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1893,9 +1771,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="spirit_ashes_6_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_6_2&amp;id=spirit_ashes_6_2&amp;link=/checklists/spirit_ashes.html%23item_6_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Depraved+Perfumer+Carmaan+Ashes&quot;&gt;Depraved Perfumer Carmaan Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_6_2&amp;id=spirit_ashes_6_2&amp;link=/checklists/spirit_ashes.html%23item_6_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Depraved+Perfumer+Carmaan+Ashes&quot;&gt;Depraved Perfumer Carmaan Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1924,9 +1800,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="spirit_ashes_6_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_6_3&amp;id=spirit_ashes_6_3&amp;link=/checklists/spirit_ashes.html%23item_6_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Man-Serpent+Ashes&quot;&gt;Man-Serpent Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_6_3&amp;id=spirit_ashes_6_3&amp;link=/checklists/spirit_ashes.html%23item_6_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Man-Serpent+Ashes&quot;&gt;Man-Serpent Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1955,9 +1829,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="spirit_ashes_6_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_6_4&amp;id=spirit_ashes_6_4&amp;link=/checklists/spirit_ashes.html%23item_6_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Perfumer+Tricia+Ashes&quot;&gt;Perfumer Tricia Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_6_4&amp;id=spirit_ashes_6_4&amp;link=/checklists/spirit_ashes.html%23item_6_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Perfumer+Tricia+Ashes&quot;&gt;Perfumer Tricia Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1987,9 +1859,7 @@
         <div class="card shadow-sm mb-3" id="spirit_ashes_section_6">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#spirit_ashes_6Col" data-bs-toggle="collapse" href="#spirit_ashes_6Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#spirit_ashes_6Col" data-bs-toggle="collapse" href="#spirit_ashes_6Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Leyndell, Eternal City</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="spirit_ashes_totals_6"></span>
             </h4>
@@ -2001,9 +1871,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -2027,9 +1895,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="spirit_ashes_7_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_7_2&amp;id=spirit_ashes_7_2&amp;link=/checklists/spirit_ashes.html%23item_7_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Nomad+Ashes&quot;&gt;Nomad Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_7_2&amp;id=spirit_ashes_7_2&amp;link=/checklists/spirit_ashes.html%23item_7_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Nomad+Ashes&quot;&gt;Nomad Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2058,9 +1924,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="spirit_ashes_7_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_7_3&amp;id=spirit_ashes_7_3&amp;link=/checklists/spirit_ashes.html%23item_7_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Omenkiller+Rollo&quot;&gt;Omenkiller Rollo&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_7_3&amp;id=spirit_ashes_7_3&amp;link=/checklists/spirit_ashes.html%23item_7_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Omenkiller+Rollo&quot;&gt;Omenkiller Rollo&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2089,9 +1953,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="spirit_ashes_7_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_7_4&amp;id=spirit_ashes_7_4&amp;link=/checklists/spirit_ashes.html%23item_7_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Soldjars+of+Fortune+Ashes&quot;&gt;Soldjars of Fortune Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_7_4&amp;id=spirit_ashes_7_4&amp;link=/checklists/spirit_ashes.html%23item_7_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Soldjars+of+Fortune+Ashes&quot;&gt;Soldjars of Fortune Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2120,9 +1982,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="spirit_ashes_7_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_7_5&amp;id=spirit_ashes_7_5&amp;link=/checklists/spirit_ashes.html%23item_7_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Vulgar+Militia+Ashes&quot;&gt;Vulgar Militia Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_7_5&amp;id=spirit_ashes_7_5&amp;link=/checklists/spirit_ashes.html%23item_7_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Vulgar+Militia+Ashes&quot;&gt;Vulgar Militia Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2152,9 +2012,7 @@
         <div class="card shadow-sm mb-3" id="spirit_ashes_section_7">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#spirit_ashes_7Col" data-bs-toggle="collapse" href="#spirit_ashes_7Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#spirit_ashes_7Col" data-bs-toggle="collapse" href="#spirit_ashes_7Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Mountaintops of the Giants</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="spirit_ashes_totals_7"></span>
             </h4>
@@ -2166,9 +2024,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -2192,9 +2048,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="spirit_ashes_8_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_8_1&amp;id=spirit_ashes_8_1&amp;link=/checklists/spirit_ashes.html%23item_8_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Fire+Monk+Ashes&quot;&gt;Fire Monk Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_8_1&amp;id=spirit_ashes_8_1&amp;link=/checklists/spirit_ashes.html%23item_8_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Fire+Monk+Ashes&quot;&gt;Fire Monk Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2224,9 +2078,7 @@
         <div class="card shadow-sm mb-3" id="spirit_ashes_section_8">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#spirit_ashes_8Col" data-bs-toggle="collapse" href="#spirit_ashes_8Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#spirit_ashes_8Col" data-bs-toggle="collapse" href="#spirit_ashes_8Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Consecrated Snowfield</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="spirit_ashes_totals_8"></span>
             </h4>
@@ -2238,9 +2090,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -2264,9 +2114,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="spirit_ashes_9_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_9_1&amp;id=spirit_ashes_9_1&amp;link=/checklists/spirit_ashes.html%23item_9_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Blackflame+Monk+Amon+Ashes&quot;&gt;Blackflame Monk Amon Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_9_1&amp;id=spirit_ashes_9_1&amp;link=/checklists/spirit_ashes.html%23item_9_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Blackflame+Monk+Amon+Ashes&quot;&gt;Blackflame Monk Amon Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2295,9 +2143,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="spirit_ashes_9_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_9_2&amp;id=spirit_ashes_9_2&amp;link=/checklists/spirit_ashes.html%23item_9_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Cleanrot+Knight+Finlay+Ashes&quot;&gt;Cleanrot Knight Finlay Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_9_2&amp;id=spirit_ashes_9_2&amp;link=/checklists/spirit_ashes.html%23item_9_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Cleanrot+Knight+Finlay+Ashes&quot;&gt;Cleanrot Knight Finlay Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2326,9 +2172,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="spirit_ashes_9_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_9_3&amp;id=spirit_ashes_9_3&amp;link=/checklists/spirit_ashes.html%23item_9_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Haligtree+Soldier+Ashes&quot;&gt;Haligtree Soldier Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_9_3&amp;id=spirit_ashes_9_3&amp;link=/checklists/spirit_ashes.html%23item_9_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Haligtree+Soldier+Ashes&quot;&gt;Haligtree Soldier Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2357,9 +2201,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="spirit_ashes_9_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_9_4&amp;id=spirit_ashes_9_4&amp;link=/checklists/spirit_ashes.html%23item_9_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Oracle+Envoy+Ashes&quot;&gt;Oracle Envoy Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_9_4&amp;id=spirit_ashes_9_4&amp;link=/checklists/spirit_ashes.html%23item_9_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Oracle+Envoy+Ashes&quot;&gt;Oracle Envoy Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2389,9 +2231,7 @@
         <div class="card shadow-sm mb-3" id="spirit_ashes_section_9">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#spirit_ashes_9Col" data-bs-toggle="collapse" href="#spirit_ashes_9Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#spirit_ashes_9Col" data-bs-toggle="collapse" href="#spirit_ashes_9Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Crumbling Farum Azula</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="spirit_ashes_totals_9"></span>
             </h4>
@@ -2403,9 +2243,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -2429,9 +2267,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="spirit_ashes_10_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_10_1&amp;id=spirit_ashes_10_1&amp;link=/checklists/spirit_ashes.html%23item_10_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Azula+Beastman+Ashes&quot;&gt;Azula Beastman Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_10_1&amp;id=spirit_ashes_10_1&amp;link=/checklists/spirit_ashes.html%23item_10_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Azula+Beastman+Ashes&quot;&gt;Azula Beastman Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2461,9 +2297,7 @@
         <div class="card shadow-sm mb-3" id="spirit_ashes_section_10">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#spirit_ashes_10Col" data-bs-toggle="collapse" href="#spirit_ashes_10Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#spirit_ashes_10Col" data-bs-toggle="collapse" href="#spirit_ashes_10Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Siofra River</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="spirit_ashes_totals_10"></span>
             </h4>
@@ -2475,9 +2309,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -2501,9 +2333,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="10" id="spirit_ashes_11_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_11_1&amp;id=spirit_ashes_11_1&amp;link=/checklists/spirit_ashes.html%23item_11_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ancestral+Follower+Ashes&quot;&gt;Ancestral Follower Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_11_1&amp;id=spirit_ashes_11_1&amp;link=/checklists/spirit_ashes.html%23item_11_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ancestral+Follower+Ashes&quot;&gt;Ancestral Follower Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2533,9 +2363,7 @@
         <div class="card shadow-sm mb-3" id="spirit_ashes_section_11">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#spirit_ashes_11Col" data-bs-toggle="collapse" href="#spirit_ashes_11Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#spirit_ashes_11Col" data-bs-toggle="collapse" href="#spirit_ashes_11Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Nokron, Eternal City</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="spirit_ashes_totals_11"></span>
             </h4>
@@ -2547,9 +2375,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -2573,9 +2399,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="11" id="spirit_ashes_12_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_12_1&amp;id=spirit_ashes_12_1&amp;link=/checklists/spirit_ashes.html%23item_12_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Greatshield+Soldier+Ashes&quot;&gt;Greatshield Soldier Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_12_1&amp;id=spirit_ashes_12_1&amp;link=/checklists/spirit_ashes.html%23item_12_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Greatshield+Soldier+Ashes&quot;&gt;Greatshield Soldier Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2604,9 +2428,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="11" id="spirit_ashes_12_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_12_2&amp;id=spirit_ashes_12_2&amp;link=/checklists/spirit_ashes.html%23item_12_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Mimic+Tear+Ashes&quot;&gt;Mimic Tear Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_12_2&amp;id=spirit_ashes_12_2&amp;link=/checklists/spirit_ashes.html%23item_12_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Mimic+Tear+Ashes&quot;&gt;Mimic Tear Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2636,9 +2458,7 @@
         <div class="card shadow-sm mb-3" id="spirit_ashes_section_12">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#spirit_ashes_12Col" data-bs-toggle="collapse" href="#spirit_ashes_12Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#spirit_ashes_12Col" data-bs-toggle="collapse" href="#spirit_ashes_12Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Ainsel River</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="spirit_ashes_totals_12"></span>
             </h4>
@@ -2650,9 +2470,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -2676,9 +2494,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="spirit_ashes_13_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_13_1&amp;id=spirit_ashes_13_1&amp;link=/checklists/spirit_ashes.html%23item_13_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Clayman+Ashes&quot;&gt;Clayman Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_13_1&amp;id=spirit_ashes_13_1&amp;link=/checklists/spirit_ashes.html%23item_13_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Clayman+Ashes&quot;&gt;Clayman Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2708,9 +2524,7 @@
         <div class="card shadow-sm mb-3" id="spirit_ashes_section_13">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#spirit_ashes_13Col" data-bs-toggle="collapse" href="#spirit_ashes_13Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#spirit_ashes_13Col" data-bs-toggle="collapse" href="#spirit_ashes_13Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Nokstella, Eternal City</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="spirit_ashes_totals_13"></span>
             </h4>
@@ -2722,9 +2536,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -2748,9 +2560,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="13" id="spirit_ashes_14_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_14_1&amp;id=spirit_ashes_14_1&amp;link=/checklists/spirit_ashes.html%23item_14_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Archer+Ashes&quot;&gt;Archer Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_14_1&amp;id=spirit_ashes_14_1&amp;link=/checklists/spirit_ashes.html%23item_14_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Archer+Ashes&quot;&gt;Archer Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2779,9 +2589,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="13" id="spirit_ashes_14_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_14_2&amp;id=spirit_ashes_14_2&amp;link=/checklists/spirit_ashes.html%23item_14_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Nightmaiden+&amp;+Swordstress+Puppets&quot;&gt;Nightmaiden &amp; Swordstress Puppets&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_14_2&amp;id=spirit_ashes_14_2&amp;link=/checklists/spirit_ashes.html%23item_14_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Nightmaiden+&amp;+Swordstress+Puppets&quot;&gt;Nightmaiden &amp; Swordstress Puppets&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2811,9 +2619,7 @@
         <div class="card shadow-sm mb-3" id="spirit_ashes_section_14">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#spirit_ashes_14Col" data-bs-toggle="collapse" href="#spirit_ashes_14Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#spirit_ashes_14Col" data-bs-toggle="collapse" href="#spirit_ashes_14Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Deeproot Depths</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="spirit_ashes_totals_14"></span>
             </h4>
@@ -2825,9 +2631,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -2851,9 +2655,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="14" id="spirit_ashes_15_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_15_1&amp;id=spirit_ashes_15_1&amp;link=/checklists/spirit_ashes.html%23item_15_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Mausoleum+Soldier+Ashes&quot;&gt;Mausoleum Soldier Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_15_1&amp;id=spirit_ashes_15_1&amp;link=/checklists/spirit_ashes.html%23item_15_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Mausoleum+Soldier+Ashes&quot;&gt;Mausoleum Soldier Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2883,9 +2685,7 @@
         <div class="card shadow-sm mb-3" id="spirit_ashes_section_15">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#spirit_ashes_15Col" data-bs-toggle="collapse" href="#spirit_ashes_15Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#spirit_ashes_15Col" data-bs-toggle="collapse" href="#spirit_ashes_15Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Realm of Shadow</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="spirit_ashes_totals_15"></span>
             </h4>
@@ -2897,9 +2697,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -2923,9 +2721,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="15" id="spirit_ashes_20_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_20_1&amp;id=spirit_ashes_20_1&amp;link=/checklists/spirit_ashes.html%23item_20_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Curseblade+Meera&quot;&gt;Curseblade Meera&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_20_1&amp;id=spirit_ashes_20_1&amp;link=/checklists/spirit_ashes.html%23item_20_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Curseblade+Meera&quot;&gt;Curseblade Meera&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2954,9 +2750,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="15" id="spirit_ashes_20_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_20_2&amp;id=spirit_ashes_20_2&amp;link=/checklists/spirit_ashes.html%23item_20_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Bloodfiend+Hexer's+Ashes&quot;&gt;Bloodfiend Hexer's Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_20_2&amp;id=spirit_ashes_20_2&amp;link=/checklists/spirit_ashes.html%23item_20_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Bloodfiend+Hexer's+Ashes&quot;&gt;Bloodfiend Hexer's Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2985,9 +2779,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="15" id="spirit_ashes_20_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_20_3&amp;id=spirit_ashes_20_3&amp;link=/checklists/spirit_ashes.html%23item_20_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gravebird+Ashes&quot;&gt;Gravebird Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_20_3&amp;id=spirit_ashes_20_3&amp;link=/checklists/spirit_ashes.html%23item_20_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gravebird+Ashes&quot;&gt;Gravebird Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3016,9 +2808,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="15" id="spirit_ashes_20_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_20_4&amp;id=spirit_ashes_20_4&amp;link=/checklists/spirit_ashes.html%23item_20_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Fire+Knight+Hilde&quot;&gt;Fire Knight Hilde&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_20_4&amp;id=spirit_ashes_20_4&amp;link=/checklists/spirit_ashes.html%23item_20_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Fire+Knight+Hilde&quot;&gt;Fire Knight Hilde&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3047,9 +2837,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="15" id="spirit_ashes_20_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_20_5&amp;id=spirit_ashes_20_5&amp;link=/checklists/spirit_ashes.html%23item_20_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Spider+Scorpion+Ashes&quot;&gt;Spider Scorpion Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_20_5&amp;id=spirit_ashes_20_5&amp;link=/checklists/spirit_ashes.html%23item_20_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Spider+Scorpion+Ashes&quot;&gt;Spider Scorpion Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3078,9 +2866,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="15" id="spirit_ashes_20_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_20_6&amp;id=spirit_ashes_20_6&amp;link=/checklists/spirit_ashes.html%23item_20_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Inquisitor+Ashes&quot;&gt;Inquisitor Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_20_6&amp;id=spirit_ashes_20_6&amp;link=/checklists/spirit_ashes.html%23item_20_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Inquisitor+Ashes&quot;&gt;Inquisitor Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3109,9 +2895,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="15" id="spirit_ashes_20_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_20_7&amp;id=spirit_ashes_20_7&amp;link=/checklists/spirit_ashes.html%23item_20_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Demi-Human+Swordsman+Yosh&quot;&gt;Demi-Human Swordsman Yosh&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_20_7&amp;id=spirit_ashes_20_7&amp;link=/checklists/spirit_ashes.html%23item_20_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Demi-Human+Swordsman+Yosh&quot;&gt;Demi-Human Swordsman Yosh&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3140,9 +2924,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="15" id="spirit_ashes_20_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_20_8&amp;id=spirit_ashes_20_8&amp;link=/checklists/spirit_ashes.html%23item_20_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Messmer+Soldier+Ashes&quot;&gt;Messmer Soldier Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_20_8&amp;id=spirit_ashes_20_8&amp;link=/checklists/spirit_ashes.html%23item_20_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Messmer+Soldier+Ashes&quot;&gt;Messmer Soldier Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3171,9 +2953,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="15" id="spirit_ashes_20_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_20_9&amp;id=spirit_ashes_20_9&amp;link=/checklists/spirit_ashes.html%23item_20_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Black+Knight+Commander+Andreas&quot;&gt;Black Knight Commander Andreas&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_20_9&amp;id=spirit_ashes_20_9&amp;link=/checklists/spirit_ashes.html%23item_20_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Black+Knight+Commander+Andreas&quot;&gt;Black Knight Commander Andreas&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3202,9 +2982,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="15" id="spirit_ashes_20_10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_20_10&amp;id=spirit_ashes_20_10&amp;link=/checklists/spirit_ashes.html%23item_20_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Black+Knight+Captain+Huw&quot;&gt;Black Knight Captain Huw&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_20_10&amp;id=spirit_ashes_20_10&amp;link=/checklists/spirit_ashes.html%23item_20_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Black+Knight+Captain+Huw&quot;&gt;Black Knight Captain Huw&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3233,9 +3011,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="15" id="spirit_ashes_20_11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_20_11&amp;id=spirit_ashes_20_11&amp;link=/checklists/spirit_ashes.html%23item_20_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Bigmouth+Imp+Ashes&quot;&gt;Bigmouth Imp Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_20_11&amp;id=spirit_ashes_20_11&amp;link=/checklists/spirit_ashes.html%23item_20_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Bigmouth+Imp+Ashes&quot;&gt;Bigmouth Imp Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3264,9 +3040,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="15" id="spirit_ashes_20_12" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_20_12&amp;id=spirit_ashes_20_12&amp;link=/checklists/spirit_ashes.html%23item_20_12&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Man-Fly+Ashes&quot;&gt;Man-Fly Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_20_12&amp;id=spirit_ashes_20_12&amp;link=/checklists/spirit_ashes.html%23item_20_12&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Man-Fly+Ashes&quot;&gt;Man-Fly Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3295,9 +3069,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="15" id="spirit_ashes_20_13" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_20_13&amp;id=spirit_ashes_20_13&amp;link=/checklists/spirit_ashes.html%23item_20_13&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Taylew+the+Golem+Smith&quot;&gt;Taylew the Golem Smith&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_20_13&amp;id=spirit_ashes_20_13&amp;link=/checklists/spirit_ashes.html%23item_20_13&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Taylew+the+Golem+Smith&quot;&gt;Taylew the Golem Smith&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3326,9 +3098,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="15" id="spirit_ashes_20_14" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_20_14&amp;id=spirit_ashes_20_14&amp;link=/checklists/spirit_ashes.html%23item_20_14&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Divine+Bird+Warrior+Ornis&quot;&gt;Divine Bird Warrior Ornis&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_20_14&amp;id=spirit_ashes_20_14&amp;link=/checklists/spirit_ashes.html%23item_20_14&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Divine+Bird+Warrior+Ornis&quot;&gt;Divine Bird Warrior Ornis&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3357,9 +3127,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="15" id="spirit_ashes_20_15" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_20_15&amp;id=spirit_ashes_20_15&amp;link=/checklists/spirit_ashes.html%23item_20_15&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Horned+Warrior+Ashes&quot;&gt;Horned Warrior Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_20_15&amp;id=spirit_ashes_20_15&amp;link=/checklists/spirit_ashes.html%23item_20_15&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Horned+Warrior+Ashes&quot;&gt;Horned Warrior Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3388,9 +3156,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="15" id="spirit_ashes_20_16" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_20_16&amp;id=spirit_ashes_20_16&amp;link=/checklists/spirit_ashes.html%23item_20_16&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ancient+Dragon+Florissax&quot;&gt;Ancient Dragon Florissax&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_20_16&amp;id=spirit_ashes_20_16&amp;link=/checklists/spirit_ashes.html%23item_20_16&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ancient+Dragon+Florissax&quot;&gt;Ancient Dragon Florissax&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3419,9 +3185,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="15" id="spirit_ashes_20_17" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_20_17&amp;id=spirit_ashes_20_17&amp;link=/checklists/spirit_ashes.html%23item_20_17&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Fingercreeper+Ashes&quot;&gt;Fingercreeper Ashes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_20_17&amp;id=spirit_ashes_20_17&amp;link=/checklists/spirit_ashes.html%23item_20_17&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Fingercreeper+Ashes&quot;&gt;Fingercreeper Ashes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3450,9 +3214,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="15" id="spirit_ashes_20_18" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_20_18&amp;id=spirit_ashes_20_18&amp;link=/checklists/spirit_ashes.html%23item_20_18&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Fire+Knight+Queelign&quot;&gt;Fire Knight Queelign&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_20_18&amp;id=spirit_ashes_20_18&amp;link=/checklists/spirit_ashes.html%23item_20_18&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Fire+Knight+Queelign&quot;&gt;Fire Knight Queelign&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3481,9 +3243,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="15" id="spirit_ashes_20_19" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_20_19&amp;id=spirit_ashes_20_19&amp;link=/checklists/spirit_ashes.html%23item_20_19&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Swordhand+of+Night+Jolán&quot;&gt;Swordhand of Night Jolán&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_20_19&amp;id=spirit_ashes_20_19&amp;link=/checklists/spirit_ashes.html%23item_20_19&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Swordhand+of+Night+Jolán&quot;&gt;Swordhand of Night Jolán&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3512,9 +3272,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="15" id="spirit_ashes_20_20" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=spirit_ashes_20_20&amp;id=spirit_ashes_20_20&amp;link=/checklists/spirit_ashes.html%23item_20_20&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Jolán+and+Anna&quot;&gt;Jolán and Anna&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=spirit_ashes_20_20&amp;id=spirit_ashes_20_20&amp;link=/checklists/spirit_ashes.html%23item_20_20&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Jolán+and+Anna&quot;&gt;Jolán and Anna&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">

--- a/docs/checklists/stonesword_keys_imp_seals.html
+++ b/docs/checklists/stonesword_keys_imp_seals.html
@@ -27,14 +27,10 @@
         <a class="navbar-brand me-auto ms-2" href="/index.html">Roundtable Guides</a>
         <form class="d-none d-sm-flex order-2 order-xl-3">
           <input aria-label="search" class="form-control me-2" name="search" placeholder="Search" type="search">
-          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit">
-            <i class="bi bi-search"></i>
-          </button>
+          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit"><i class="bi bi-search"></i></button>
         </form>
         <div class="d-sm-none order-2">
-          <a class="nav-link me-0" href="/search.html">
-            <i class="bi bi-search sb-icon-search"></i>
-          </a>
+          <a class="nav-link me-0" href="/search.html"><i class="bi bi-search sb-icon-search"></i></a>
         </div>
         <div class="collapse navbar-collapse order-3 order-xl-2 ms-xl-2" id="nav-collapse">
           <ul class="nav navbar-nav navbar-nav-scroll mr-auto">
@@ -179,14 +175,10 @@
               </ul>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/map.html">
-                <i class="bi bi-map"></i> Map
-              </a>
+              <a class="nav-link hide-buttons" href="/map.html"><i class="bi bi-map"></i> Map</a>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/options.html">
-                <i class="bi bi-gear-fill"></i> Options
-              </a>
+              <a class="nav-link hide-buttons" href="/options.html"><i class="bi bi-gear-fill"></i> Options</a>
             </li>
           </ul>
         </div>
@@ -207,9 +199,7 @@
       <p>Stonesword Keys are consumable key items that open Imp Statue Seals, which typically guard loot, dungeons, or optional paths. A maximum of 81 Stonesword Keys can be found in the game, plus 2 if chosen as a Keepsake. However, only 46 are required to open every Imp Statue Seal. Imp Statues each require either 1 or 2 keys, and the only way to tell the difference is by visual examination: most Imp Statues already have one key in them when you find them, meaning you only need one more.</p>
       <nav class="text-muted toc d-print-none">
         <strong class="d-block h5">
-          <a class="toc-button" data-bs-toggle="collapse" href="#toc_stonesword" role="button">
-            <i class="bi bi-plus-lg"></i>Table Of Contents
-          </a>
+          <a class="toc-button" data-bs-toggle="collapse" href="#toc_stonesword" role="button"><i class="bi bi-plus-lg"></i>Table Of Contents</a>
         </strong>
         <ul class="toc_page collapse" id="toc_stonesword">
           <li>
@@ -229,9 +219,7 @@
         <div class="card shadow-sm mb-3" id="stonesword_section_0">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#stonesword_0Col" data-bs-toggle="collapse" href="#stonesword_0Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#stonesword_0Col" data-bs-toggle="collapse" href="#stonesword_0Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <img class="me-1" data-src="/img/icons/keys/00228.png" loading="lazy" style="height: 70px; width: 70px">
               <span class="d-print-inline">Stonesword Keys</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="stonesword_totals_0"></span>
@@ -257,36 +245,28 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k3" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k3">In a tiny intact room in the center of Dragon-Burnt Ruins, on a body guarded by a single rat</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k3&amp;id=stonesword_k3&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k3&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k3&amp;id=stonesword_k3&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k3&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k4" id="item_k4">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k4" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k4">Sold by Patches for 5000 runes in Murkwater Cave (and thereafter)</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k4&amp;id=stonesword_k4&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k4&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k4&amp;id=stonesword_k4&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k4&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k5" id="item_k5">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k5" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k5">On the front of Stormhill Shack, on a body atop the little staircase of wooden platforms</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k5&amp;id=stonesword_k5&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k5&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k5&amp;id=stonesword_k5&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k5&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k6" id="item_k6">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k6" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k6">In Fringefolk Hero's Grave, on the ledge from which you can shoot down the jars to destroy the chariot</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k6&amp;id=stonesword_k6&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k6&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k6&amp;id=stonesword_k6&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k6&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -296,27 +276,21 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k7" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k7">Sold by Twin Maiden Husks for 4000 runes</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k7&amp;id=stonesword_k7&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k7&amp;title=Stonesword Key x3">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k7&amp;id=stonesword_k7&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k7&amp;title=Stonesword Key x3"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k8" id="item_k8">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k8" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k8">Sold by Twin Maiden Husks for 4000 runes</label>
-                    <a class="ms-2" href="/map.html?x=451&amp;y=8385&amp;id=stonesword_k8&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k8&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=451&amp;y=8385&amp;id=stonesword_k8&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k8&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k9" id="item_k9">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k9" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k9">Sold by Twin Maiden Husks for 4000 runes</label>
-                    <a class="ms-2" href="/map.html?x=451&amp;y=8385&amp;id=stonesword_k9&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k9&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=451&amp;y=8385&amp;id=stonesword_k9&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k9&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -326,63 +300,49 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k10" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k10">On the Bridge of Sacrifice on a body behind the ballista</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k10&amp;id=stonesword_k10&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k10&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k10&amp;id=stonesword_k10&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k10&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k11" id="item_k11">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k11" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k11">On the northern tip of the high ledge in the northeast, on a body sitting in a chair</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k11&amp;id=stonesword_k11&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k11&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k11&amp;id=stonesword_k11&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k11&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k12" id="item_k12">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k12" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k12">Sold by the Nomadic Merchant in the east for 2000 runes</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k12&amp;id=stonesword_k12&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k12&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k12&amp;id=stonesword_k12&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k12&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k13" id="item_k13">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k13" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k13">Sold by the Isolated Merchant in the west for 2000 runes</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k13&amp;id=stonesword_k13&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k13&amp;title=Stonesword Key x3">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k13&amp;id=stonesword_k13&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k13&amp;title=Stonesword Key x3"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k14" id="item_k14">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k14" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k14">Sold by the Isolated Merchant in the west for 2000 runes</label>
-                    <a class="ms-2" href="/map.html?x=3450&amp;y=8230&amp;id=stonesword_k14&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k14&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3450&amp;y=8230&amp;id=stonesword_k14&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k14&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k15" id="item_k15">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k15" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k15">Sold by the Isolated Merchant in the west for 2000 runes</label>
-                    <a class="ms-2" href="/map.html?x=3450&amp;y=8230&amp;id=stonesword_k15&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k15&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3450&amp;y=8230&amp;id=stonesword_k15&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k15&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k16" id="item_k16">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k16" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k16">From the Behind the Castle Site of Grace in Castle Morne, descend down a couple ledges to the first rooftop, then walk forward and drop off to a wooden platform halfway down with the key on a body</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k16&amp;id=stonesword_k16&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k16&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k16&amp;id=stonesword_k16&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k16&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -392,27 +352,21 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k17" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k17">From Rampart Tower, follow the path up the central spiral staircase and to the rooftops; from the stack of sandbags, follow the ledge to the south tower, then turn east and hop to the next crumbling tower, and drop down inside it to find it on a body</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k17&amp;id=stonesword_k17&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k17&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k17&amp;id=stonesword_k17&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k17&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k18" id="item_k18">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k18" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k18">On a body on the wooden platform above the Grafted Scion (down the shortcut elevator from Rampart Tower)</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k18&amp;id=stonesword_k18&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k18&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k18&amp;id=stonesword_k18&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k18&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k19" id="item_k19">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k19" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k19">On a body in the pit with the Ulcerated Tree Spirit, just past the first big roots on the left</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k19&amp;id=stonesword_k19&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k19&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k19&amp;id=stonesword_k19&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k19&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -422,81 +376,63 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k20" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k20">In Academy Crystal Cave, stick to the left past the rats and the Sages to find a small side room in the back, containing the key on a body in a cage</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k20&amp;id=stonesword_k20&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k20&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k20&amp;id=stonesword_k20&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k20&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k21" id="item_k21">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k21" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k21">On the island directly east of the South Raya Lucaria Gate Site of Grace, accessible from Gate Town North; it's in a chest in a small tower sticking out of the water, requiring Torrent's double jump to reach</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k21&amp;id=stonesword_k21&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k21&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k21&amp;id=stonesword_k21&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k21&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k22" id="item_k22">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k22" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k22">Outside Raya Lucaria at the base of its northeastern corner, up an incline leading to an area with many Wraith Callers and a body sitting in a chair with the key</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k22&amp;id=stonesword_k22&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k22&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k22&amp;id=stonesword_k22&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k22&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k23" id="item_k23">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k23" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k23">Sold by the Isolated Merchant inside the South Raya Lucaria Gate for 3000 runes</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k23&amp;id=stonesword_k23&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k23&amp;title=Stonesword Key x3">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k23&amp;id=stonesword_k23&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k23&amp;title=Stonesword Key x3"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k24" id="item_k24">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k24" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k24">Sold by the Isolated Merchant inside the South Raya Lucaria Gate for 3000 runes</label>
-                    <a class="ms-2" href="/map.html?x=2028&amp;y=4957&amp;id=stonesword_k24&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k24&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2028&amp;y=4957&amp;id=stonesword_k24&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k24&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k25" id="item_k25">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k25" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k25">Sold by the Isolated Merchant inside the South Raya Lucaria Gate for 3000 runes</label>
-                    <a class="ms-2" href="/map.html?x=2028&amp;y=4957&amp;id=stonesword_k25&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k25&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2028&amp;y=4957&amp;id=stonesword_k25&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k25&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k26" id="item_k26">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k26" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k26">As far north as it's possible to go from the Ainsel River Well before the cliff wall cuts off the path, on a body in a chair in a small patch of flowers</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k26&amp;id=stonesword_k26&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k26&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k26&amp;id=stonesword_k26&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k26&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k27" id="item_k27">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k27" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k27">Atop the western wall of Frenzied Flame Village</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k27&amp;id=stonesword_k27&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k27&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k27&amp;id=stonesword_k27&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k27&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k28" id="item_k28">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k28" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k28">From Three Sisters above Caria Manor, follow the path along the rooftops, dropping down when necessary, all the way to the rampart overlooking the Main Gate, with a Giant Crab on top guarding a body with the key</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k28&amp;id=stonesword_k28&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k28&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k28&amp;id=stonesword_k28&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k28&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -506,18 +442,14 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k29" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k29">Past the illusory bookshelf directly before the Debate Parlor (Red Wolf of Radagon), on the other side of the altar behind the chest</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k29&amp;id=stonesword_k29&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k29&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k29&amp;id=stonesword_k29&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k29&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k30" id="item_k30">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k30" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k30">In the courtyard directly after the Debate Parlor, on a body draped on the central fountain</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k30&amp;id=stonesword_k30&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k30&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k30&amp;id=stonesword_k30&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k30&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -527,54 +459,42 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k31" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k31">In Gaol Cave, on a body in a cell</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k31&amp;id=stonesword_k31&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k31&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k31&amp;id=stonesword_k31&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k31&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k32" id="item_k32">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k32" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k32">Sold by the Nomadic Merchant in the south for 4000 runes</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k32&amp;id=stonesword_k32&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k32&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k32&amp;id=stonesword_k32&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k32&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k33" id="item_k33">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k33" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k33">From the Dragonbarrow West grace, head to the Divine Tower of Caelid and jump onto the high tree branch, then to the first ledge with a ladder and a sentry with a torch; don't climb the ladder but face southeast from it and follow the arch to find the key on a body on the next landing, guarded by a knight</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k33&amp;id=stonesword_k33&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k33&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k33&amp;id=stonesword_k33&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k33&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k34" id="item_k34">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k34" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k34">In Sellia, Town of Sorcery, on a body slumped atop an archway connecting two buildings at the southern entrance of town; passing northward through the arch underneath, turn right to see rubble with a rotted tree through it, an easy way up on horseback</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k34&amp;id=stonesword_k34&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k34&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k34&amp;id=stonesword_k34&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k34&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k35" id="item_k35">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k35" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k35">From Fort Faroth, face west and climb the hulking white rock in the distance; it's on one of the bodies on top, the one whose chair fell over</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k35&amp;id=stonesword_k35&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k35&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k35&amp;id=stonesword_k35&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k35&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k36" id="item_k36">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k36" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k36">South of the Deep Siofra Well, past the large bear, on a body sitting on the cliff</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k36&amp;id=stonesword_k36&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k36&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k36&amp;id=stonesword_k36&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k36&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -584,63 +504,49 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k37" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k37">Early on the road northeast from the Grand Lift of Dectus, in the small encampment of Misbegottens on the right, on a body against a tent</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k37&amp;id=stonesword_k37&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k37&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k37&amp;id=stonesword_k37&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k37&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k38" id="item_k38">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k38" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k38">In Sage's Cave, proceed down the linear path, through illusory walls when necessary, until a more open room with a bonfire, many stalactites, and a larger skeleton wielding the Executioner's Greataxe; on the left, being stared at by another skeleton, is an illusory wall hiding a nook with a chest with the key inside</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k38&amp;id=stonesword_k38&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k38&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k38&amp;id=stonesword_k38&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k38&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k39" id="item_k39">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k39" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k39">Sold by the Nomadic Merchant here for 4000 runes</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k39&amp;id=stonesword_k39&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k39&amp;title=Stonesword Key x3">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k39&amp;id=stonesword_k39&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k39&amp;title=Stonesword Key x3"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k40" id="item_k40">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k40" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k40">Sold by the Nomadic Merchant here for 4000 runes</label>
-                    <a class="ms-2" href="/map.html?x=3321&amp;y=3074&amp;id=stonesword_k40&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k40&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3321&amp;y=3074&amp;id=stonesword_k40&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k40&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k41" id="item_k41">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k41" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k41">Sold by the Nomadic Merchant here for 4000 runes</label>
-                    <a class="ms-2" href="/map.html?x=3321&amp;y=3074&amp;id=stonesword_k41&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k41&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3321&amp;y=3074&amp;id=stonesword_k41&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k41&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k42" id="item_k42">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k42" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k42">On the eastern side of the raised plateau in the center of Altus with perpetual lightning storms, on a body slumped on a stone platform</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k42&amp;id=stonesword_k42&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k42&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k42&amp;id=stonesword_k42&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k42&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k43" id="item_k43">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k43" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k43">From the Shaded Castle Ramparts grace, go back down the little stairs and turn left, following the rampart around to find a Perfumer near a ramp down to the swamp below. The wall of the rampart is broken near this ramp, providing a way up, so get on the wall and follow it back a bit the way you came (south) until you can hop to the right onto the large stone barrier. Carefully climb up the stones with a few precise jumps, until a ledge wraps slightly around to the right, from where you can see a lower landing ahead that you can jump to. Then turn left and hop over the rock in the way (it's a bit tricky to get over it) and drop down to the other side of it, onto a small ledge with a body holding the key, with three slugs looking up at you from below.</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k43&amp;id=stonesword_k43&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k43&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k43&amp;id=stonesword_k43&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k43&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -650,36 +556,28 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k44" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k44">In Gelmir Hero's Grave, past the first chariot, a few Nobles and Pages, and a fire trap, you'll find a second chariot through an archway; instead of turning left to go down the incline and progress through the dungeon, turn right and run up into a dead end to find the key, though beware it's very difficult to get back on track without being killed by the chariot, as it will suddenly go all the way up the incline on its way back, so you may need to make a suicide run for it</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k44&amp;id=stonesword_k44&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k44&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k44&amp;id=stonesword_k44&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k44&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k45" id="item_k45">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k45" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k45">On the broken bridge just west of Corpse-Stench Shack</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k45&amp;id=stonesword_k45&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k45&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k45&amp;id=stonesword_k45&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k45&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k46" id="item_k46">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k46" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k46">Sold by the Nomadic Merchant here for 5000 runes</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k46&amp;id=stonesword_k46&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k46&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k46&amp;id=stonesword_k46&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k46&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k47" id="item_k47">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k47" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k47">North of Fort Laiedd, in the corner with gravestones and jellyfish, on a body against a large tree</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k47&amp;id=stonesword_k47&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k47&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k47&amp;id=stonesword_k47&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k47&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -689,18 +587,14 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k48" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k48">From the Prison Town Church grace, descend into the town square with an Omenkiller by a bonfire. Go through the doorway near the Omenkiller's initial position, proceed through another archway with a dog, and turn right. Go down the stairs to the broken gap. Instead of dropping all the way down (you can survive that fall), if you take a running jump, you can just barely reach the other end of the gap and land on the wooden platform, which has the key.</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k48&amp;id=stonesword_k48&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k48&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k48&amp;id=stonesword_k48&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k48&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k49" id="item_k49">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k49" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k49">Exit southeast from the room Rya moves to deep in Volcano Manor later in her questline, hop over the thin lava stream, and jump up the ledge through an open window to find the key on a body on a cot</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k49&amp;id=stonesword_k49&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k49&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k49&amp;id=stonesword_k49&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k49&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -710,18 +604,14 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k50" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k50">In Sealed Tunnel, when you emerge into an open room navigable by tree branches and containing many Vulgar Militia and an Iron Maiden, use the branches to get to the platform on the right side, which has a short dead-end path with the key on a body</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k50&amp;id=stonesword_k50&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k50&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k50&amp;id=stonesword_k50&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k50&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k51" id="item_k51">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k51" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k51">In Auriza Hero's Grave in the room with two chariots running opposite each other, on a body in an alcove in the center of their paths</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k51&amp;id=stonesword_k51&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k51&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k51&amp;id=stonesword_k51&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k51&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -731,54 +621,42 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k52" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k52">From East Capital Rampart, follow the rampart all the way south until just before the door into a building filled with plants, drop off the side of the rampart onto the rooftops, and hop between rooftops all the way back north, until you find the key on a body next to two Imps</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k52&amp;id=stonesword_k52&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k52&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k52&amp;id=stonesword_k52&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k52&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k53" id="item_k53">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k53" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k53">From West Capital Rampart, drop down to ground level and face northwest, then climb the petrified dragon foot and leap from its extended claw to the roof of a barn, and from there into the second floor of an adjacent building, with the key on a body draped over a windowsill</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k53&amp;id=stonesword_k53&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k53&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k53&amp;id=stonesword_k53&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k53&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k54" id="item_k54">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k54" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k54">From Avenue Balcony, head down the stairs and hook around them to the right, then down the ladder into a room with many enemies throwing lightning pots, and open the little cell on the ground floor to find a chest with the key inside</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k54&amp;id=stonesword_k54&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k54&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k54&amp;id=stonesword_k54&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k54&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k55" id="item_k55">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k55" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k55">From the previous, head out the door on the ground floor, and continue forward until you can hook around a little set of stairs up and right, to see two Skeletal Militiamen and a Putrid Corpse praying at a grave bearing a body with the key</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k55&amp;id=stonesword_k55&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k55&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k55&amp;id=stonesword_k55&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k55&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k56" id="item_k56">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k56" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k56">From Lower Capital Church, exit the church and wrap around the building to the right; climb the long ladder and the following ladder to emerge at a gazebo; hook right again before the gazebo, then turn left and follow the tight path until you can climb a large staircase on your left; finally, from the top of the staircase, face directly east and run and jump on top of the gazebo to loot the key from the body</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k56&amp;id=stonesword_k56&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k56&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k56&amp;id=stonesword_k56&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k56&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k57" id="item_k57">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k57" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k57">Subterranean Shunning-Grounds: From Underground Roadside, head northeast and drop through the gap in the floor grate, turn northwest and go into the tunnel in the right wall, drop into the first hole surrounded by Slugs, and follow the path from there into a room with three Wraith Callers and the key on a body</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k57&amp;id=stonesword_k57&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k57&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k57&amp;id=stonesword_k57&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k57&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -788,45 +666,35 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k58" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k58">Sold by the Hermit Merchant here for 5000 runes</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k58&amp;id=stonesword_k58&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k58&amp;title=Stonesword Key x3">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k58&amp;id=stonesword_k58&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k58&amp;title=Stonesword Key x3"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k59" id="item_k59">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k59" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k59">Sold by the Hermit Merchant here for 5000 runes</label>
-                    <a class="ms-2" href="/map.html?x=5960&amp;y=2238&amp;id=stonesword_k59&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k59&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5960&amp;y=2238&amp;id=stonesword_k59&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k59&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k60" id="item_k60">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k60" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k60">Sold by the Hermit Merchant here for 5000 runes</label>
-                    <a class="ms-2" href="/map.html?x=5960&amp;y=2238&amp;id=stonesword_k60&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k60&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5960&amp;y=2238&amp;id=stonesword_k60&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k60&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k61" id="item_k61">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k61" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k61">In Castle Sol, from the Church of the Eclipse, exit to the north, climb the ladder to the east, go all the way north, cross the wooden bridge, and climb the stairs on the right to find a body slumped over the wall on the left with the key</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k61&amp;id=stonesword_k61&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k61&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k61&amp;id=stonesword_k61&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k61&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k62" id="item_k62">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k62" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k62">On a body right behind the Fire Prelate outside Guardians' Garrison</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k62&amp;id=stonesword_k62&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k62&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k62&amp;id=stonesword_k62&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k62&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -836,18 +704,14 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k63" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k63">From Inner Consecrated Snowfield, look at your compass and travel exactly one notch north of West, to a hill guarded by two lightning balls; on top is a chair with a corpse with the key</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k63&amp;id=stonesword_k63&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k63&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k63&amp;id=stonesword_k63&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k63&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k64" id="item_k64">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k64" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k64">In the northwest of Yelough Anix Ruins, in a tiny crumbling room packed with four frenzied rats</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k64&amp;id=stonesword_k64&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k64&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k64&amp;id=stonesword_k64&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k64&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -857,18 +721,14 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k65" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k65">Directly south of Haligtree Canopy on a body at the tip of the same branch</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k65&amp;id=stonesword_k65&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k65&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k65&amp;id=stonesword_k65&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k65&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k66" id="item_k66">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k66" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k66">From Haligtree Canopy, head east, dropping down when necessary to reach the first Large Oracle Envoy; follow the branch from there east/northeast until you can reach a large central branch with Giant Ants patrolling; follow the large branch south until its first offshoot on the left, which you can follow around in a large ascending circle onto a wide branch above with a scarlot rot flavored Giant Miranda Sprout; face northwest and walk along this branch until its first offshoot at a sharp left angle, at the end of which is an Oracle Envoy and a body with the key</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k66&amp;id=stonesword_k66&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k66&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k66&amp;id=stonesword_k66&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k66&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -878,9 +738,7 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k67" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k67">In the back of the Dragon Temple to the east, on a body near a ledge</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k67&amp;id=stonesword_k67&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k67&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k67&amp;id=stonesword_k67&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k67&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -890,45 +748,35 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k68" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k68">Sold by the Abandoned Merchant for 2000 runes</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k68&amp;id=stonesword_k68&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k68&amp;title=Stonesword Key x3">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k68&amp;id=stonesword_k68&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k68&amp;title=Stonesword Key x3"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k69" id="item_k69">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k69" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k69">Sold by the Abandoned Merchant for 2000 runes</label>
-                    <a class="ms-2" href="/map.html?x=6289&amp;y=14256&amp;id=stonesword_k69&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k69&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6289&amp;y=14256&amp;id=stonesword_k69&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k69&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k70" id="item_k70">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k70" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k70">Sold by the Abandoned Merchant for 2000 runes</label>
-                    <a class="ms-2" href="/map.html?x=6289&amp;y=14256&amp;id=stonesword_k70&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k70&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6289&amp;y=14256&amp;id=stonesword_k70&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k70&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k71" id="item_k71">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k71" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k71">At the end of the long bridge/wall protruding from the southwest of Siofra River, accessed via a spiritspring in front of it</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k71&amp;id=stonesword_k71&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k71&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k71&amp;id=stonesword_k71&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k71&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k72" id="item_k72">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k72" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k72">From the Below the Well grace, travel southwest along the right cliffside until you find a bridge leading to the other side near a Golden Tree; turn left at the other side and hop onto the pillar there, then run down the attached beam to the next pillar, which hides a body with a key</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k72&amp;id=stonesword_k72&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k72&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k72&amp;id=stonesword_k72&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k72&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -938,9 +786,7 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k73" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k73">On a body just south of the Aqueduct-Facing Cliffs grace, right outside the cave, where you drop down from the ledge above with the jellyfish to reach it</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k73&amp;id=stonesword_k73&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k73&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k73&amp;id=stonesword_k73&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k73&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -950,18 +796,14 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k74" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k74">On a body in water surrounded by many frenzied Miranda Sprouts, near the waterfall just southwest of Uld Palace Ruins</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k74&amp;id=stonesword_k74&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k74&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k74&amp;id=stonesword_k74&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k74&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k75" id="item_k75">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k75" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k75">In Nokstella, Eternal City, directly north of the elevator to Nokstella Waterfall Basin, on a cliff under a ledge</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k75&amp;id=stonesword_k75&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k75&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k75&amp;id=stonesword_k75&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k75&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -971,9 +813,7 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k76" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k76">Atop the very tall square building directly southeast of Crucible Knight Siluria, reached via the spiritspring next to the building</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k76&amp;id=stonesword_k76&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k76&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k76&amp;id=stonesword_k76&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k76&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -983,63 +823,49 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k77" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k77">On the south end of the area with many Giant Crows, on a body on the ground in the open</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k77&amp;id=stonesword_k77&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k77&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k77&amp;id=stonesword_k77&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k77&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k78" id="item_k78">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k78" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k78">Along the path up from Dynasty Mausoleum Entrance, just past the Giant Skeletal Slime, turn right for a dead end side path with many praying Putrid Corpses and a key on a body against a rock</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k78&amp;id=stonesword_k78&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k78&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k78&amp;id=stonesword_k78&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k78&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k79" id="item_k79">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k79" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k79">Sold by the Imprisoned Merchant for 5000 runes</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_k79&amp;id=stonesword_k79&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k79&amp;title=Stonesword Key x5">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_k79&amp;id=stonesword_k79&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k79&amp;title=Stonesword Key x5"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k80" id="item_k80">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k80" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k80">Sold by the Imprisoned Merchant for 5000 runes</label>
-                    <a class="ms-2" href="/map.html?x=6793&amp;y=14474&amp;id=stonesword_k80&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k80&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6793&amp;y=14474&amp;id=stonesword_k80&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k80&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k81" id="item_k81">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k81" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k81">Sold by the Imprisoned Merchant for 5000 runes</label>
-                    <a class="ms-2" href="/map.html?x=6793&amp;y=14474&amp;id=stonesword_k81&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k81&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6793&amp;y=14474&amp;id=stonesword_k81&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k81&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k82" id="item_k82">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k82" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k82">Sold by the Imprisoned Merchant for 5000 runes</label>
-                    <a class="ms-2" href="/map.html?x=6793&amp;y=14474&amp;id=stonesword_k82&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k82&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6793&amp;y=14474&amp;id=stonesword_k82&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k82&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_k83" id="item_k83">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="stonesword_k83" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_k83">Sold by the Imprisoned Merchant for 5000 runes</label>
-                    <a class="ms-2" href="/map.html?x=6793&amp;y=14474&amp;id=stonesword_k83&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k83&amp;title=Stonesword Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6793&amp;y=14474&amp;id=stonesword_k83&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_k83&amp;title=Stonesword Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -1049,9 +875,7 @@
         <div class="card shadow-sm mb-3" id="stonesword_section_1">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#stonesword_1Col" data-bs-toggle="collapse" href="#stonesword_1Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#stonesword_1Col" data-bs-toggle="collapse" href="#stonesword_1Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Imp Statue Seals</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="stonesword_totals_1"></span>
             </h4>
@@ -1062,18 +886,14 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="stonesword_s1" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_s1">2 keys: The entrance to Fringefolk Hero's Grave</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_s1&amp;id=stonesword_s1&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s1&amp;title=Imp Statue Seal (2 keys)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_s1&amp;id=stonesword_s1&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s1&amp;title=Imp Statue Seal (2 keys)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_s2" id="item_s2">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="stonesword_s2" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_s2">1 key: A cellar in eastern Summonwater Village containing the Green Turtle Talisman</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_s2&amp;id=stonesword_s2&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s2&amp;title=Imp Statue Seal (1 key)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_s2&amp;id=stonesword_s2&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s2&amp;title=Imp Statue Seal (1 key)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -1083,18 +903,14 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="stonesword_s3" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_s3">1 key: A small room down the stairs near Smithing Master Hewg containing Crepus's Black-Key Crossbow and another Imp Statue Seal</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_s3&amp;id=stonesword_s3&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s3&amp;title=Imp Statue Seal (1 key)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_s3&amp;id=stonesword_s3&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s3&amp;title=Imp Statue Seal (1 key)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_s4" id="item_s4">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="stonesword_s4" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_s4">2 keys: A small room accessed via the previous, containing the Assassin's Prayerbook</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_s4&amp;id=stonesword_s4&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s4&amp;title=Imp Statue Seal (2 keys)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_s4&amp;id=stonesword_s4&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s4&amp;title=Imp Statue Seal (2 keys)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -1104,18 +920,14 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="stonesword_s5" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_s5">1 key: A small room in Tombsward Catacombs containing Nomadic Warrior's Cookbook [9]</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_s5&amp;id=stonesword_s5&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s5&amp;title=Imp Statue Seal (1 key)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_s5&amp;id=stonesword_s5&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s5&amp;title=Imp Statue Seal (1 key)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_s6" id="item_s6">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="stonesword_s6" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_s6">1 key: Unlocks Weeping Evergaol</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_s6&amp;id=stonesword_s6&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s6&amp;title=Imp Statue Seal (1 key)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_s6&amp;id=stonesword_s6&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s6&amp;title=Imp Statue Seal (1 key)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -1125,18 +937,14 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="stonesword_s7" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_s7">1 key: A cellar down some stairs in the main courtyard opposite Liftside Chamber, on the other side of a room full of rats; contains the Godskin Prayerbook, the Godslayer's Seal, and a shortcut door</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_s7&amp;id=stonesword_s7&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s7&amp;title=Imp Statue Seal (1 key)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_s7&amp;id=stonesword_s7&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s7&amp;title=Imp Statue Seal (1 key)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_s8" id="item_s8">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="stonesword_s8" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_s8">1 key: A small room out the northwest of the main hall with the Grafted Scion, containing the Iron Whetblade, a Miséricorde, and a Hawk Crest Wooden Shield</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_s8&amp;id=stonesword_s8&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s8&amp;title=Imp Statue Seal (1 key)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_s8&amp;id=stonesword_s8&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s8&amp;title=Imp Statue Seal (1 key)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -1146,36 +954,28 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="stonesword_s9" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_s9">1 key: A small room in Cliffbottom Catacombs containing the Nox Mirrorhelm</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_s9&amp;id=stonesword_s9&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s9&amp;title=Imp Statue Seal (1 key)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_s9&amp;id=stonesword_s9&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s9&amp;title=Imp Statue Seal (1 key)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_s10" id="item_s10">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="stonesword_s10" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_s10">2 keys: The entrance to Academy Crystal Cave</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_s10&amp;id=stonesword_s10&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s10&amp;title=Imp Statue Seal (2 keys)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_s10&amp;id=stonesword_s10&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s10&amp;title=Imp Statue Seal (2 keys)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_s11" id="item_s11">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="stonesword_s11" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_s11">1 key: A small room in Black Knife Catacombs containing Rosus' Axe</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_s11&amp;id=stonesword_s11&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s11&amp;title=Imp Statue Seal (1 key)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_s11&amp;id=stonesword_s11&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s11&amp;title=Imp Statue Seal (1 key)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_s12" id="item_s12">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="stonesword_s12" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_s12">1 key: A cellar in Lunar Estate Ruins up by the Moonlight Altar accessed late in Ranni's questline. The Imp Statue appears to be by itself, with its seal located to its right underneath an illusory floor blocking a hidden basement. Contains the Cerulean Amber Medallion +2.</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_s12&amp;id=stonesword_s12&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s12&amp;title=Imp Statue Seal (1 key)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_s12&amp;id=stonesword_s12&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s12&amp;title=Imp Statue Seal (1 key)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -1185,18 +985,14 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="stonesword_s13" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_s13">2 keys: The entrance to Gaol Cave</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_s13&amp;id=stonesword_s13&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s13&amp;title=Imp Statue Seal (2 keys)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_s13&amp;id=stonesword_s13&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s13&amp;title=Imp Statue Seal (2 keys)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_s14" id="item_s14">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="stonesword_s14" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_s14">1 key: A cellar in Forsaken Ruins containing the Sword of St. Trina</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_s14&amp;id=stonesword_s14&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s14&amp;title=Imp Statue Seal (1 key)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_s14&amp;id=stonesword_s14&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s14&amp;title=Imp Statue Seal (1 key)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -1206,54 +1002,42 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="stonesword_s15" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_s15">1 key: Unlocks Golden Lineage Evergaol</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_s15&amp;id=stonesword_s15&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s15&amp;title=Imp Statue Seal (1 key)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_s15&amp;id=stonesword_s15&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s15&amp;title=Imp Statue Seal (1 key)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_s16" id="item_s16">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="stonesword_s16" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_s16">2 keys: The entrance to Unsightly Catacombs</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_s16&amp;id=stonesword_s16&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s16&amp;title=Imp Statue Seal (2 keys)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_s16&amp;id=stonesword_s16&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s16&amp;title=Imp Statue Seal (2 keys)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_s21" id="item_s21">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="stonesword_s21" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_s21">1 key: A cellar near the top of Wyndham Ruins containing the Pearldrake Talisman +1</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_s21&amp;id=stonesword_s21&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s21&amp;title=Imp Statue Seal (1 key)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_s21&amp;id=stonesword_s21&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s21&amp;title=Imp Statue Seal (1 key)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_s17" id="item_s17">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="stonesword_s17" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_s17">1 key: A small room in Sainted Hero's Grave containing the Crimson Seed Talisman</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_s17&amp;id=stonesword_s17&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s17&amp;title=Imp Statue Seal (1 key)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_s17&amp;id=stonesword_s17&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s17&amp;title=Imp Statue Seal (1 key)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_s18" id="item_s18">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="stonesword_s18" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_s18">1 key: A small room much farther into Sainted Hero's Grave containing a Ghost Glovewort [5] and the Dragoncrest Shield Talisman +1</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_s18&amp;id=stonesword_s18&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s18&amp;title=Imp Statue Seal (1 key)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_s18&amp;id=stonesword_s18&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s18&amp;title=Imp Statue Seal (1 key)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_s19" id="item_s19">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="stonesword_s19" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_s19">2 keys: The entrance to Old Altus Tunnel</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_s19&amp;id=stonesword_s19&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s19&amp;title=Imp Statue Seal (2 keys)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_s19&amp;id=stonesword_s19&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s19&amp;title=Imp Statue Seal (2 keys)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -1263,18 +1047,14 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="stonesword_s20" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_s20">2 keys: The entrance to Seethewater Cave</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_s20&amp;id=stonesword_s20&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s20&amp;title=Imp Statue Seal (2 keys)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_s20&amp;id=stonesword_s20&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s20&amp;title=Imp Statue Seal (2 keys)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_s22" id="item_s22">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="stonesword_s22" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_s22">1 key: A small room in Wyndham Catacombs containing the Lightning Scorpion Charm</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_s22&amp;id=stonesword_s22&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s22&amp;title=Imp Statue Seal (1 key)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_s22&amp;id=stonesword_s22&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s22&amp;title=Imp Statue Seal (1 key)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -1284,18 +1064,14 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="stonesword_s23" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_s23">1 key: A building along the main path from Prison Town Church with an Abductor Virgin and a spiral staircase to the Crimson Amber Medallion +1</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_s23&amp;id=stonesword_s23&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s23&amp;title=Imp Statue Seal (1 key)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_s23&amp;id=stonesword_s23&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s23&amp;title=Imp Statue Seal (1 key)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_s24" id="item_s24">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="stonesword_s24" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_s24">2 keys: In the grand hall with an eastern upstairs exit to a balcony with the teleporter to Audience Chamber, climb the west-facing stairs instead; a cavernous room with hanging cages that leads to the Dagger Talisman, a Seedbed Curse, a Somber Smithing Stone [7], and eventually a shortcut door</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_s24&amp;id=stonesword_s24&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s24&amp;title=Imp Statue Seal (2 keys)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_s24&amp;id=stonesword_s24&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s24&amp;title=Imp Statue Seal (2 keys)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -1305,9 +1081,7 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="stonesword_s25" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_s25">1 key: A small room in Auriza Hero's Grave containing the Golden Epitaph</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_s25&amp;id=stonesword_s25&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s25&amp;title=Imp Statue Seal (1 key)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_s25&amp;id=stonesword_s25&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s25&amp;title=Imp Statue Seal (1 key)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -1317,18 +1091,14 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="stonesword_s26" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_s26">2 keys: The entrance to Spiritcaller Cave</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_s26&amp;id=stonesword_s26&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s26&amp;title=Imp Statue Seal (2 keys)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_s26&amp;id=stonesword_s26&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s26&amp;title=Imp Statue Seal (2 keys)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_s27" id="item_s27">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="stonesword_s27" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_s27">1 key: A small room in Giant-Conquering Hero's Grave containing Flame, Protect Me</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_s27&amp;id=stonesword_s27&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s27&amp;title=Imp Statue Seal (1 key)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_s27&amp;id=stonesword_s27&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s27&amp;title=Imp Statue Seal (1 key)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -1338,9 +1108,7 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="stonesword_s28" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_s28">2 keys: The entrance to Cave of the Forlorn</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_s28&amp;id=stonesword_s28&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s28&amp;title=Imp Statue Seal (2 keys)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_s28&amp;id=stonesword_s28&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s28&amp;title=Imp Statue Seal (2 keys)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -1350,18 +1118,14 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="stonesword_s29" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_s29">1 key: Drop down twice immediately after the Prayer Room grace; a small room containing Triple Rings of Light</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_s29&amp;id=stonesword_s29&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s29&amp;title=Imp Statue Seal (1 key)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_s29&amp;id=stonesword_s29&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s29&amp;title=Imp Statue Seal (1 key)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="stonesword_s30" id="item_s30">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="stonesword_s30" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_s30">1 key: Visible below from the previous, but must be climbed down to further on, e.g. via the pillars; a small room containing the Marika's Soreseal</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_s30&amp;id=stonesword_s30&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s30&amp;title=Imp Statue Seal (1 key)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_s30&amp;id=stonesword_s30&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s30&amp;title=Imp Statue Seal (1 key)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -1371,9 +1135,7 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="stonesword_s31" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_s31">2 keys: Unlocks the Dragon Temple Lift</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_s31&amp;id=stonesword_s31&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s31&amp;title=Imp Statue Seal (2 keys)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_s31&amp;id=stonesword_s31&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s31&amp;title=Imp Statue Seal (2 keys)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -1383,9 +1145,7 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="stonesword_s32" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_s32">2 keys: The elevator up to Deep Siofra Well</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_s32&amp;id=stonesword_s32&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s32&amp;title=Imp Statue Seal (2 keys)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_s32&amp;id=stonesword_s32&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s32&amp;title=Imp Statue Seal (2 keys)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -1395,9 +1155,7 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="stonesword_s33" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_s33">1 key: A room down a small hall in the massive cathedral with a large ball in Night's Sacred Ground, upstairs near the altar with the Black Whetblade; contains the Mimic Tear Ashes</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_s33&amp;id=stonesword_s33&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s33&amp;title=Imp Statue Seal (1 key)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_s33&amp;id=stonesword_s33&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s33&amp;title=Imp Statue Seal (1 key)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -1407,9 +1165,7 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="stonesword_s34" type="checkbox" value="">
                     <label class="form-check-label item_content" for="stonesword_s34">1 key: A room along the path to the top, tucked around the far side of a building before the bridge leading to a large ball on a stairway; contains two Nox Monks guarding the Nightmaiden & Swordstress Puppets</label>
-                    <a class="ms-2" href="/map.html?target=stonesword_s34&amp;id=stonesword_s34&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s34&amp;title=Imp Statue Seal (1 key)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?target=stonesword_s34&amp;id=stonesword_s34&amp;link=/checklists/stonesword_keys_imp_seals.html%23item_s34&amp;title=Imp Statue Seal (1 key)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>

--- a/docs/checklists/talismans.html
+++ b/docs/checklists/talismans.html
@@ -27,14 +27,10 @@
         <a class="navbar-brand me-auto ms-2" href="/index.html">Roundtable Guides</a>
         <form class="d-none d-sm-flex order-2 order-xl-3">
           <input aria-label="search" class="form-control me-2" name="search" placeholder="Search" type="search">
-          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit">
-            <i class="bi bi-search"></i>
-          </button>
+          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit"><i class="bi bi-search"></i></button>
         </form>
         <div class="d-sm-none order-2">
-          <a class="nav-link me-0" href="/search.html">
-            <i class="bi bi-search sb-icon-search"></i>
-          </a>
+          <a class="nav-link me-0" href="/search.html"><i class="bi bi-search sb-icon-search"></i></a>
         </div>
         <div class="collapse navbar-collapse order-3 order-xl-2 ms-xl-2" id="nav-collapse">
           <ul class="nav navbar-nav navbar-nav-scroll mr-auto">
@@ -179,14 +175,10 @@
               </ul>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/map.html">
-                <i class="bi bi-map"></i> Map
-              </a>
+              <a class="nav-link hide-buttons" href="/map.html"><i class="bi bi-map"></i> Map</a>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/options.html">
-                <i class="bi bi-gear-fill"></i> Options
-              </a>
+              <a class="nav-link hide-buttons" href="/options.html"><i class="bi bi-gear-fill"></i> Options</a>
             </li>
           </ul>
         </div>
@@ -206,9 +198,7 @@
       </div>
       <nav class="text-muted toc d-print-none">
         <strong class="d-block h5">
-          <a class="toc-button" data-bs-toggle="collapse" href="#toc_talismans" role="button">
-            <i class="bi bi-plus-lg"></i>Table Of Contents
-          </a>
+          <a class="toc-button" data-bs-toggle="collapse" href="#toc_talismans" role="button"><i class="bi bi-plus-lg"></i>Table Of Contents</a>
         </strong>
         <ul class="toc_page collapse" id="toc_talismans">
           <li>
@@ -300,9 +290,7 @@
         <div class="card shadow-sm mb-3" id="talismans_section_0">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#talismans_0Col" data-bs-toggle="collapse" href="#talismans_0Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#talismans_0Col" data-bs-toggle="collapse" href="#talismans_0Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Limgrave</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="talismans_totals_0"></span>
             </h4>
@@ -314,9 +302,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -345,9 +331,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="talismans_2_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_2_1&amp;id=talismans_2_1&amp;link=/checklists/talismans.html%23item_2_1&amp;title=Crimson Amber Medallion">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_2_1&amp;id=talismans_2_1&amp;link=/checklists/talismans.html%23item_2_1&amp;title=Crimson Amber Medallion"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -380,9 +364,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="talismans_2_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_2_2&amp;id=talismans_2_2&amp;link=/checklists/talismans.html%23item_2_2&amp;title=Roar Medallion">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_2_2&amp;id=talismans_2_2&amp;link=/checklists/talismans.html%23item_2_2&amp;title=Roar Medallion"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -415,9 +397,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="talismans_2_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_2_3&amp;id=talismans_2_3&amp;link=/checklists/talismans.html%23item_2_3&amp;title=Flamedrake Talisman">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_2_3&amp;id=talismans_2_3&amp;link=/checklists/talismans.html%23item_2_3&amp;title=Flamedrake Talisman"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -450,9 +430,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="talismans_2_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_2_4&amp;id=talismans_2_4&amp;link=/checklists/talismans.html%23item_2_4&amp;title=Haligdrake Talisman">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_2_4&amp;id=talismans_2_4&amp;link=/checklists/talismans.html%23item_2_4&amp;title=Haligdrake Talisman"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -485,9 +463,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="talismans_2_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_2_5&amp;id=talismans_2_5&amp;link=/checklists/talismans.html%23item_2_5&amp;title=Axe Talisman">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_2_5&amp;id=talismans_2_5&amp;link=/checklists/talismans.html%23item_2_5&amp;title=Axe Talisman"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -520,9 +496,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="talismans_2_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_2_6&amp;id=talismans_2_6&amp;link=/checklists/talismans.html%23item_2_6&amp;title=Prince of Death's Pustule">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_2_6&amp;id=talismans_2_6&amp;link=/checklists/talismans.html%23item_2_6&amp;title=Prince of Death's Pustule"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -555,9 +529,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="talismans_2_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_2_7&amp;id=talismans_2_7&amp;link=/checklists/talismans.html%23item_2_7&amp;title=Claw Talisman">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_2_7&amp;id=talismans_2_7&amp;link=/checklists/talismans.html%23item_2_7&amp;title=Claw Talisman"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -590,9 +562,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="talismans_2_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_2_8&amp;id=talismans_2_8&amp;link=/checklists/talismans.html%23item_2_8&amp;title=Curved Sword Talisman">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_2_8&amp;id=talismans_2_8&amp;link=/checklists/talismans.html%23item_2_8&amp;title=Curved Sword Talisman"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -625,9 +595,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="talismans_2_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_2_9&amp;id=talismans_2_9&amp;link=/checklists/talismans.html%23item_2_9&amp;title=Boltdrake Talisman">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_2_9&amp;id=talismans_2_9&amp;link=/checklists/talismans.html%23item_2_9&amp;title=Boltdrake Talisman"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -660,9 +628,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="talismans_2_10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_2_10&amp;id=talismans_2_10&amp;link=/checklists/talismans.html%23item_2_10&amp;title=Green Turtle Talisman">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_2_10&amp;id=talismans_2_10&amp;link=/checklists/talismans.html%23item_2_10&amp;title=Green Turtle Talisman"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -695,9 +661,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="talismans_2_11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_2_11&amp;id=talismans_2_11&amp;link=/checklists/talismans.html%23item_2_11&amp;title=Hammer Talisman">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_2_11&amp;id=talismans_2_11&amp;link=/checklists/talismans.html%23item_2_11&amp;title=Hammer Talisman"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -730,9 +694,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="talismans_2_12" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_2_12&amp;id=talismans_2_12&amp;link=/checklists/talismans.html%23item_2_12&amp;title=Arrow's Reach Talisman">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_2_12&amp;id=talismans_2_12&amp;link=/checklists/talismans.html%23item_2_12&amp;title=Arrow's Reach Talisman"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -765,9 +727,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="talismans_2_13" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_2_13&amp;id=talismans_2_13&amp;link=/checklists/talismans.html%23item_2_13&amp;title=Blue Dancer Charm">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_2_13&amp;id=talismans_2_13&amp;link=/checklists/talismans.html%23item_2_13&amp;title=Blue Dancer Charm"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -800,9 +760,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="talismans_2_14" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_2_14&amp;id=talismans_2_14&amp;link=/checklists/talismans.html%23item_2_14&amp;title=Lance Talisman">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_2_14&amp;id=talismans_2_14&amp;link=/checklists/talismans.html%23item_2_14&amp;title=Lance Talisman"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -835,9 +793,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="talismans_2_15" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_2_15&amp;id=talismans_2_15&amp;link=/checklists/talismans.html%23item_2_15&amp;title=Sacrificial Twig">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_2_15&amp;id=talismans_2_15&amp;link=/checklists/talismans.html%23item_2_15&amp;title=Sacrificial Twig"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -870,9 +826,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="talismans_2_20" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_2_20&amp;id=talismans_2_20&amp;link=/checklists/talismans.html%23item_2_20&amp;title=Sacrificial Twig">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_2_20&amp;id=talismans_2_20&amp;link=/checklists/talismans.html%23item_2_20&amp;title=Sacrificial Twig"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -905,9 +859,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="talismans_2_16" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_2_16&amp;id=talismans_2_16&amp;link=/checklists/talismans.html%23item_2_16&amp;title=Erdtree's Favor">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_2_16&amp;id=talismans_2_16&amp;link=/checklists/talismans.html%23item_2_16&amp;title=Erdtree's Favor"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -940,9 +892,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="talismans_2_17" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_2_17&amp;id=talismans_2_17&amp;link=/checklists/talismans.html%23item_2_17&amp;title=Blue-Feathered Branchsword">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_2_17&amp;id=talismans_2_17&amp;link=/checklists/talismans.html%23item_2_17&amp;title=Blue-Feathered Branchsword"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -975,9 +925,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="talismans_2_18" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_2_18&amp;id=talismans_2_18&amp;link=/checklists/talismans.html%23item_2_18&amp;title=Assassin's Crimson Dagger">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_2_18&amp;id=talismans_2_18&amp;link=/checklists/talismans.html%23item_2_18&amp;title=Assassin's Crimson Dagger"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1010,9 +958,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="talismans_2_19" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_2_19&amp;id=talismans_2_19&amp;link=/checklists/talismans.html%23item_2_19&amp;title=Sacred Scorpion Charm">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_2_19&amp;id=talismans_2_19&amp;link=/checklists/talismans.html%23item_2_19&amp;title=Sacred Scorpion Charm"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1046,9 +992,7 @@
         <div class="card shadow-sm mb-3" id="talismans_section_1">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#talismans_1Col" data-bs-toggle="collapse" href="#talismans_1Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#talismans_1Col" data-bs-toggle="collapse" href="#talismans_1Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Weeping Peninsula</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="talismans_totals_1"></span>
             </h4>
@@ -1060,9 +1004,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -1091,9 +1033,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="talismans_1_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_1_1&amp;id=talismans_1_1&amp;link=/checklists/talismans.html%23item_1_1&amp;title=Crimson Amber Medallion">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_1_1&amp;id=talismans_1_1&amp;link=/checklists/talismans.html%23item_1_1&amp;title=Crimson Amber Medallion"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1126,9 +1066,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="talismans_1_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_1_2&amp;id=talismans_1_2&amp;link=/checklists/talismans.html%23item_1_2&amp;title=Sacrificial Twig (x3)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_1_2&amp;id=talismans_1_2&amp;link=/checklists/talismans.html%23item_1_2&amp;title=Sacrificial Twig (x3)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1161,9 +1099,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="talismans_1_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_1_3&amp;id=talismans_1_3&amp;link=/checklists/talismans.html%23item_1_3&amp;title=Viridian Amber Medallion">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_1_3&amp;id=talismans_1_3&amp;link=/checklists/talismans.html%23item_1_3&amp;title=Viridian Amber Medallion"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1196,9 +1132,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="talismans_1_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_1_4&amp;id=talismans_1_4&amp;link=/checklists/talismans.html%23item_1_4&amp;title=Sacrificial Twig">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_1_4&amp;id=talismans_1_4&amp;link=/checklists/talismans.html%23item_1_4&amp;title=Sacrificial Twig"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1231,9 +1165,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="talismans_1_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_1_5&amp;id=talismans_1_5&amp;link=/checklists/talismans.html%23item_1_5&amp;title=Spelldrake Talisman">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_1_5&amp;id=talismans_1_5&amp;link=/checklists/talismans.html%23item_1_5&amp;title=Spelldrake Talisman"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1266,9 +1198,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="talismans_1_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_1_6&amp;id=talismans_1_6&amp;link=/checklists/talismans.html%23item_1_6&amp;title=Radagon's Scarseal">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_1_6&amp;id=talismans_1_6&amp;link=/checklists/talismans.html%23item_1_6&amp;title=Radagon's Scarseal"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1301,9 +1231,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="talismans_1_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_1_7&amp;id=talismans_1_7&amp;link=/checklists/talismans.html%23item_1_7&amp;title=Twinblade Talisman">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_1_7&amp;id=talismans_1_7&amp;link=/checklists/talismans.html%23item_1_7&amp;title=Twinblade Talisman"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1337,9 +1265,7 @@
         <div class="card shadow-sm mb-3" id="talismans_section_2">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#talismans_2Col" data-bs-toggle="collapse" href="#talismans_2Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#talismans_2Col" data-bs-toggle="collapse" href="#talismans_2Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Roundtable Hold</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="talismans_totals_2"></span>
             </h4>
@@ -1351,9 +1277,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -1382,9 +1306,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="talismans_3_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_3_1&amp;id=talismans_3_1&amp;link=/checklists/talismans.html%23item_3_1&amp;title=Arsenal Charm">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_3_1&amp;id=talismans_3_1&amp;link=/checklists/talismans.html%23item_3_1&amp;title=Arsenal Charm"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1417,9 +1339,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="talismans_3_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_3_2&amp;id=talismans_3_2&amp;link=/checklists/talismans.html%23item_3_2&amp;title=Furled Finger's Trick-Mirror">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_3_2&amp;id=talismans_3_2&amp;link=/checklists/talismans.html%23item_3_2&amp;title=Furled Finger's Trick-Mirror"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1452,9 +1372,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="talismans_3_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_3_3&amp;id=talismans_3_3&amp;link=/checklists/talismans.html%23item_3_3&amp;title=Host's Trick-Mirror">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_3_3&amp;id=talismans_3_3&amp;link=/checklists/talismans.html%23item_3_3&amp;title=Host's Trick-Mirror"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1487,9 +1405,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="talismans_3_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_3_4&amp;id=talismans_3_4&amp;link=/checklists/talismans.html%23item_3_4&amp;title=Ancestral Spirit's Horn">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_3_4&amp;id=talismans_3_4&amp;link=/checklists/talismans.html%23item_3_4&amp;title=Ancestral Spirit's Horn"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1523,9 +1439,7 @@
         <div class="card shadow-sm mb-3" id="talismans_section_3">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#talismans_3Col" data-bs-toggle="collapse" href="#talismans_3Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#talismans_3Col" data-bs-toggle="collapse" href="#talismans_3Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Liurnia of the Lakes</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="talismans_totals_3"></span>
             </h4>
@@ -1537,9 +1451,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -1568,9 +1480,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="talismans_4_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_4_1&amp;id=talismans_4_1&amp;link=/checklists/talismans.html%23item_4_1&amp;title=Assassin's Cerulean Dagger">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_4_1&amp;id=talismans_4_1&amp;link=/checklists/talismans.html%23item_4_1&amp;title=Assassin's Cerulean Dagger"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1603,9 +1513,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="talismans_4_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_4_2&amp;id=talismans_4_2&amp;link=/checklists/talismans.html%23item_4_2&amp;title=Sacrificial Twig">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_4_2&amp;id=talismans_4_2&amp;link=/checklists/talismans.html%23item_4_2&amp;title=Sacrificial Twig"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1638,9 +1546,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="talismans_4_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_4_3&amp;id=talismans_4_3&amp;link=/checklists/talismans.html%23item_4_3&amp;title=Graven-School Talisman">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_4_3&amp;id=talismans_4_3&amp;link=/checklists/talismans.html%23item_4_3&amp;title=Graven-School Talisman"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1673,9 +1579,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="talismans_4_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_4_4&amp;id=talismans_4_4&amp;link=/checklists/talismans.html%23item_4_4&amp;title=Radagon Icon">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_4_4&amp;id=talismans_4_4&amp;link=/checklists/talismans.html%23item_4_4&amp;title=Radagon Icon"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1708,9 +1612,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="talismans_4_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_4_5&amp;id=talismans_4_5&amp;link=/checklists/talismans.html%23item_4_5&amp;title=Longtail Cat Talisman">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_4_5&amp;id=talismans_4_5&amp;link=/checklists/talismans.html%23item_4_5&amp;title=Longtail Cat Talisman"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1743,9 +1645,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="talismans_4_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_4_6&amp;id=talismans_4_6&amp;link=/checklists/talismans.html%23item_4_6&amp;title=Cerulean Amber Medallion">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_4_6&amp;id=talismans_4_6&amp;link=/checklists/talismans.html%23item_4_6&amp;title=Cerulean Amber Medallion"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1778,9 +1678,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="talismans_4_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_4_7&amp;id=talismans_4_7&amp;link=/checklists/talismans.html%23item_4_7&amp;title=Cerulean Amber Medallion +2">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_4_7&amp;id=talismans_4_7&amp;link=/checklists/talismans.html%23item_4_7&amp;title=Cerulean Amber Medallion +2"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1813,9 +1711,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="talismans_4_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_4_8&amp;id=talismans_4_8&amp;link=/checklists/talismans.html%23item_4_8&amp;title=Stargazer Heirloom">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_4_8&amp;id=talismans_4_8&amp;link=/checklists/talismans.html%23item_4_8&amp;title=Stargazer Heirloom"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1848,9 +1744,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="talismans_4_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_4_9&amp;id=talismans_4_9&amp;link=/checklists/talismans.html%23item_4_9&amp;title=Two Fingers Heirloom">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_4_9&amp;id=talismans_4_9&amp;link=/checklists/talismans.html%23item_4_9&amp;title=Two Fingers Heirloom"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1883,9 +1777,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="talismans_4_10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_4_10&amp;id=talismans_4_10&amp;link=/checklists/talismans.html%23item_4_10&amp;title=Winged Sword Insignia">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_4_10&amp;id=talismans_4_10&amp;link=/checklists/talismans.html%23item_4_10&amp;title=Winged Sword Insignia"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1918,9 +1810,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="talismans_4_11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_4_11&amp;id=talismans_4_11&amp;link=/checklists/talismans.html%23item_4_11&amp;title=Stalwart Horn Charm">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_4_11&amp;id=talismans_4_11&amp;link=/checklists/talismans.html%23item_4_11&amp;title=Stalwart Horn Charm"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1953,9 +1843,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="talismans_4_12" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_4_12&amp;id=talismans_4_12&amp;link=/checklists/talismans.html%23item_4_12&amp;title=Magic Scorpion Charm">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_4_12&amp;id=talismans_4_12&amp;link=/checklists/talismans.html%23item_4_12&amp;title=Magic Scorpion Charm"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1988,9 +1876,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="talismans_4_13" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_4_13&amp;id=talismans_4_13&amp;link=/checklists/talismans.html%23item_4_13&amp;title=Red-Feathered Branchsword">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_4_13&amp;id=talismans_4_13&amp;link=/checklists/talismans.html%23item_4_13&amp;title=Red-Feathered Branchsword"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2023,9 +1909,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="talismans_4_14" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_4_14&amp;id=talismans_4_14&amp;link=/checklists/talismans.html%23item_4_14&amp;title=Spear Talisman">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_4_14&amp;id=talismans_4_14&amp;link=/checklists/talismans.html%23item_4_14&amp;title=Spear Talisman"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2058,9 +1942,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="talismans_4_15" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_4_15&amp;id=talismans_4_15&amp;link=/checklists/talismans.html%23item_4_15&amp;title=Pearldrake Talisman">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_4_15&amp;id=talismans_4_15&amp;link=/checklists/talismans.html%23item_4_15&amp;title=Pearldrake Talisman"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2093,9 +1975,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="talismans_4_16" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_4_16&amp;id=talismans_4_16&amp;link=/checklists/talismans.html%23item_4_16&amp;title=Cerulean Seed Talisman">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_4_16&amp;id=talismans_4_16&amp;link=/checklists/talismans.html%23item_4_16&amp;title=Cerulean Seed Talisman"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2128,9 +2008,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="talismans_4_17" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_4_17&amp;id=talismans_4_17&amp;link=/checklists/talismans.html%23item_4_17&amp;title=Crucible Knot Talisman">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_4_17&amp;id=talismans_4_17&amp;link=/checklists/talismans.html%23item_4_17&amp;title=Crucible Knot Talisman"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2163,9 +2041,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="talismans_4_18" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_4_18&amp;id=talismans_4_18&amp;link=/checklists/talismans.html%23item_4_18&amp;title=Carian Filigreed Crest">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_4_18&amp;id=talismans_4_18&amp;link=/checklists/talismans.html%23item_4_18&amp;title=Carian Filigreed Crest"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2198,9 +2074,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="talismans_4_19" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_4_19&amp;id=talismans_4_19&amp;link=/checklists/talismans.html%23item_4_19&amp;title=Shabriri's Woe">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_4_19&amp;id=talismans_4_19&amp;link=/checklists/talismans.html%23item_4_19&amp;title=Shabriri's Woe"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2233,9 +2107,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="talismans_4_20" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_4_20&amp;id=talismans_4_20&amp;link=/checklists/talismans.html%23item_4_20&amp;title=Companion Jar">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_4_20&amp;id=talismans_4_20&amp;link=/checklists/talismans.html%23item_4_20&amp;title=Companion Jar"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2269,9 +2141,7 @@
         <div class="card shadow-sm mb-3" id="talismans_section_4">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#talismans_4Col" data-bs-toggle="collapse" href="#talismans_4Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#talismans_4Col" data-bs-toggle="collapse" href="#talismans_4Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Caelid</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="talismans_totals_4"></span>
             </h4>
@@ -2283,9 +2153,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -2314,9 +2182,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="talismans_5_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_5_1&amp;id=talismans_5_1&amp;link=/checklists/talismans.html%23item_5_1&amp;title=Arrow's Sting Talisman">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_5_1&amp;id=talismans_5_1&amp;link=/checklists/talismans.html%23item_5_1&amp;title=Arrow's Sting Talisman"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2349,9 +2215,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="talismans_5_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_5_2&amp;id=talismans_5_2&amp;link=/checklists/talismans.html%23item_5_2&amp;title=Gold Scarab">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_5_2&amp;id=talismans_5_2&amp;link=/checklists/talismans.html%23item_5_2&amp;title=Gold Scarab"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2384,9 +2248,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="talismans_5_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_5_3&amp;id=talismans_5_3&amp;link=/checklists/talismans.html%23item_5_3&amp;title=Great-Jar's Arsenal">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_5_3&amp;id=talismans_5_3&amp;link=/checklists/talismans.html%23item_5_3&amp;title=Great-Jar's Arsenal"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2419,9 +2281,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="talismans_5_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_5_4&amp;id=talismans_5_4&amp;link=/checklists/talismans.html%23item_5_4&amp;title=Prosthesis-Wearer Heirloom">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_5_4&amp;id=talismans_5_4&amp;link=/checklists/talismans.html%23item_5_4&amp;title=Prosthesis-Wearer Heirloom"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2454,9 +2314,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="talismans_5_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_5_5&amp;id=talismans_5_5&amp;link=/checklists/talismans.html%23item_5_5&amp;title=Radagon's Soreseal">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_5_5&amp;id=talismans_5_5&amp;link=/checklists/talismans.html%23item_5_5&amp;title=Radagon's Soreseal"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2489,9 +2347,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="talismans_5_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_5_6&amp;id=talismans_5_6&amp;link=/checklists/talismans.html%23item_5_6&amp;title=Sacrificial Twig (x3)">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_5_6&amp;id=talismans_5_6&amp;link=/checklists/talismans.html%23item_5_6&amp;title=Sacrificial Twig (x3)"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2524,9 +2380,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="talismans_5_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_5_7&amp;id=talismans_5_7&amp;link=/checklists/talismans.html%23item_5_7&amp;title=Flamedrake Talisman +2">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_5_7&amp;id=talismans_5_7&amp;link=/checklists/talismans.html%23item_5_7&amp;title=Flamedrake Talisman +2"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2559,9 +2413,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="talismans_5_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_5_8&amp;id=talismans_5_8&amp;link=/checklists/talismans.html%23item_5_8&amp;title=Bull-Goat's Talisman">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_5_8&amp;id=talismans_5_8&amp;link=/checklists/talismans.html%23item_5_8&amp;title=Bull-Goat's Talisman"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2594,9 +2446,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="talismans_5_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_5_9&amp;id=talismans_5_9&amp;link=/checklists/talismans.html%23item_5_9&amp;title=Starscourge Heirloom">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_5_9&amp;id=talismans_5_9&amp;link=/checklists/talismans.html%23item_5_9&amp;title=Starscourge Heirloom"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2629,9 +2479,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="talismans_5_10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_5_10&amp;id=talismans_5_10&amp;link=/checklists/talismans.html%23item_5_10&amp;title=Faithful's Canvas Talisman">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_5_10&amp;id=talismans_5_10&amp;link=/checklists/talismans.html%23item_5_10&amp;title=Faithful's Canvas Talisman"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2664,9 +2512,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="talismans_5_11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_5_11&amp;id=talismans_5_11&amp;link=/checklists/talismans.html%23item_5_11&amp;title=Flock's Canvas Talisman">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_5_11&amp;id=talismans_5_11&amp;link=/checklists/talismans.html%23item_5_11&amp;title=Flock's Canvas Talisman"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2699,9 +2545,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="talismans_5_12" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_5_12&amp;id=talismans_5_12&amp;link=/checklists/talismans.html%23item_5_12&amp;title=Spelldrake Talisman +1">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_5_12&amp;id=talismans_5_12&amp;link=/checklists/talismans.html%23item_5_12&amp;title=Spelldrake Talisman +1"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2734,9 +2578,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="talismans_5_13" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_5_13&amp;id=talismans_5_13&amp;link=/checklists/talismans.html%23item_5_13&amp;title=Dragoncrest Shield Talisman">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_5_13&amp;id=talismans_5_13&amp;link=/checklists/talismans.html%23item_5_13&amp;title=Dragoncrest Shield Talisman"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2770,9 +2612,7 @@
         <div class="card shadow-sm mb-3" id="talismans_section_5">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#talismans_5Col" data-bs-toggle="collapse" href="#talismans_5Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#talismans_5Col" data-bs-toggle="collapse" href="#talismans_5Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Altus Plateau</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="talismans_totals_5"></span>
             </h4>
@@ -2784,9 +2624,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -2815,9 +2653,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="talismans_6_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_6_1&amp;id=talismans_6_1&amp;link=/checklists/talismans.html%23item_6_1&amp;title=Arsenal Charm +1">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_6_1&amp;id=talismans_6_1&amp;link=/checklists/talismans.html%23item_6_1&amp;title=Arsenal Charm +1"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2850,9 +2686,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="talismans_6_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_6_2&amp;id=talismans_6_2&amp;link=/checklists/talismans.html%23item_6_2&amp;title=Lightning Scorpion Charm">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_6_2&amp;id=talismans_6_2&amp;link=/checklists/talismans.html%23item_6_2&amp;title=Lightning Scorpion Charm"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2885,9 +2719,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="talismans_6_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_6_3&amp;id=talismans_6_3&amp;link=/checklists/talismans.html%23item_6_3&amp;title=Ritual Sword Talisman">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_6_3&amp;id=talismans_6_3&amp;link=/checklists/talismans.html%23item_6_3&amp;title=Ritual Sword Talisman"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2920,9 +2752,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="talismans_6_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_6_4&amp;id=talismans_6_4&amp;link=/checklists/talismans.html%23item_6_4&amp;title=Perfumer's Talisman">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_6_4&amp;id=talismans_6_4&amp;link=/checklists/talismans.html%23item_6_4&amp;title=Perfumer's Talisman"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2955,9 +2785,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="talismans_6_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_6_5&amp;id=talismans_6_5&amp;link=/checklists/talismans.html%23item_6_5&amp;title=Godfrey Icon">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_6_5&amp;id=talismans_6_5&amp;link=/checklists/talismans.html%23item_6_5&amp;title=Godfrey Icon"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2990,9 +2818,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="talismans_6_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_6_6&amp;id=talismans_6_6&amp;link=/checklists/talismans.html%23item_6_6&amp;title=Dragoncrest Shield Talisman +1">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_6_6&amp;id=talismans_6_6&amp;link=/checklists/talismans.html%23item_6_6&amp;title=Dragoncrest Shield Talisman +1"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3025,9 +2851,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="talismans_6_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_6_7&amp;id=talismans_6_7&amp;link=/checklists/talismans.html%23item_6_7&amp;title=Boltdrake Talisman +1">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_6_7&amp;id=talismans_6_7&amp;link=/checklists/talismans.html%23item_6_7&amp;title=Boltdrake Talisman +1"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3060,9 +2884,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="talismans_6_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_6_8&amp;id=talismans_6_8&amp;link=/checklists/talismans.html%23item_6_8&amp;title=Greatshield Talisman">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_6_8&amp;id=talismans_6_8&amp;link=/checklists/talismans.html%23item_6_8&amp;title=Greatshield Talisman"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3095,9 +2917,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="talismans_6_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_6_9&amp;id=talismans_6_9&amp;link=/checklists/talismans.html%23item_6_9&amp;title=Crimson Seed Talisman">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_6_9&amp;id=talismans_6_9&amp;link=/checklists/talismans.html%23item_6_9&amp;title=Crimson Seed Talisman"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3130,9 +2950,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="talismans_6_10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_6_10&amp;id=talismans_6_10&amp;link=/checklists/talismans.html%23item_6_10&amp;title=Concealing Veil">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_6_10&amp;id=talismans_6_10&amp;link=/checklists/talismans.html%23item_6_10&amp;title=Concealing Veil"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3165,9 +2983,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="talismans_6_11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_6_11&amp;id=talismans_6_11&amp;link=/checklists/talismans.html%23item_6_11&amp;title=Sacrificial Twig">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_6_11&amp;id=talismans_6_11&amp;link=/checklists/talismans.html%23item_6_11&amp;title=Sacrificial Twig"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3200,9 +3016,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="talismans_7_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_7_8&amp;id=talismans_7_8&amp;link=/checklists/talismans.html%23item_7_8&amp;title=Crepus's Vial">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_7_8&amp;id=talismans_7_8&amp;link=/checklists/talismans.html%23item_7_8&amp;title=Crepus's Vial"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3236,9 +3050,7 @@
         <div class="card shadow-sm mb-3" id="talismans_section_6">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#talismans_6Col" data-bs-toggle="collapse" href="#talismans_6Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#talismans_6Col" data-bs-toggle="collapse" href="#talismans_6Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Mt. Gelmir</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="talismans_totals_6"></span>
             </h4>
@@ -3250,9 +3062,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -3281,9 +3091,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="talismans_7_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_7_1&amp;id=talismans_7_1&amp;link=/checklists/talismans.html%23item_7_1&amp;title=Crimson Amber Medallion +1">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_7_1&amp;id=talismans_7_1&amp;link=/checklists/talismans.html%23item_7_1&amp;title=Crimson Amber Medallion +1"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3316,9 +3124,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="talismans_7_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_7_2&amp;id=talismans_7_2&amp;link=/checklists/talismans.html%23item_7_2&amp;title=Fire Scorpion Charm">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_7_2&amp;id=talismans_7_2&amp;link=/checklists/talismans.html%23item_7_2&amp;title=Fire Scorpion Charm"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3351,9 +3157,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="talismans_7_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_7_4&amp;id=talismans_7_4&amp;link=/checklists/talismans.html%23item_7_4&amp;title=Dagger Talisman">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_7_4&amp;id=talismans_7_4&amp;link=/checklists/talismans.html%23item_7_4&amp;title=Dagger Talisman"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3386,9 +3190,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="talismans_7_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_7_5&amp;id=talismans_7_5&amp;link=/checklists/talismans.html%23item_7_5&amp;title=Kindred of Rot's Exultation">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_7_5&amp;id=talismans_7_5&amp;link=/checklists/talismans.html%23item_7_5&amp;title=Kindred of Rot's Exultation"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3421,9 +3223,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="talismans_7_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_7_6&amp;id=talismans_7_6&amp;link=/checklists/talismans.html%23item_7_6&amp;title=Pearldrake Talisman +1">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_7_6&amp;id=talismans_7_6&amp;link=/checklists/talismans.html%23item_7_6&amp;title=Pearldrake Talisman +1"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3456,9 +3256,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="talismans_7_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_7_7&amp;id=talismans_7_7&amp;link=/checklists/talismans.html%23item_7_7&amp;title=Taker's Cameo">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_7_7&amp;id=talismans_7_7&amp;link=/checklists/talismans.html%23item_7_7&amp;title=Taker's Cameo"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3491,9 +3289,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="talismans_7_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_7_9&amp;id=talismans_7_9&amp;link=/checklists/talismans.html%23item_7_9&amp;title=Daedicar's Woe">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_7_9&amp;id=talismans_7_9&amp;link=/checklists/talismans.html%23item_7_9&amp;title=Daedicar's Woe"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3527,9 +3323,7 @@
         <div class="card shadow-sm mb-3" id="talismans_section_7">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#talismans_7Col" data-bs-toggle="collapse" href="#talismans_7Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#talismans_7Col" data-bs-toggle="collapse" href="#talismans_7Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Leyndell, Royal City</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="talismans_totals_7"></span>
             </h4>
@@ -3541,9 +3335,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -3572,9 +3364,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="talismans_8_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_8_1&amp;id=talismans_8_1&amp;link=/checklists/talismans.html%23item_8_1&amp;title=Viridian Amber Medallion +1">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_8_1&amp;id=talismans_8_1&amp;link=/checklists/talismans.html%23item_8_1&amp;title=Viridian Amber Medallion +1"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3607,9 +3397,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="talismans_8_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_8_2&amp;id=talismans_8_2&amp;link=/checklists/talismans.html%23item_8_2&amp;title=Erdtree's Favor +1">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_8_2&amp;id=talismans_8_2&amp;link=/checklists/talismans.html%23item_8_2&amp;title=Erdtree's Favor +1"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3642,9 +3430,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="talismans_8_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_8_3&amp;id=talismans_8_3&amp;link=/checklists/talismans.html%23item_8_3&amp;title=Flamedrake Talisman +1">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_8_3&amp;id=talismans_8_3&amp;link=/checklists/talismans.html%23item_8_3&amp;title=Flamedrake Talisman +1"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3677,9 +3463,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="talismans_8_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_8_4&amp;id=talismans_8_4&amp;link=/checklists/talismans.html%23item_8_4&amp;title=Haligdrake Talisman +1">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_8_4&amp;id=talismans_8_4&amp;link=/checklists/talismans.html%23item_8_4&amp;title=Haligdrake Talisman +1"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3712,9 +3496,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="talismans_8_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_8_5&amp;id=talismans_8_5&amp;link=/checklists/talismans.html%23item_8_5&amp;title=Crucible Scale Talisman">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_8_5&amp;id=talismans_8_5&amp;link=/checklists/talismans.html%23item_8_5&amp;title=Crucible Scale Talisman"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3747,9 +3529,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="talismans_8_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_8_6&amp;id=talismans_8_6&amp;link=/checklists/talismans.html%23item_8_6&amp;title=Crucible Feather Talisman">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_8_6&amp;id=talismans_8_6&amp;link=/checklists/talismans.html%23item_8_6&amp;title=Crucible Feather Talisman"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3782,9 +3562,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="talismans_8_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_8_7&amp;id=talismans_8_7&amp;link=/checklists/talismans.html%23item_8_7&amp;title=Ritual Shield Talisman">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_8_7&amp;id=talismans_8_7&amp;link=/checklists/talismans.html%23item_8_7&amp;title=Ritual Shield Talisman"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3817,9 +3595,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="talismans_8_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_8_8&amp;id=talismans_8_8&amp;link=/checklists/talismans.html%23item_8_8&amp;title=Blessed Dew Talisman">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_8_8&amp;id=talismans_8_8&amp;link=/checklists/talismans.html%23item_8_8&amp;title=Blessed Dew Talisman"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3853,9 +3629,7 @@
         <div class="card shadow-sm mb-3" id="talismans_section_8">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#talismans_8Col" data-bs-toggle="collapse" href="#talismans_8Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#talismans_8Col" data-bs-toggle="collapse" href="#talismans_8Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Mountaintops of the Giants</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="talismans_totals_8"></span>
             </h4>
@@ -3867,9 +3641,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -3898,9 +3670,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="talismans_9_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_9_1&amp;id=talismans_9_1&amp;link=/checklists/talismans.html%23item_9_1&amp;title=Cerulean Amber Medallion +1">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_9_1&amp;id=talismans_9_1&amp;link=/checklists/talismans.html%23item_9_1&amp;title=Cerulean Amber Medallion +1"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3933,9 +3703,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="talismans_9_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_9_2&amp;id=talismans_9_2&amp;link=/checklists/talismans.html%23item_9_2&amp;title=Lord of Blood's Exultation">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_9_2&amp;id=talismans_9_2&amp;link=/checklists/talismans.html%23item_9_2&amp;title=Lord of Blood's Exultation"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3968,9 +3736,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="talismans_9_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_9_3&amp;id=talismans_9_3&amp;link=/checklists/talismans.html%23item_9_3&amp;title=Primal Glintstone Blade">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_9_3&amp;id=talismans_9_3&amp;link=/checklists/talismans.html%23item_9_3&amp;title=Primal Glintstone Blade"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4003,9 +3769,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="talismans_9_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_9_4&amp;id=talismans_9_4&amp;link=/checklists/talismans.html%23item_9_4&amp;title=Pearldrake Talisman +2">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_9_4&amp;id=talismans_9_4&amp;link=/checklists/talismans.html%23item_9_4&amp;title=Pearldrake Talisman +2"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4038,9 +3802,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="talismans_9_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_9_5&amp;id=talismans_9_5&amp;link=/checklists/talismans.html%23item_9_5&amp;title=Godskin Swaddling Cloth">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_9_5&amp;id=talismans_9_5&amp;link=/checklists/talismans.html%23item_9_5&amp;title=Godskin Swaddling Cloth"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4074,9 +3836,7 @@
         <div class="card shadow-sm mb-3" id="talismans_section_9">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#talismans_9Col" data-bs-toggle="collapse" href="#talismans_9Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#talismans_9Col" data-bs-toggle="collapse" href="#talismans_9Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Consecrated Snowfield</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="talismans_totals_9"></span>
             </h4>
@@ -4088,9 +3848,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -4119,9 +3877,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="talismans_10_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_10_1&amp;id=talismans_10_1&amp;link=/checklists/talismans.html%23item_10_1&amp;title=Viridian Amber Medallion +2">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_10_1&amp;id=talismans_10_1&amp;link=/checklists/talismans.html%23item_10_1&amp;title=Viridian Amber Medallion +2"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4154,9 +3910,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="talismans_10_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_10_2&amp;id=talismans_10_2&amp;link=/checklists/talismans.html%23item_10_2&amp;title=Silver Scarab">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_10_2&amp;id=talismans_10_2&amp;link=/checklists/talismans.html%23item_10_2&amp;title=Silver Scarab"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4189,9 +3943,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="talismans_10_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_10_3&amp;id=talismans_10_3&amp;link=/checklists/talismans.html%23item_10_3&amp;title=Stalwart Horn Charm +1">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_10_3&amp;id=talismans_10_3&amp;link=/checklists/talismans.html%23item_10_3&amp;title=Stalwart Horn Charm +1"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4224,9 +3976,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="talismans_10_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_10_4&amp;id=talismans_10_4&amp;link=/checklists/talismans.html%23item_10_4&amp;title=Marika's Soreseal">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_10_4&amp;id=talismans_10_4&amp;link=/checklists/talismans.html%23item_10_4&amp;title=Marika's Soreseal"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4259,9 +4009,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="talismans_10_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_10_5&amp;id=talismans_10_5&amp;link=/checklists/talismans.html%23item_10_5&amp;title=Millicent's Prosthesis">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_10_5&amp;id=talismans_10_5&amp;link=/checklists/talismans.html%23item_10_5&amp;title=Millicent's Prosthesis"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4294,9 +4042,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="talismans_10_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_10_6&amp;id=talismans_10_6&amp;link=/checklists/talismans.html%23item_10_6&amp;title=Rotten Winged Sword Insignia">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_10_6&amp;id=talismans_10_6&amp;link=/checklists/talismans.html%23item_10_6&amp;title=Rotten Winged Sword Insignia"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4329,9 +4075,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="talismans_10_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_10_7&amp;id=talismans_10_7&amp;link=/checklists/talismans.html%23item_10_7&amp;title=Graven-Mass Talisman">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_10_7&amp;id=talismans_10_7&amp;link=/checklists/talismans.html%23item_10_7&amp;title=Graven-Mass Talisman"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4364,9 +4108,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="talismans_10_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_10_8&amp;id=talismans_10_8&amp;link=/checklists/talismans.html%23item_10_8&amp;title=Dragoncrest Greatshield Talisman">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_10_8&amp;id=talismans_10_8&amp;link=/checklists/talismans.html%23item_10_8&amp;title=Dragoncrest Greatshield Talisman"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4399,9 +4141,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="talismans_10_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_10_9&amp;id=talismans_10_9&amp;link=/checklists/talismans.html%23item_10_9&amp;title=Spelldrake Talisman +2">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_10_9&amp;id=talismans_10_9&amp;link=/checklists/talismans.html%23item_10_9&amp;title=Spelldrake Talisman +2"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4435,9 +4175,7 @@
         <div class="card shadow-sm mb-3" id="talismans_section_10">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#talismans_10Col" data-bs-toggle="collapse" href="#talismans_10Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#talismans_10Col" data-bs-toggle="collapse" href="#talismans_10Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Crumbling Farum Azula</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="talismans_totals_10"></span>
             </h4>
@@ -4449,9 +4187,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -4480,9 +4216,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="10" id="talismans_11_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_11_1&amp;id=talismans_11_1&amp;link=/checklists/talismans.html%23item_11_1&amp;title=Warrior Jar Shard">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_11_1&amp;id=talismans_11_1&amp;link=/checklists/talismans.html%23item_11_1&amp;title=Warrior Jar Shard"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4515,9 +4249,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="10" id="talismans_11_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_11_2&amp;id=talismans_11_2&amp;link=/checklists/talismans.html%23item_11_2&amp;title=Shard of Alexander">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_11_2&amp;id=talismans_11_2&amp;link=/checklists/talismans.html%23item_11_2&amp;title=Shard of Alexander"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4550,9 +4282,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="10" id="talismans_11_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_11_3&amp;id=talismans_11_3&amp;link=/checklists/talismans.html%23item_11_3&amp;title=Old Lord's Talisman">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_11_3&amp;id=talismans_11_3&amp;link=/checklists/talismans.html%23item_11_3&amp;title=Old Lord's Talisman"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4585,9 +4315,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="10" id="talismans_11_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_11_4&amp;id=talismans_11_4&amp;link=/checklists/talismans.html%23item_11_4&amp;title=Dragoncrest Shield Talisman +2">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_11_4&amp;id=talismans_11_4&amp;link=/checklists/talismans.html%23item_11_4&amp;title=Dragoncrest Shield Talisman +2"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4620,9 +4348,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="10" id="talismans_11_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_11_5&amp;id=talismans_11_5&amp;link=/checklists/talismans.html%23item_11_5&amp;title=Boltdrake Talisman +2">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_11_5&amp;id=talismans_11_5&amp;link=/checklists/talismans.html%23item_11_5&amp;title=Boltdrake Talisman +2"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4656,9 +4382,7 @@
         <div class="card shadow-sm mb-3" id="talismans_section_11">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#talismans_11Col" data-bs-toggle="collapse" href="#talismans_11Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#talismans_11Col" data-bs-toggle="collapse" href="#talismans_11Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Leyndell, Capital of Ash</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="talismans_totals_11"></span>
             </h4>
@@ -4670,9 +4394,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -4701,9 +4423,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="11" id="talismans_12_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_12_1&amp;id=talismans_12_1&amp;link=/checklists/talismans.html%23item_12_1&amp;title=Crimson Amber Medallion +2">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_12_1&amp;id=talismans_12_1&amp;link=/checklists/talismans.html%23item_12_1&amp;title=Crimson Amber Medallion +2"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4736,9 +4456,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="11" id="talismans_12_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_12_2&amp;id=talismans_12_2&amp;link=/checklists/talismans.html%23item_12_2&amp;title=Erdtree's Favor +2">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_12_2&amp;id=talismans_12_2&amp;link=/checklists/talismans.html%23item_12_2&amp;title=Erdtree's Favor +2"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4772,9 +4490,7 @@
         <div class="card shadow-sm mb-3" id="talismans_section_12">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#talismans_12Col" data-bs-toggle="collapse" href="#talismans_12Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#talismans_12Col" data-bs-toggle="collapse" href="#talismans_12Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Siofra River</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="talismans_totals_12"></span>
             </h4>
@@ -4786,9 +4502,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -4817,9 +4531,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="talismans_13_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_13_1&amp;id=talismans_13_1&amp;link=/checklists/talismans.html%23item_13_1&amp;title=Clarifying Horn Charm">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_13_1&amp;id=talismans_13_1&amp;link=/checklists/talismans.html%23item_13_1&amp;title=Clarifying Horn Charm"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4852,9 +4564,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="talismans_13_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_13_2&amp;id=talismans_13_2&amp;link=/checklists/talismans.html%23item_13_2&amp;title=Marika's Scarseal">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_13_2&amp;id=talismans_13_2&amp;link=/checklists/talismans.html%23item_13_2&amp;title=Marika's Scarseal"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4888,9 +4598,7 @@
         <div class="card shadow-sm mb-3" id="talismans_section_13">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#talismans_13Col" data-bs-toggle="collapse" href="#talismans_13Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#talismans_13Col" data-bs-toggle="collapse" href="#talismans_13Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Nokron, Eternal City</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="talismans_totals_13"></span>
             </h4>
@@ -4902,9 +4610,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -4933,9 +4639,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="13" id="talismans_14_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_14_1&amp;id=talismans_14_1&amp;link=/checklists/talismans.html%23item_14_1&amp;title=Clarifying Horn Charm +1">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_14_1&amp;id=talismans_14_1&amp;link=/checklists/talismans.html%23item_14_1&amp;title=Clarifying Horn Charm +1"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4968,9 +4672,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="13" id="talismans_14_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_14_2&amp;id=talismans_14_2&amp;link=/checklists/talismans.html%23item_14_2&amp;title=Mottled Necklace">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_14_2&amp;id=talismans_14_2&amp;link=/checklists/talismans.html%23item_14_2&amp;title=Mottled Necklace"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5003,9 +4705,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="13" id="talismans_14_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_14_3&amp;id=talismans_14_3&amp;link=/checklists/talismans.html%23item_14_3&amp;title=Mottled Necklace +1">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_14_3&amp;id=talismans_14_3&amp;link=/checklists/talismans.html%23item_14_3&amp;title=Mottled Necklace +1"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5039,9 +4739,7 @@
         <div class="card shadow-sm mb-3" id="talismans_section_14">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#talismans_14Col" data-bs-toggle="collapse" href="#talismans_14Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#talismans_14Col" data-bs-toggle="collapse" href="#talismans_14Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Mohgwyn Palace</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="talismans_totals_14"></span>
             </h4>
@@ -5053,9 +4751,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -5084,9 +4780,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="14" id="talismans_15_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_15_1&amp;id=talismans_15_1&amp;link=/checklists/talismans.html%23item_15_1&amp;title=Haligdrake Talisman +2">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_15_1&amp;id=talismans_15_1&amp;link=/checklists/talismans.html%23item_15_1&amp;title=Haligdrake Talisman +2"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5120,9 +4814,7 @@
         <div class="card shadow-sm mb-3" id="talismans_section_15">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#talismans_15Col" data-bs-toggle="collapse" href="#talismans_15Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#talismans_15Col" data-bs-toggle="collapse" href="#talismans_15Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Ainsel River</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="talismans_totals_15"></span>
             </h4>
@@ -5134,9 +4826,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -5165,9 +4855,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="15" id="talismans_16_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_16_1&amp;id=talismans_16_1&amp;link=/checklists/talismans.html%23item_16_1&amp;title=Immunizing Horn Charm">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_16_1&amp;id=talismans_16_1&amp;link=/checklists/talismans.html%23item_16_1&amp;title=Immunizing Horn Charm"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5201,9 +4889,7 @@
         <div class="card shadow-sm mb-3" id="talismans_section_16">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#talismans_16Col" data-bs-toggle="collapse" href="#talismans_16Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#talismans_16Col" data-bs-toggle="collapse" href="#talismans_16Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Nokstella, Eternal City</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="talismans_totals_16"></span>
             </h4>
@@ -5215,9 +4901,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -5246,9 +4930,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="16" id="talismans_17_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_17_1&amp;id=talismans_17_1&amp;link=/checklists/talismans.html%23item_17_1&amp;title=Moon of Nokstella">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_17_1&amp;id=talismans_17_1&amp;link=/checklists/talismans.html%23item_17_1&amp;title=Moon of Nokstella"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5282,9 +4964,7 @@
         <div class="card shadow-sm mb-3" id="talismans_section_17">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#talismans_17Col" data-bs-toggle="collapse" href="#talismans_17Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#talismans_17Col" data-bs-toggle="collapse" href="#talismans_17Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Lake of Rot</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="talismans_totals_17"></span>
             </h4>
@@ -5296,9 +4976,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -5327,9 +5005,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="17" id="talismans_18_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_18_1&amp;id=talismans_18_1&amp;link=/checklists/talismans.html%23item_18_1&amp;title=Immunizing Horn Charm +1">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_18_1&amp;id=talismans_18_1&amp;link=/checklists/talismans.html%23item_18_1&amp;title=Immunizing Horn Charm +1"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5363,9 +5039,7 @@
         <div class="card shadow-sm mb-3" id="talismans_section_18">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#talismans_18Col" data-bs-toggle="collapse" href="#talismans_18Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#talismans_18Col" data-bs-toggle="collapse" href="#talismans_18Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Deeproot Depths</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="talismans_totals_18"></span>
             </h4>
@@ -5377,9 +5051,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -5408,9 +5080,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="18" id="talismans_19_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_19_1&amp;id=talismans_19_1&amp;link=/checklists/talismans.html%23item_19_1&amp;title=Prince of Death's Cyst">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_19_1&amp;id=talismans_19_1&amp;link=/checklists/talismans.html%23item_19_1&amp;title=Prince of Death's Cyst"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5444,9 +5114,7 @@
         <div class="card shadow-sm mb-3" id="talismans_section_19">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#talismans_19Col" data-bs-toggle="collapse" href="#talismans_19Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#talismans_19Col" data-bs-toggle="collapse" href="#talismans_19Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Realm of Shadow</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="talismans_totals_19"></span>
             </h4>
@@ -5458,9 +5126,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -5489,9 +5155,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="19" id="talismans_50_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_50_1&amp;id=talismans_50_1&amp;link=/checklists/talismans.html%23item_50_1&amp;title=Crimson Amber Medallion +3">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_50_1&amp;id=talismans_50_1&amp;link=/checklists/talismans.html%23item_50_1&amp;title=Crimson Amber Medallion +3"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5524,9 +5188,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="19" id="talismans_50_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_50_2&amp;id=talismans_50_2&amp;link=/checklists/talismans.html%23item_50_2&amp;title=Cerulean Amber Medallion +3">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_50_2&amp;id=talismans_50_2&amp;link=/checklists/talismans.html%23item_50_2&amp;title=Cerulean Amber Medallion +3"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5559,9 +5221,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="19" id="talismans_50_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_50_3&amp;id=talismans_50_3&amp;link=/checklists/talismans.html%23item_50_3&amp;title=Viridian Amber Medallion +3">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_50_3&amp;id=talismans_50_3&amp;link=/checklists/talismans.html%23item_50_3&amp;title=Viridian Amber Medallion +3"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5594,9 +5254,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="19" id="talismans_50_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_50_4&amp;id=talismans_50_4&amp;link=/checklists/talismans.html%23item_50_4&amp;title=Two-Headed Turtle Talisman">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_50_4&amp;id=talismans_50_4&amp;link=/checklists/talismans.html%23item_50_4&amp;title=Two-Headed Turtle Talisman"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5629,9 +5287,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="19" id="talismans_50_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_50_5&amp;id=talismans_50_5&amp;link=/checklists/talismans.html%23item_50_5&amp;title=Stalwart Horn Charm +2">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_50_5&amp;id=talismans_50_5&amp;link=/checklists/talismans.html%23item_50_5&amp;title=Stalwart Horn Charm +2"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5664,9 +5320,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="19" id="talismans_50_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_50_6&amp;id=talismans_50_6&amp;link=/checklists/talismans.html%23item_50_6&amp;title=Immunizing Horn Charm +2">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_50_6&amp;id=talismans_50_6&amp;link=/checklists/talismans.html%23item_50_6&amp;title=Immunizing Horn Charm +2"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5699,9 +5353,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="19" id="talismans_50_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_50_7&amp;id=talismans_50_7&amp;link=/checklists/talismans.html%23item_50_7&amp;title=Clarifying Horn Charm +2">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_50_7&amp;id=talismans_50_7&amp;link=/checklists/talismans.html%23item_50_7&amp;title=Clarifying Horn Charm +2"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5734,9 +5386,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="19" id="talismans_50_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_50_8&amp;id=talismans_50_8&amp;link=/checklists/talismans.html%23item_50_8&amp;title=Mottled Necklace +2">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_50_8&amp;id=talismans_50_8&amp;link=/checklists/talismans.html%23item_50_8&amp;title=Mottled Necklace +2"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5769,9 +5419,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="19" id="talismans_50_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_50_9&amp;id=talismans_50_9&amp;link=/checklists/talismans.html%23item_50_9&amp;title=Spelldrake Talisman +3">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_50_9&amp;id=talismans_50_9&amp;link=/checklists/talismans.html%23item_50_9&amp;title=Spelldrake Talisman +3"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5804,9 +5452,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="19" id="talismans_50_10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_50_10&amp;id=talismans_50_10&amp;link=/checklists/talismans.html%23item_50_10&amp;title=Flamedrake Talisman +3">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_50_10&amp;id=talismans_50_10&amp;link=/checklists/talismans.html%23item_50_10&amp;title=Flamedrake Talisman +3"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5839,9 +5485,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="19" id="talismans_50_11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_50_11&amp;id=talismans_50_11&amp;link=/checklists/talismans.html%23item_50_11&amp;title=Boltdrake Talisman +3">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_50_11&amp;id=talismans_50_11&amp;link=/checklists/talismans.html%23item_50_11&amp;title=Boltdrake Talisman +3"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5874,9 +5518,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="19" id="talismans_50_12" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_50_12&amp;id=talismans_50_12&amp;link=/checklists/talismans.html%23item_50_12&amp;title=Golden Braid">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_50_12&amp;id=talismans_50_12&amp;link=/checklists/talismans.html%23item_50_12&amp;title=Golden Braid"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5909,9 +5551,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="19" id="talismans_50_13" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_50_13&amp;id=talismans_50_13&amp;link=/checklists/talismans.html%23item_50_13&amp;title=Pearldrake Talisman +3">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_50_13&amp;id=talismans_50_13&amp;link=/checklists/talismans.html%23item_50_13&amp;title=Pearldrake Talisman +3"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5944,9 +5584,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="19" id="talismans_50_14" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_50_14&amp;id=talismans_50_14&amp;link=/checklists/talismans.html%23item_50_14&amp;title=Crimson Seed Talisman +1">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_50_14&amp;id=talismans_50_14&amp;link=/checklists/talismans.html%23item_50_14&amp;title=Crimson Seed Talisman +1"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5979,9 +5617,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="19" id="talismans_50_15" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_50_15&amp;id=talismans_50_15&amp;link=/checklists/talismans.html%23item_50_15&amp;title=Cerulean Seed Talisman +1">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_50_15&amp;id=talismans_50_15&amp;link=/checklists/talismans.html%23item_50_15&amp;title=Cerulean Seed Talisman +1"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6014,9 +5650,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="19" id="talismans_50_16" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_50_16&amp;id=talismans_50_16&amp;link=/checklists/talismans.html%23item_50_16&amp;title=Blessed Blue Dew Talisman">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_50_16&amp;id=talismans_50_16&amp;link=/checklists/talismans.html%23item_50_16&amp;title=Blessed Blue Dew Talisman"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6049,9 +5683,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="19" id="talismans_50_17" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_50_17&amp;id=talismans_50_17&amp;link=/checklists/talismans.html%23item_50_17&amp;title=Fine Crucible Feather Talisman">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_50_17&amp;id=talismans_50_17&amp;link=/checklists/talismans.html%23item_50_17&amp;title=Fine Crucible Feather Talisman"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6084,9 +5716,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="19" id="talismans_50_18" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_50_18&amp;id=talismans_50_18&amp;link=/checklists/talismans.html%23item_50_18&amp;title=Outer God Heirloom">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_50_18&amp;id=talismans_50_18&amp;link=/checklists/talismans.html%23item_50_18&amp;title=Outer God Heirloom"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6119,9 +5749,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="19" id="talismans_50_19" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_50_19&amp;id=talismans_50_19&amp;link=/checklists/talismans.html%23item_50_19&amp;title=Shattered Stone Talisman">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_50_19&amp;id=talismans_50_19&amp;link=/checklists/talismans.html%23item_50_19&amp;title=Shattered Stone Talisman"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6154,9 +5782,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="19" id="talismans_50_20" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_50_20&amp;id=talismans_50_20&amp;link=/checklists/talismans.html%23item_50_20&amp;title=Two-Handed Sword Talisman">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_50_20&amp;id=talismans_50_20&amp;link=/checklists/talismans.html%23item_50_20&amp;title=Two-Handed Sword Talisman"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6189,9 +5815,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="19" id="talismans_50_21" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_50_21&amp;id=talismans_50_21&amp;link=/checklists/talismans.html%23item_50_21&amp;title=Crusade Insignia">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_50_21&amp;id=talismans_50_21&amp;link=/checklists/talismans.html%23item_50_21&amp;title=Crusade Insignia"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6224,9 +5848,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="19" id="talismans_50_22" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_50_22&amp;id=talismans_50_22&amp;link=/checklists/talismans.html%23item_50_22&amp;title=Aged One's Exultation">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_50_22&amp;id=talismans_50_22&amp;link=/checklists/talismans.html%23item_50_22&amp;title=Aged One's Exultation"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6259,9 +5881,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="19" id="talismans_50_23" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_50_23&amp;id=talismans_50_23&amp;link=/checklists/talismans.html%23item_50_23&amp;title=Arrow's Soaring Sting Talisman">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_50_23&amp;id=talismans_50_23&amp;link=/checklists/talismans.html%23item_50_23&amp;title=Arrow's Soaring Sting Talisman"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6294,9 +5914,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="19" id="talismans_50_24" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_50_24&amp;id=talismans_50_24&amp;link=/checklists/talismans.html%23item_50_24&amp;title=Pearl Shield Talisman">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_50_24&amp;id=talismans_50_24&amp;link=/checklists/talismans.html%23item_50_24&amp;title=Pearl Shield Talisman"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6329,9 +5947,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="19" id="talismans_50_25" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_50_25&amp;id=talismans_50_25&amp;link=/checklists/talismans.html%23item_50_25&amp;title=Dried Bouquet">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_50_25&amp;id=talismans_50_25&amp;link=/checklists/talismans.html%23item_50_25&amp;title=Dried Bouquet"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6364,9 +5980,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="19" id="talismans_50_26" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_50_26&amp;id=talismans_50_26&amp;link=/checklists/talismans.html%23item_50_26&amp;title=Smithing Talisman">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_50_26&amp;id=talismans_50_26&amp;link=/checklists/talismans.html%23item_50_26&amp;title=Smithing Talisman"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6399,9 +6013,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="19" id="talismans_50_27" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_50_27&amp;id=talismans_50_27&amp;link=/checklists/talismans.html%23item_50_27&amp;title=Ailment Talisman">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_50_27&amp;id=talismans_50_27&amp;link=/checklists/talismans.html%23item_50_27&amp;title=Ailment Talisman"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6434,9 +6046,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="19" id="talismans_50_28" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_50_28&amp;id=talismans_50_28&amp;link=/checklists/talismans.html%23item_50_28&amp;title=Retaliatory Crossed-Tree">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_50_28&amp;id=talismans_50_28&amp;link=/checklists/talismans.html%23item_50_28&amp;title=Retaliatory Crossed-Tree"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6469,9 +6079,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="19" id="talismans_50_29" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_50_29&amp;id=talismans_50_29&amp;link=/checklists/talismans.html%23item_50_29&amp;title=Lacerating Crossed-Tree">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_50_29&amp;id=talismans_50_29&amp;link=/checklists/talismans.html%23item_50_29&amp;title=Lacerating Crossed-Tree"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6504,9 +6112,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="19" id="talismans_50_30" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_50_30&amp;id=talismans_50_30&amp;link=/checklists/talismans.html%23item_50_30&amp;title=Sharpshot Talisman">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_50_30&amp;id=talismans_50_30&amp;link=/checklists/talismans.html%23item_50_30&amp;title=Sharpshot Talisman"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6539,9 +6145,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="19" id="talismans_50_31" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_50_31&amp;id=talismans_50_31&amp;link=/checklists/talismans.html%23item_50_31&amp;title=St. Trina's Smile">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_50_31&amp;id=talismans_50_31&amp;link=/checklists/talismans.html%23item_50_31&amp;title=St. Trina's Smile"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6574,9 +6178,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="19" id="talismans_50_32" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_50_32&amp;id=talismans_50_32&amp;link=/checklists/talismans.html%23item_50_32&amp;title=Talisman of the Dread">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_50_32&amp;id=talismans_50_32&amp;link=/checklists/talismans.html%23item_50_32&amp;title=Talisman of the Dread"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6609,9 +6211,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="19" id="talismans_50_33" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_50_33&amp;id=talismans_50_33&amp;link=/checklists/talismans.html%23item_50_33&amp;title=Enraged Divine Beast">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_50_33&amp;id=talismans_50_33&amp;link=/checklists/talismans.html%23item_50_33&amp;title=Enraged Divine Beast"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6644,9 +6244,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="19" id="talismans_50_34" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_50_34&amp;id=talismans_50_34&amp;link=/checklists/talismans.html%23item_50_34&amp;title=Beloved Stardust">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_50_34&amp;id=talismans_50_34&amp;link=/checklists/talismans.html%23item_50_34&amp;title=Beloved Stardust"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6679,9 +6277,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="19" id="talismans_50_35" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_50_35&amp;id=talismans_50_35&amp;link=/checklists/talismans.html%23item_50_35&amp;title=Talisman of Lord's Bestowal">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_50_35&amp;id=talismans_50_35&amp;link=/checklists/talismans.html%23item_50_35&amp;title=Talisman of Lord's Bestowal"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6714,9 +6310,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="19" id="talismans_50_36" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_50_36&amp;id=talismans_50_36&amp;link=/checklists/talismans.html%23item_50_36&amp;title=Verdigris Discus">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_50_36&amp;id=talismans_50_36&amp;link=/checklists/talismans.html%23item_50_36&amp;title=Verdigris Discus"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6749,9 +6343,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="19" id="talismans_50_37" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_50_37&amp;id=talismans_50_37&amp;link=/checklists/talismans.html%23item_50_37&amp;title=Rellana's Cameo">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_50_37&amp;id=talismans_50_37&amp;link=/checklists/talismans.html%23item_50_37&amp;title=Rellana's Cameo"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6784,9 +6376,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="19" id="talismans_50_38" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_50_38&amp;id=talismans_50_38&amp;link=/checklists/talismans.html%23item_50_38&amp;title=Blade of Mercy">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_50_38&amp;id=talismans_50_38&amp;link=/checklists/talismans.html%23item_50_38&amp;title=Blade of Mercy"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6819,9 +6409,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="19" id="talismans_50_39" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=talismans_50_39&amp;id=talismans_50_39&amp;link=/checklists/talismans.html%23item_50_39&amp;title=Talisman of All Crucibles">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=talismans_50_39&amp;id=talismans_50_39&amp;link=/checklists/talismans.html%23item_50_39&amp;title=Talisman of All Crucibles"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">

--- a/docs/checklists/tldr_all_npc_quest_stepsin_order.html
+++ b/docs/checklists/tldr_all_npc_quest_stepsin_order.html
@@ -27,14 +27,10 @@
         <a class="navbar-brand me-auto ms-2" href="/index.html">Roundtable Guides</a>
         <form class="d-none d-sm-flex order-2 order-xl-3">
           <input aria-label="search" class="form-control me-2" name="search" placeholder="Search" type="search">
-          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit">
-            <i class="bi bi-search"></i>
-          </button>
+          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit"><i class="bi bi-search"></i></button>
         </form>
         <div class="d-sm-none order-2">
-          <a class="nav-link me-0" href="/search.html">
-            <i class="bi bi-search sb-icon-search"></i>
-          </a>
+          <a class="nav-link me-0" href="/search.html"><i class="bi bi-search sb-icon-search"></i></a>
         </div>
         <div class="collapse navbar-collapse order-3 order-xl-2 ms-xl-2" id="nav-collapse">
           <ul class="nav navbar-nav navbar-nav-scroll mr-auto">
@@ -179,14 +175,10 @@
               </ul>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/map.html">
-                <i class="bi bi-map"></i> Map
-              </a>
+              <a class="nav-link hide-buttons" href="/map.html"><i class="bi bi-map"></i> Map</a>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/options.html">
-                <i class="bi bi-gear-fill"></i> Options
-              </a>
+              <a class="nav-link hide-buttons" href="/options.html"><i class="bi bi-gear-fill"></i> Options</a>
             </li>
           </ul>
         </div>
@@ -207,9 +199,7 @@
       <p>These Steps are a TL;DR Version and will not explain how to get anywhere, only where to go. They will also follow the order of "Intended" Route and as such, will complete every questline in that order. That said, if I were to completely go with what I believed was "Intended", several questlines wouldn't be completed at all. Therefore, I will instead complete every questline with the "best" ending, that is to say I will try for happy endings whenever possible. If you are looking for specific results to questlines, please try the NPC Questlines section instead.</p>
       <nav class="text-muted toc d-print-none">
         <strong class="d-block h5">
-          <a class="toc-button" data-bs-toggle="collapse" href="#toc_quest_order_tldr" role="button">
-            <i class="bi bi-plus-lg"></i>Table Of Contents
-          </a>
+          <a class="toc-button" data-bs-toggle="collapse" href="#toc_quest_order_tldr" role="button"><i class="bi bi-plus-lg"></i>Table Of Contents</a>
         </strong>
         <ul class="toc_page collapse" id="toc_quest_order_tldr">
           <li>
@@ -325,9 +315,7 @@
         <div class="card shadow-sm mb-3" id="quest_order_tldr_section_0">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#quest_order_tldr_0Col" data-bs-toggle="collapse" href="#quest_order_tldr_0Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#quest_order_tldr_0Col" data-bs-toggle="collapse" href="#quest_order_tldr_0Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Limgrave</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="quest_order_tldr_totals_0"></span>
             </h4>
@@ -562,9 +550,7 @@
         <div class="card shadow-sm mb-3" id="quest_order_tldr_section_1">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#quest_order_tldr_1Col" data-bs-toggle="collapse" href="#quest_order_tldr_1Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#quest_order_tldr_1Col" data-bs-toggle="collapse" href="#quest_order_tldr_1Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Weeping Peninsula</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="quest_order_tldr_totals_1"></span>
             </h4>
@@ -607,9 +593,7 @@
         <div class="card shadow-sm mb-3" id="quest_order_tldr_section_2">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#quest_order_tldr_2Col" data-bs-toggle="collapse" href="#quest_order_tldr_2Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#quest_order_tldr_2Col" data-bs-toggle="collapse" href="#quest_order_tldr_2Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Roundtable Hold</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="quest_order_tldr_totals_2"></span>
             </h4>
@@ -640,9 +624,7 @@
         <div class="card shadow-sm mb-3" id="quest_order_tldr_section_3">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#quest_order_tldr_3Col" data-bs-toggle="collapse" href="#quest_order_tldr_3Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#quest_order_tldr_3Col" data-bs-toggle="collapse" href="#quest_order_tldr_3Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Stormveil</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="quest_order_tldr_totals_3"></span>
             </h4>
@@ -697,9 +679,7 @@
         <div class="card shadow-sm mb-3" id="quest_order_tldr_section_4">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#quest_order_tldr_4Col" data-bs-toggle="collapse" href="#quest_order_tldr_4Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#quest_order_tldr_4Col" data-bs-toggle="collapse" href="#quest_order_tldr_4Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Limgrave/Roundtable</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="quest_order_tldr_totals_4"></span>
             </h4>
@@ -754,9 +734,7 @@
         <div class="card shadow-sm mb-3" id="quest_order_tldr_section_5">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#quest_order_tldr_5Col" data-bs-toggle="collapse" href="#quest_order_tldr_5Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#quest_order_tldr_5Col" data-bs-toggle="collapse" href="#quest_order_tldr_5Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Liurnia Lake</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="quest_order_tldr_totals_5"></span>
             </h4>
@@ -937,9 +915,7 @@
         <div class="card shadow-sm mb-3" id="quest_order_tldr_section_6">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#quest_order_tldr_6Col" data-bs-toggle="collapse" href="#quest_order_tldr_6Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#quest_order_tldr_6Col" data-bs-toggle="collapse" href="#quest_order_tldr_6Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Roundtable Hold</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="quest_order_tldr_totals_6"></span>
             </h4>
@@ -988,9 +964,7 @@
         <div class="card shadow-sm mb-3" id="quest_order_tldr_section_7">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#quest_order_tldr_7Col" data-bs-toggle="collapse" href="#quest_order_tldr_7Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#quest_order_tldr_7Col" data-bs-toggle="collapse" href="#quest_order_tldr_7Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Liurnia Lake/Roundtable</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="quest_order_tldr_totals_7"></span>
             </h4>
@@ -1039,9 +1013,7 @@
         <div class="card shadow-sm mb-3" id="quest_order_tldr_section_8">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#quest_order_tldr_8Col" data-bs-toggle="collapse" href="#quest_order_tldr_8Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#quest_order_tldr_8Col" data-bs-toggle="collapse" href="#quest_order_tldr_8Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Caelid</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="quest_order_tldr_totals_8"></span>
             </h4>
@@ -1108,9 +1080,7 @@
         <div class="card shadow-sm mb-3" id="quest_order_tldr_section_9">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#quest_order_tldr_9Col" data-bs-toggle="collapse" href="#quest_order_tldr_9Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#quest_order_tldr_9Col" data-bs-toggle="collapse" href="#quest_order_tldr_9Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Liurnia Lake/Roundtable</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="quest_order_tldr_totals_9"></span>
             </h4>
@@ -1147,9 +1117,7 @@
         <div class="card shadow-sm mb-3" id="quest_order_tldr_section_10">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#quest_order_tldr_10Col" data-bs-toggle="collapse" href="#quest_order_tldr_10Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#quest_order_tldr_10Col" data-bs-toggle="collapse" href="#quest_order_tldr_10Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Underground Siofra/Liurnia Lake/Castle Redmane</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="quest_order_tldr_totals_10"></span>
             </h4>
@@ -1210,9 +1178,7 @@
         <div class="card shadow-sm mb-3" id="quest_order_tldr_section_11">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#quest_order_tldr_11Col" data-bs-toggle="collapse" href="#quest_order_tldr_11Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#quest_order_tldr_11Col" data-bs-toggle="collapse" href="#quest_order_tldr_11Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Underground Crater/Liurnia Lake</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="quest_order_tldr_totals_11"></span>
             </h4>
@@ -1261,9 +1227,7 @@
         <div class="card shadow-sm mb-3" id="quest_order_tldr_section_12">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#quest_order_tldr_12Col" data-bs-toggle="collapse" href="#quest_order_tldr_12Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#quest_order_tldr_12Col" data-bs-toggle="collapse" href="#quest_order_tldr_12Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Mt. Gelmir</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="quest_order_tldr_totals_12"></span>
             </h4>
@@ -1336,9 +1300,7 @@
         <div class="card shadow-sm mb-3" id="quest_order_tldr_section_13">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#quest_order_tldr_13Col" data-bs-toggle="collapse" href="#quest_order_tldr_13Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#quest_order_tldr_13Col" data-bs-toggle="collapse" href="#quest_order_tldr_13Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Sellen/Volcano Manor Quests</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="quest_order_tldr_totals_13"></span>
             </h4>
@@ -1417,9 +1379,7 @@
         <div class="card shadow-sm mb-3" id="quest_order_tldr_section_14">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#quest_order_tldr_14Col" data-bs-toggle="collapse" href="#quest_order_tldr_14Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#quest_order_tldr_14Col" data-bs-toggle="collapse" href="#quest_order_tldr_14Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Altus Plateau/Roundtable Hold</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="quest_order_tldr_totals_14"></span>
             </h4>
@@ -1528,9 +1488,7 @@
         <div class="card shadow-sm mb-3" id="quest_order_tldr_section_15">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#quest_order_tldr_15Col" data-bs-toggle="collapse" href="#quest_order_tldr_15Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#quest_order_tldr_15Col" data-bs-toggle="collapse" href="#quest_order_tldr_15Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Leyndell Start/Dung Eater/Seluvis</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="quest_order_tldr_totals_15"></span>
             </h4>
@@ -1615,9 +1573,7 @@
         <div class="card shadow-sm mb-3" id="quest_order_tldr_section_16">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#quest_order_tldr_16Col" data-bs-toggle="collapse" href="#quest_order_tldr_16Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#quest_order_tldr_16Col" data-bs-toggle="collapse" href="#quest_order_tldr_16Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Liurnia Lake/Deeproot Depths</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="quest_order_tldr_totals_16"></span>
             </h4>
@@ -1672,9 +1628,7 @@
         <div class="card shadow-sm mb-3" id="quest_order_tldr_section_17">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#quest_order_tldr_17Col" data-bs-toggle="collapse" href="#quest_order_tldr_17Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#quest_order_tldr_17Col" data-bs-toggle="collapse" href="#quest_order_tldr_17Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Liurnia Lake/Ainsel River Main</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="quest_order_tldr_totals_17"></span>
             </h4>
@@ -1753,9 +1707,7 @@
         <div class="card shadow-sm mb-3" id="quest_order_tldr_section_18">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#quest_order_tldr_18Col" data-bs-toggle="collapse" href="#quest_order_tldr_18Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#quest_order_tldr_18Col" data-bs-toggle="collapse" href="#quest_order_tldr_18Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Leyndell/Roundtable Hold</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="quest_order_tldr_totals_18"></span>
             </h4>
@@ -1852,9 +1804,7 @@
         <div class="card shadow-sm mb-3" id="quest_order_tldr_section_19">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#quest_order_tldr_19Col" data-bs-toggle="collapse" href="#quest_order_tldr_19Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#quest_order_tldr_19Col" data-bs-toggle="collapse" href="#quest_order_tldr_19Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Roundtable Hold/Nepheli/Dragonbarrow/Volcano Manor</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="quest_order_tldr_totals_19"></span>
             </h4>
@@ -1939,9 +1889,7 @@
         <div class="card shadow-sm mb-3" id="quest_order_tldr_section_20">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#quest_order_tldr_20Col" data-bs-toggle="collapse" href="#quest_order_tldr_20Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#quest_order_tldr_20Col" data-bs-toggle="collapse" href="#quest_order_tldr_20Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Mountaintops of the Giants/Volcano Manor</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="quest_order_tldr_totals_20"></span>
             </h4>
@@ -2068,9 +2016,7 @@
         <div class="card shadow-sm mb-3" id="quest_order_tldr_section_21">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#quest_order_tldr_21Col" data-bs-toggle="collapse" href="#quest_order_tldr_21Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#quest_order_tldr_21Col" data-bs-toggle="collapse" href="#quest_order_tldr_21Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Consecrated Snowfield/Gurranq/Gowry</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="quest_order_tldr_totals_21"></span>
             </h4>
@@ -2119,9 +2065,7 @@
         <div class="card shadow-sm mb-3" id="quest_order_tldr_section_22">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#quest_order_tldr_22Col" data-bs-toggle="collapse" href="#quest_order_tldr_22Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#quest_order_tldr_22Col" data-bs-toggle="collapse" href="#quest_order_tldr_22Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Mohgwyn's Palace/Miquella's Haligtree</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="quest_order_tldr_totals_22"></span>
             </h4>
@@ -2200,9 +2144,7 @@
         <div class="card shadow-sm mb-3" id="quest_order_tldr_section_23">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#quest_order_tldr_23Col" data-bs-toggle="collapse" href="#quest_order_tldr_23Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#quest_order_tldr_23Col" data-bs-toggle="collapse" href="#quest_order_tldr_23Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">WARNING!!! THIS PARTICULAR STEP IS OPTIONAL BUT WILL BE REQUIRED TO FINISH ALL QUESTLINES COMPLETELY</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="quest_order_tldr_totals_23"></span>
             </h4>
@@ -2251,9 +2193,7 @@
         <div class="card shadow-sm mb-3" id="quest_order_tldr_section_24">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#quest_order_tldr_24Col" data-bs-toggle="collapse" href="#quest_order_tldr_24Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#quest_order_tldr_24Col" data-bs-toggle="collapse" href="#quest_order_tldr_24Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Crumbling Farum Azula/Wrapping Up</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="quest_order_tldr_totals_24"></span>
             </h4>
@@ -2320,9 +2260,7 @@
         <div class="card shadow-sm mb-3" id="quest_order_tldr_section_25">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#quest_order_tldr_25Col" data-bs-toggle="collapse" href="#quest_order_tldr_25Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#quest_order_tldr_25Col" data-bs-toggle="collapse" href="#quest_order_tldr_25Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Capital of Ash</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="quest_order_tldr_totals_25"></span>
             </h4>

--- a/docs/checklists/tools_multiplayer.html
+++ b/docs/checklists/tools_multiplayer.html
@@ -27,14 +27,10 @@
         <a class="navbar-brand me-auto ms-2" href="/index.html">Roundtable Guides</a>
         <form class="d-none d-sm-flex order-2 order-xl-3">
           <input aria-label="search" class="form-control me-2" name="search" placeholder="Search" type="search">
-          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit">
-            <i class="bi bi-search"></i>
-          </button>
+          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit"><i class="bi bi-search"></i></button>
         </form>
         <div class="d-sm-none order-2">
-          <a class="nav-link me-0" href="/search.html">
-            <i class="bi bi-search sb-icon-search"></i>
-          </a>
+          <a class="nav-link me-0" href="/search.html"><i class="bi bi-search sb-icon-search"></i></a>
         </div>
         <div class="collapse navbar-collapse order-3 order-xl-2 ms-xl-2" id="nav-collapse">
           <ul class="nav navbar-nav navbar-nav-scroll mr-auto">
@@ -179,14 +175,10 @@
               </ul>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/map.html">
-                <i class="bi bi-map"></i> Map
-              </a>
+              <a class="nav-link hide-buttons" href="/map.html"><i class="bi bi-map"></i> Map</a>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/options.html">
-                <i class="bi bi-gear-fill"></i> Options
-              </a>
+              <a class="nav-link hide-buttons" href="/options.html"><i class="bi bi-gear-fill"></i> Options</a>
             </li>
           </ul>
         </div>
@@ -206,9 +198,7 @@
       </div>
       <nav class="text-muted toc d-print-none">
         <strong class="d-block h5">
-          <a class="toc-button" data-bs-toggle="collapse" href="#toc_tools" role="button">
-            <i class="bi bi-plus-lg"></i>Table Of Contents
-          </a>
+          <a class="toc-button" data-bs-toggle="collapse" href="#toc_tools" role="button"><i class="bi bi-plus-lg"></i>Table Of Contents</a>
         </strong>
         <ul class="toc_page collapse" id="toc_tools">
           <li>
@@ -236,9 +226,7 @@
         <div class="card shadow-sm mb-3" id="tools_section_0">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#tools_0Col" data-bs-toggle="collapse" href="#tools_0Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#tools_0Col" data-bs-toggle="collapse" href="#tools_0Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Functional</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="tools_totals_0"></span>
             </h4>
@@ -250,9 +238,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -281,9 +267,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="tools_1_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=tools_1_1&amp;id=tools_1_1&amp;link=/checklists/tools_multiplayer.html%23item_1_1&amp;title=Memory of Grace">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=tools_1_1&amp;id=tools_1_1&amp;link=/checklists/tools_multiplayer.html%23item_1_1&amp;title=Memory of Grace"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -316,9 +300,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="tools_1_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=tools_1_2&amp;id=tools_1_2&amp;link=/checklists/tools_multiplayer.html%23item_1_2&amp;title=Telescope">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=tools_1_2&amp;id=tools_1_2&amp;link=/checklists/tools_multiplayer.html%23item_1_2&amp;title=Telescope"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -351,9 +333,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="tools_1_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=tools_1_3&amp;id=tools_1_3&amp;link=/checklists/tools_multiplayer.html%23item_1_3&amp;title=Spectral Steed Whistle">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=tools_1_3&amp;id=tools_1_3&amp;link=/checklists/tools_multiplayer.html%23item_1_3&amp;title=Spectral Steed Whistle"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -386,9 +366,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="tools_1_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=tools_1_7&amp;id=tools_1_7&amp;link=/checklists/tools_multiplayer.html%23item_1_7&amp;title=Flask of Wondrous Physick">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=tools_1_7&amp;id=tools_1_7&amp;link=/checklists/tools_multiplayer.html%23item_1_7&amp;title=Flask of Wondrous Physick"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -421,9 +399,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="tools_1_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=tools_1_4&amp;id=tools_1_4&amp;link=/checklists/tools_multiplayer.html%23item_1_4&amp;title=Mimic's Veil">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=tools_1_4&amp;id=tools_1_4&amp;link=/checklists/tools_multiplayer.html%23item_1_4&amp;title=Mimic's Veil"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -456,9 +432,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="tools_1_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=tools_1_5&amp;id=tools_1_5&amp;link=/checklists/tools_multiplayer.html%23item_1_5&amp;title=Lantern">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=tools_1_5&amp;id=tools_1_5&amp;link=/checklists/tools_multiplayer.html%23item_1_5&amp;title=Lantern"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -491,9 +465,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="tools_1_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=tools_1_6&amp;id=tools_1_6&amp;link=/checklists/tools_multiplayer.html%23item_1_6&amp;title=Pureblood Knight's Medal">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=tools_1_6&amp;id=tools_1_6&amp;link=/checklists/tools_multiplayer.html%23item_1_6&amp;title=Pureblood Knight's Medal"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -527,9 +499,7 @@
         <div class="card shadow-sm mb-3" id="tools_section_1">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#tools_1Col" data-bs-toggle="collapse" href="#tools_1Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#tools_1Col" data-bs-toggle="collapse" href="#tools_1Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Combat</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="tools_totals_1"></span>
             </h4>
@@ -541,9 +511,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -572,9 +540,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="tools_2_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=tools_2_1&amp;id=tools_2_1&amp;link=/checklists/tools_multiplayer.html%23item_2_1&amp;title=Margit's Shackle">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=tools_2_1&amp;id=tools_2_1&amp;link=/checklists/tools_multiplayer.html%23item_2_1&amp;title=Margit's Shackle"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -607,9 +573,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="tools_2_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=tools_2_2&amp;id=tools_2_2&amp;link=/checklists/tools_multiplayer.html%23item_2_2&amp;title=Wraith Calling Bell">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=tools_2_2&amp;id=tools_2_2&amp;link=/checklists/tools_multiplayer.html%23item_2_2&amp;title=Wraith Calling Bell"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -642,9 +606,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="tools_2_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=tools_2_3&amp;id=tools_2_3&amp;link=/checklists/tools_multiplayer.html%23item_2_3&amp;title=Ancestral Infant's Head">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=tools_2_3&amp;id=tools_2_3&amp;link=/checklists/tools_multiplayer.html%23item_2_3&amp;title=Ancestral Infant's Head"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -677,9 +639,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="tools_2_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=tools_2_4&amp;id=tools_2_4&amp;link=/checklists/tools_multiplayer.html%23item_2_4&amp;title=Mohg's Shackle">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=tools_2_4&amp;id=tools_2_4&amp;link=/checklists/tools_multiplayer.html%23item_2_4&amp;title=Mohg's Shackle"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -712,9 +672,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="tools_2_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=tools_2_5&amp;id=tools_2_5&amp;link=/checklists/tools_multiplayer.html%23item_2_5&amp;title=Omen Bairn">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=tools_2_5&amp;id=tools_2_5&amp;link=/checklists/tools_multiplayer.html%23item_2_5&amp;title=Omen Bairn"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -747,9 +705,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="tools_2_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=tools_2_6&amp;id=tools_2_6&amp;link=/checklists/tools_multiplayer.html%23item_2_6&amp;title=Regal Omen Bairn">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=tools_2_6&amp;id=tools_2_6&amp;link=/checklists/tools_multiplayer.html%23item_2_6&amp;title=Regal Omen Bairn"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -782,9 +738,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="tools_2_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=tools_2_7&amp;id=tools_2_7&amp;link=/checklists/tools_multiplayer.html%23item_2_7&amp;title=Blasphemous Claw">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=tools_2_7&amp;id=tools_2_7&amp;link=/checklists/tools_multiplayer.html%23item_2_7&amp;title=Blasphemous Claw"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -817,9 +771,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="tools_2_11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=tools_2_11&amp;id=tools_2_11&amp;link=/checklists/tools_multiplayer.html%23item_2_11&amp;title=Bondstone">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=tools_2_11&amp;id=tools_2_11&amp;link=/checklists/tools_multiplayer.html%23item_2_11&amp;title=Bondstone"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -852,9 +804,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="tools_2_12" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=tools_2_12&amp;id=tools_2_12&amp;link=/checklists/tools_multiplayer.html%23item_2_12&amp;title=Horned Bairn">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=tools_2_12&amp;id=tools_2_12&amp;link=/checklists/tools_multiplayer.html%23item_2_12&amp;title=Horned Bairn"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -887,9 +837,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="tools_2_13" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=tools_2_13&amp;id=tools_2_13&amp;link=/checklists/tools_multiplayer.html%23item_2_13&amp;title=Perfumed Oil of Ranah">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=tools_2_13&amp;id=tools_2_13&amp;link=/checklists/tools_multiplayer.html%23item_2_13&amp;title=Perfumed Oil of Ranah"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -922,9 +870,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="tools_2_14" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=tools_2_14&amp;id=tools_2_14&amp;link=/checklists/tools_multiplayer.html%23item_2_14&amp;title=Call of Tibia">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=tools_2_14&amp;id=tools_2_14&amp;link=/checklists/tools_multiplayer.html%23item_2_14&amp;title=Call of Tibia"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -958,9 +904,7 @@
         <div class="card shadow-sm mb-3" id="tools_section_2">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#tools_2Col" data-bs-toggle="collapse" href="#tools_2Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#tools_2Col" data-bs-toggle="collapse" href="#tools_2Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Prattling Pates</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="tools_totals_2"></span>
             </h4>
@@ -972,9 +916,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -1003,9 +945,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="tools_3_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=tools_3_1&amp;id=tools_3_1&amp;link=/checklists/tools_multiplayer.html%23item_3_1&amp;title=&quot;Hello&quot;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=tools_3_1&amp;id=tools_3_1&amp;link=/checklists/tools_multiplayer.html%23item_3_1&amp;title=&quot;Hello&quot;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1038,9 +978,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="tools_3_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=tools_3_2&amp;id=tools_3_2&amp;link=/checklists/tools_multiplayer.html%23item_3_2&amp;title=&quot;Please Help&quot;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=tools_3_2&amp;id=tools_3_2&amp;link=/checklists/tools_multiplayer.html%23item_3_2&amp;title=&quot;Please Help&quot;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1073,9 +1011,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="tools_3_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=tools_3_3&amp;id=tools_3_3&amp;link=/checklists/tools_multiplayer.html%23item_3_3&amp;title=&quot;Thank You&quot;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=tools_3_3&amp;id=tools_3_3&amp;link=/checklists/tools_multiplayer.html%23item_3_3&amp;title=&quot;Thank You&quot;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1108,9 +1044,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="tools_3_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=tools_3_4&amp;id=tools_3_4&amp;link=/checklists/tools_multiplayer.html%23item_3_4&amp;title=&quot;Wonderful&quot;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=tools_3_4&amp;id=tools_3_4&amp;link=/checklists/tools_multiplayer.html%23item_3_4&amp;title=&quot;Wonderful&quot;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1143,9 +1077,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="tools_3_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=tools_3_5&amp;id=tools_3_5&amp;link=/checklists/tools_multiplayer.html%23item_3_5&amp;title=&quot;Apologies&quot;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=tools_3_5&amp;id=tools_3_5&amp;link=/checklists/tools_multiplayer.html%23item_3_5&amp;title=&quot;Apologies&quot;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1178,9 +1110,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="tools_3_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=tools_3_6&amp;id=tools_3_6&amp;link=/checklists/tools_multiplayer.html%23item_3_6&amp;title=&quot;You're Beautiful&quot;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=tools_3_6&amp;id=tools_3_6&amp;link=/checklists/tools_multiplayer.html%23item_3_6&amp;title=&quot;You're Beautiful&quot;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1213,9 +1143,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="tools_3_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=tools_3_7&amp;id=tools_3_7&amp;link=/checklists/tools_multiplayer.html%23item_3_7&amp;title=&quot;Let's Get to It&quot;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=tools_3_7&amp;id=tools_3_7&amp;link=/checklists/tools_multiplayer.html%23item_3_7&amp;title=&quot;Let's Get to It&quot;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1248,9 +1176,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="tools_3_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=tools_3_8&amp;id=tools_3_8&amp;link=/checklists/tools_multiplayer.html%23item_3_8&amp;title=&quot;My Beloved&quot;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=tools_3_8&amp;id=tools_3_8&amp;link=/checklists/tools_multiplayer.html%23item_3_8&amp;title=&quot;My Beloved&quot;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1283,9 +1209,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="tools_3_11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=tools_3_11&amp;id=tools_3_11&amp;link=/checklists/tools_multiplayer.html%23item_3_11&amp;title=&quot;Lamentation&quot;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=tools_3_11&amp;id=tools_3_11&amp;link=/checklists/tools_multiplayer.html%23item_3_11&amp;title=&quot;Lamentation&quot;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1319,9 +1243,7 @@
         <div class="card shadow-sm mb-3" id="tools_section_3">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#tools_3Col" data-bs-toggle="collapse" href="#tools_3Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#tools_3Col" data-bs-toggle="collapse" href="#tools_3Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Multiplayer</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="tools_totals_3"></span>
             </h4>
@@ -1333,9 +1255,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -1364,9 +1284,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="tools_4_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=tools_4_1&amp;id=tools_4_1&amp;link=/checklists/tools_multiplayer.html%23item_4_1&amp;title=Tarnished's Wizened Finger">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=tools_4_1&amp;id=tools_4_1&amp;link=/checklists/tools_multiplayer.html%23item_4_1&amp;title=Tarnished's Wizened Finger"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1399,9 +1317,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="tools_4_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=tools_4_2&amp;id=tools_4_2&amp;link=/checklists/tools_multiplayer.html%23item_4_2&amp;title=Tarnished's Furled Finger">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=tools_4_2&amp;id=tools_4_2&amp;link=/checklists/tools_multiplayer.html%23item_4_2&amp;title=Tarnished's Furled Finger"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1434,9 +1350,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="tools_4_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=tools_4_3&amp;id=tools_4_3&amp;link=/checklists/tools_multiplayer.html%23item_4_3&amp;title=Finger Severer">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=tools_4_3&amp;id=tools_4_3&amp;link=/checklists/tools_multiplayer.html%23item_4_3&amp;title=Finger Severer"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1469,9 +1383,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="tools_4_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=tools_4_4&amp;id=tools_4_4&amp;link=/checklists/tools_multiplayer.html%23item_4_4&amp;title=Small Golden Effigy">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=tools_4_4&amp;id=tools_4_4&amp;link=/checklists/tools_multiplayer.html%23item_4_4&amp;title=Small Golden Effigy"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1504,9 +1416,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="tools_4_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=tools_4_5&amp;id=tools_4_5&amp;link=/checklists/tools_multiplayer.html%23item_4_5&amp;title=Furlcalling Finger Remedy">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=tools_4_5&amp;id=tools_4_5&amp;link=/checklists/tools_multiplayer.html%23item_4_5&amp;title=Furlcalling Finger Remedy"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1539,9 +1449,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="tools_4_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=tools_4_6&amp;id=tools_4_6&amp;link=/checklists/tools_multiplayer.html%23item_4_6&amp;title=Festering Bloody Finger">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=tools_4_6&amp;id=tools_4_6&amp;link=/checklists/tools_multiplayer.html%23item_4_6&amp;title=Festering Bloody Finger"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1574,9 +1482,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="tools_4_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=tools_4_7&amp;id=tools_4_7&amp;link=/checklists/tools_multiplayer.html%23item_4_7&amp;title=Phantom Bloody Finger">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=tools_4_7&amp;id=tools_4_7&amp;link=/checklists/tools_multiplayer.html%23item_4_7&amp;title=Phantom Bloody Finger"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1609,9 +1515,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="tools_4_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=tools_4_8&amp;id=tools_4_8&amp;link=/checklists/tools_multiplayer.html%23item_4_8&amp;title=Duelist's Furled Finger">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=tools_4_8&amp;id=tools_4_8&amp;link=/checklists/tools_multiplayer.html%23item_4_8&amp;title=Duelist's Furled Finger"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1644,9 +1548,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="tools_4_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=tools_4_9&amp;id=tools_4_9&amp;link=/checklists/tools_multiplayer.html%23item_4_9&amp;title=Small Red Effigy">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=tools_4_9&amp;id=tools_4_9&amp;link=/checklists/tools_multiplayer.html%23item_4_9&amp;title=Small Red Effigy"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1679,9 +1581,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="tools_4_10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=tools_4_10&amp;id=tools_4_10&amp;link=/checklists/tools_multiplayer.html%23item_4_10&amp;title=Taunter's Tongue">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=tools_4_10&amp;id=tools_4_10&amp;link=/checklists/tools_multiplayer.html%23item_4_10&amp;title=Taunter's Tongue"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1714,9 +1614,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="tools_4_11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=tools_4_11&amp;id=tools_4_11&amp;link=/checklists/tools_multiplayer.html%23item_4_11&amp;title=White Cipher Ring">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=tools_4_11&amp;id=tools_4_11&amp;link=/checklists/tools_multiplayer.html%23item_4_11&amp;title=White Cipher Ring"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1749,9 +1647,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="tools_4_12" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=tools_4_12&amp;id=tools_4_12&amp;link=/checklists/tools_multiplayer.html%23item_4_12&amp;title=Blue Cipher Ring">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=tools_4_12&amp;id=tools_4_12&amp;link=/checklists/tools_multiplayer.html%23item_4_12&amp;title=Blue Cipher Ring"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1784,9 +1680,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="tools_4_13" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=tools_4_13&amp;id=tools_4_13&amp;link=/checklists/tools_multiplayer.html%23item_4_13&amp;title=Bloody Finger">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=tools_4_13&amp;id=tools_4_13&amp;link=/checklists/tools_multiplayer.html%23item_4_13&amp;title=Bloody Finger"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1819,9 +1713,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="tools_4_14" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=tools_4_14&amp;id=tools_4_14&amp;link=/checklists/tools_multiplayer.html%23item_4_14&amp;title=Recusant Finger">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=tools_4_14&amp;id=tools_4_14&amp;link=/checklists/tools_multiplayer.html%23item_4_14&amp;title=Recusant Finger"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1854,9 +1746,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="tools_4_15" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=tools_4_15&amp;id=tools_4_15&amp;link=/checklists/tools_multiplayer.html%23item_4_15&amp;title=Phantom Great Rune">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=tools_4_15&amp;id=tools_4_15&amp;link=/checklists/tools_multiplayer.html%23item_4_15&amp;title=Phantom Great Rune"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">

--- a/docs/checklists/walkthrough.html
+++ b/docs/checklists/walkthrough.html
@@ -27,14 +27,10 @@
         <a class="navbar-brand me-auto ms-2" href="/index.html">Roundtable Guides</a>
         <form class="d-none d-sm-flex order-2 order-xl-3">
           <input aria-label="search" class="form-control me-2" name="search" placeholder="Search" type="search">
-          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit">
-            <i class="bi bi-search"></i>
-          </button>
+          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit"><i class="bi bi-search"></i></button>
         </form>
         <div class="d-sm-none order-2">
-          <a class="nav-link me-0" href="/search.html">
-            <i class="bi bi-search sb-icon-search"></i>
-          </a>
+          <a class="nav-link me-0" href="/search.html"><i class="bi bi-search sb-icon-search"></i></a>
         </div>
         <div class="collapse navbar-collapse order-3 order-xl-2 ms-xl-2" id="nav-collapse">
           <ul class="nav navbar-nav navbar-nav-scroll mr-auto">
@@ -179,14 +175,10 @@
               </ul>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/map.html">
-                <i class="bi bi-map"></i> Map
-              </a>
+              <a class="nav-link hide-buttons" href="/map.html"><i class="bi bi-map"></i> Map</a>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/options.html">
-                <i class="bi bi-gear-fill"></i> Options
-              </a>
+              <a class="nav-link hide-buttons" href="/options.html"><i class="bi bi-gear-fill"></i> Options</a>
             </li>
           </ul>
         </div>
@@ -206,9 +198,7 @@
       </div>
       <nav class="text-muted toc d-print-none">
         <strong class="d-block h5">
-          <a class="toc-button" data-bs-toggle="collapse" href="#toc_playthrough" role="button">
-            <i class="bi bi-plus-lg"></i>Table Of Contents
-          </a>
+          <a class="toc-button" data-bs-toggle="collapse" href="#toc_playthrough" role="button"><i class="bi bi-plus-lg"></i>Table Of Contents</a>
         </strong>
         <ul class="toc_page collapse" id="toc_playthrough">
           <li>
@@ -372,9 +362,7 @@
         <div class="card shadow-sm mb-3" id="playthrough_section_0">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_0Col" data-bs-toggle="collapse" href="#playthrough_0Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_0Col" data-bs-toggle="collapse" href="#playthrough_0Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Limgrave</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="playthrough_totals_0"></span>
             </h4>
@@ -384,630 +372,490 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_0" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_0">Grab The First Step Grace at the start of the game.</label>
-                    <a class="ms-2" href="/map.html?x=3701&amp;y=7341&amp;id=playthrough_0&amp;link=/checklists/walkthrough.html%23item_0&amp;title=Grab The First Step Grace at the start of the game.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3701&amp;y=7341&amp;id=playthrough_0&amp;link=/checklists/walkthrough.html%23item_0&amp;title=Grab The First Step Grace at the start of the game."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_1" id="item_1">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_1" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_1">Talk to Varré nearby and exhaust his dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=3694&amp;y=7334&amp;id=playthrough_1&amp;link=/checklists/walkthrough.html%23item_1&amp;title=Talk to Varré nearby and exhaust his dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3694&amp;y=7334&amp;id=playthrough_1&amp;link=/checklists/walkthrough.html%23item_1&amp;title=Talk to Varré nearby and exhaust his dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_2" id="item_2">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_2" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_2">Grab the Small Golden Effigy next to the summon statue.</label>
-                    <a class="ms-2" href="/map.html?x=3711&amp;y=7342&amp;id=playthrough_2&amp;link=/checklists/walkthrough.html%23item_2&amp;title=Grab the Small Golden Effigy next to the summon statue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3711&amp;y=7342&amp;id=playthrough_2&amp;link=/checklists/walkthrough.html%23item_2&amp;title=Grab the Small Golden Effigy next to the summon statue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_3" id="item_3">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_3" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_3">Go North and grab the Church of Elleh Grace.</label>
-                    <a class="ms-2" href="/map.html?x=3679&amp;y=7224&amp;id=playthrough_3&amp;link=/checklists/walkthrough.html%23item_3&amp;title=Go North and grab the Church of Elleh Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3679&amp;y=7224&amp;id=playthrough_3&amp;link=/checklists/walkthrough.html%23item_3&amp;title=Go North and grab the Church of Elleh Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_4" id="item_4">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_4" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_4">Talk to Kalé at the Church of Elleh</label>
-                    <a class="ms-2" href="/map.html?x=3655&amp;y=7210&amp;id=playthrough_4&amp;link=/checklists/walkthrough.html%23item_4&amp;title=Talk to Kalé at the Church of Elleh">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3655&amp;y=7210&amp;id=playthrough_4&amp;link=/checklists/walkthrough.html%23item_4&amp;title=Talk to Kalé at the Church of Elleh"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_5" id="item_5">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_5" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_5">Go North-East to the Gatefront Ruins and grab Map (Limgrave, West) at the pillar.</label>
-                    <a class="ms-2" href="/map.html?x=3789&amp;y=6956&amp;id=playthrough_5&amp;link=/checklists/walkthrough.html%23item_5&amp;title=Go North-East to the Gatefront Ruins and grab Map (Limgrave, West) at the pillar.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3789&amp;y=6956&amp;id=playthrough_5&amp;link=/checklists/walkthrough.html%23item_5&amp;title=Go North-East to the Gatefront Ruins and grab Map (Limgrave, West) at the pillar."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_6" id="item_6">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_6" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_6">Go down the stairs in the center of the Gatefront Ruins and grab the Whetstone Knife</label>
-                    <a class="ms-2" href="/map.html?x=3808&amp;y=6982&amp;id=playthrough_6&amp;link=/checklists/walkthrough.html%23item_6&amp;title=Go down the stairs in the center of the Gatefront Ruins and grab the Whetstone Knife">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3808&amp;y=6982&amp;id=playthrough_6&amp;link=/checklists/walkthrough.html%23item_6&amp;title=Go down the stairs in the center of the Gatefront Ruins and grab the Whetstone Knife"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_7" id="item_7">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_7" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_7">Go East of the Gatefront Ruins and grab the Agheel Lake North Grace</label>
-                    <a class="ms-2" href="/map.html?x=3885&amp;y=6983&amp;id=playthrough_7&amp;link=/checklists/walkthrough.html%23item_7&amp;title=Go East of the Gatefront Ruins and grab the Agheel Lake North Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3885&amp;y=6983&amp;id=playthrough_7&amp;link=/checklists/walkthrough.html%23item_7&amp;title=Go East of the Gatefront Ruins and grab the Agheel Lake North Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_8" id="item_8">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_8" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_8">Rest at the Agheel Lake North Grace, form accord with Melina and exhaust her dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=3885&amp;y=6983&amp;id=playthrough_8&amp;link=/checklists/walkthrough.html%23item_8&amp;title=Rest at the Agheel Lake North Grace, form accord with Melina and exhaust her dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3885&amp;y=6983&amp;id=playthrough_8&amp;link=/checklists/walkthrough.html%23item_8&amp;title=Rest at the Agheel Lake North Grace, form accord with Melina and exhaust her dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_9" id="item_9">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_9" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_9">Go East from the Grace and break the tree illusion and talk to Boc until his dialogue is exhausted.</label>
-                    <a class="ms-2" href="/map.html?x=3985&amp;y=7039&amp;id=playthrough_9&amp;link=/checklists/walkthrough.html%23item_9&amp;title=Go East from the Grace and break the tree illusion and talk to Boc until his dialogue is exhausted.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3985&amp;y=7039&amp;id=playthrough_9&amp;link=/checklists/walkthrough.html%23item_9&amp;title=Go East from the Grace and break the tree illusion and talk to Boc until his dialogue is exhausted."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_10" id="item_10">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_10" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_10">Head North, getting atop the cliffs using one of the Spiritjumps, and free Alexander from his hole on the cliffs above the Saintsbridge Grace. After freeing him, talk to him until his dialogue is exhausted.</label>
-                    <a class="ms-2" href="/map.html?x=3954&amp;y=6543&amp;id=playthrough_10&amp;link=/checklists/walkthrough.html%23item_10&amp;title=Head North, getting atop the cliffs using one of the Spiritjumps, and free Alexander from his hole on the cliffs above the Saintsbridge Grace. After freeing him, talk to him until his dialogue is exhausted.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3954&amp;y=6543&amp;id=playthrough_10&amp;link=/checklists/walkthrough.html%23item_10&amp;title=Head North, getting atop the cliffs using one of the Spiritjumps, and free Alexander from his hole on the cliffs above the Saintsbridge Grace. After freeing him, talk to him until his dialogue is exhausted."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_11" id="item_11">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_11" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_11">Grab the Saintsbridge Grace below the cliffs where you found Alexander.</label>
-                    <a class="ms-2" href="/map.html?x=3989&amp;y=6525&amp;id=playthrough_11&amp;link=/checklists/walkthrough.html%23item_11&amp;title=Grab the Saintsbridge Grace below the cliffs where you found Alexander.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3989&amp;y=6525&amp;id=playthrough_11&amp;link=/checklists/walkthrough.html%23item_11&amp;title=Grab the Saintsbridge Grace below the cliffs where you found Alexander."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_12" id="item_12">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_12" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_12">Head East across the bridge and talk to D, Hunter of the Dead near the graveyard until his dialogue is exhausted.</label>
-                    <a class="ms-2" href="/map.html?x=4233&amp;y=6507&amp;id=playthrough_12&amp;link=/checklists/walkthrough.html%23item_12&amp;title=Head East across the bridge and talk to D, Hunter of the Dead near the graveyard until his dialogue is exhausted.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4233&amp;y=6507&amp;id=playthrough_12&amp;link=/checklists/walkthrough.html%23item_12&amp;title=Head East across the bridge and talk to D, Hunter of the Dead near the graveyard until his dialogue is exhausted."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_13" id="item_13">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_13" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_13">Follow the road East to Summonwater Village and kill the Tibia Mariner there.</label>
-                    <a class="ms-2" href="/map.html?x=4452&amp;y=6518&amp;id=playthrough_13&amp;link=/checklists/walkthrough.html%23item_13&amp;title=Follow the road East to Summonwater Village and kill the Tibia Mariner there.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4452&amp;y=6518&amp;id=playthrough_13&amp;link=/checklists/walkthrough.html%23item_13&amp;title=Follow the road East to Summonwater Village and kill the Tibia Mariner there."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_14" id="item_14">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_14" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_14">After killing the Tibia Mariner, talk to D, Hunter of the Dead nearby.</label>
-                    <a class="ms-2" href="/map.html?x=4379&amp;y=6573&amp;id=playthrough_14&amp;link=/checklists/walkthrough.html%23item_14&amp;title=After killing the Tibia Mariner, talk to D, Hunter of the Dead nearby.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4379&amp;y=6573&amp;id=playthrough_14&amp;link=/checklists/walkthrough.html%23item_14&amp;title=After killing the Tibia Mariner, talk to D, Hunter of the Dead nearby."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_15" id="item_15">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_15" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_15">Make your way down the cliffs going South and talk to Kenneth Haight on top of the ruin.</label>
-                    <a class="ms-2" href="/map.html?x=4399&amp;y=6816&amp;id=playthrough_15&amp;link=/checklists/walkthrough.html%23item_15&amp;title=Make your way down the cliffs going South and talk to Kenneth Haight on top of the ruin.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4399&amp;y=6816&amp;id=playthrough_15&amp;link=/checklists/walkthrough.html%23item_15&amp;title=Make your way down the cliffs going South and talk to Kenneth Haight on top of the ruin."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_16" id="item_16">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_16" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_16">Head East from Kenneth Haight and grab the Third Church of Marika Grace as well as the Sacred Tear, the Flask of Wondrous Physick and the Crimson Crystal Tear.</label>
-                    <a class="ms-2" href="/map.html?x=4635&amp;y=6711&amp;id=playthrough_16&amp;link=/checklists/walkthrough.html%23item_16&amp;title=Head East from Kenneth Haight and grab the Third Church of Marika Grace as well as the Sacred Tear, the Flask of Wondrous Physick and the Crimson Crystal Tear.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4635&amp;y=6711&amp;id=playthrough_16&amp;link=/checklists/walkthrough.html%23item_16&amp;title=Head East from Kenneth Haight and grab the Third Church of Marika Grace as well as the Sacred Tear, the Flask of Wondrous Physick and the Crimson Crystal Tear."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_17" id="item_17">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_17" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_17">Rest at the Grace and talk to Melina until her dialogue is exhausted.</label>
-                    <a class="ms-2" href="/map.html?x=4635&amp;y=6711&amp;id=playthrough_17&amp;link=/checklists/walkthrough.html%23item_17&amp;title=Rest at the Grace and talk to Melina until her dialogue is exhausted.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4635&amp;y=6711&amp;id=playthrough_17&amp;link=/checklists/walkthrough.html%23item_17&amp;title=Rest at the Grace and talk to Melina until her dialogue is exhausted."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_18" id="item_18">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_18" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_18">Head South along the road to find Map (Limgrave, East) at the pillar beside the road.</label>
-                    <a class="ms-2" href="/map.html?x=4524&amp;y=7053&amp;id=playthrough_18&amp;link=/checklists/walkthrough.html%23item_18&amp;title=Head South along the road to find Map (Limgrave, East) at the pillar beside the road.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4524&amp;y=7053&amp;id=playthrough_18&amp;link=/checklists/walkthrough.html%23item_18&amp;title=Head South along the road to find Map (Limgrave, East) at the pillar beside the road."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_19" id="item_19">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_19" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_19">Go South-West from the pillar and listen to Blaidd's howling at Mistwood Ruins</label>
-                    <a class="ms-2" href="/map.html?x=4435&amp;y=7149&amp;id=playthrough_19&amp;link=/checklists/walkthrough.html%23item_19&amp;title=Go South-West from the pillar and listen to Blaidd's howling at Mistwood Ruins">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4435&amp;y=7149&amp;id=playthrough_19&amp;link=/checklists/walkthrough.html%23item_19&amp;title=Go South-West from the pillar and listen to Blaidd's howling at Mistwood Ruins"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_20" id="item_20">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_20" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_20">Follow the road South-East and grab the Fort Haight West Grace.</label>
-                    <a class="ms-2" href="/map.html?x=4595&amp;y=7341&amp;id=playthrough_20&amp;link=/checklists/walkthrough.html%23item_20&amp;title=Follow the road South-East and grab the Fort Haight West Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4595&amp;y=7341&amp;id=playthrough_20&amp;link=/checklists/walkthrough.html%23item_20&amp;title=Follow the road South-East and grab the Fort Haight West Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_21" id="item_21">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_21" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_21">Grab the Golden Seed from the Erdtree Sapling in front of Fort Haight.</label>
-                    <a class="ms-2" href="/map.html?x=4674&amp;y=7344&amp;id=playthrough_21&amp;link=/checklists/walkthrough.html%23item_21&amp;title=Grab the Golden Seed from the Erdtree Sapling in front of Fort Haight.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4674&amp;y=7344&amp;id=playthrough_21&amp;link=/checklists/walkthrough.html%23item_21&amp;title=Grab the Golden Seed from the Erdtree Sapling in front of Fort Haight."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_22" id="item_22">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_22" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_22">Climb to the top of Fort Haight and kill the Knight at the top</label>
-                    <a class="ms-2" href="/map.html?x=4727&amp;y=7292&amp;id=playthrough_22&amp;link=/checklists/walkthrough.html%23item_22&amp;title=Climb to the top of Fort Haight and kill the Knight at the top">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4727&amp;y=7292&amp;id=playthrough_22&amp;link=/checklists/walkthrough.html%23item_22&amp;title=Climb to the top of Fort Haight and kill the Knight at the top"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_23" id="item_23">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_23" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_23">Climb the ladder in the nearby tower to collect Dectus Medallion(Left)</label>
-                    <a class="ms-2" href="/map.html?x=4733&amp;y=7324&amp;id=playthrough_23&amp;link=/checklists/walkthrough.html%23item_23&amp;title=Climb the ladder in the nearby tower to collect Dectus Medallion(Left)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4733&amp;y=7324&amp;id=playthrough_23&amp;link=/checklists/walkthrough.html%23item_23&amp;title=Climb the ladder in the nearby tower to collect Dectus Medallion(Left)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_24" id="item_24">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_24" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_24">Go back to the Church of Elleh, pass time until Night if needed, meet Renna to receive the Spirit Calling Bell and the Lone Wolf Ashes and exhaust her dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=3670&amp;y=7214&amp;id=playthrough_24&amp;link=/checklists/walkthrough.html%23item_24&amp;title=Go back to the Church of Elleh, pass time until Night if needed, meet Renna to receive the Spirit Calling Bell and the Lone Wolf Ashes and exhaust her dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3670&amp;y=7214&amp;id=playthrough_24&amp;link=/checklists/walkthrough.html%23item_24&amp;title=Go back to the Church of Elleh, pass time until Night if needed, meet Renna to receive the Spirit Calling Bell and the Lone Wolf Ashes and exhaust her dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_25" id="item_25">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_25" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_25">Talk to Kalé nearby for the Fingersnap emote and exhaust his dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=3655&amp;y=7210&amp;id=playthrough_25&amp;link=/checklists/walkthrough.html%23item_25&amp;title=Talk to Kalé nearby for the Fingersnap emote and exhaust his dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3655&amp;y=7210&amp;id=playthrough_25&amp;link=/checklists/walkthrough.html%23item_25&amp;title=Talk to Kalé nearby for the Fingersnap emote and exhaust his dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_26" id="item_26">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_26" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_26">Go South-West from the Church of Elleh and make your way down to the shore then enter the Coastal Cave and grab the Coastal Cave Grace.</label>
-                    <a class="ms-2" href="/map.html?x=3504&amp;y=7336&amp;id=playthrough_26&amp;link=/checklists/walkthrough.html%23item_26&amp;title=Go South-West from the Church of Elleh and make your way down to the shore then enter the Coastal Cave and grab the Coastal Cave Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3504&amp;y=7336&amp;id=playthrough_26&amp;link=/checklists/walkthrough.html%23item_26&amp;title=Go South-West from the Church of Elleh and make your way down to the shore then enter the Coastal Cave and grab the Coastal Cave Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_27" id="item_27">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_27" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_27">Talk to Boc near the Grace and exhaust his dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=3504&amp;y=7336&amp;id=playthrough_27&amp;link=/checklists/walkthrough.html%23item_27&amp;title=Talk to Boc near the Grace and exhaust his dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3504&amp;y=7336&amp;id=playthrough_27&amp;link=/checklists/walkthrough.html%23item_27&amp;title=Talk to Boc near the Grace and exhaust his dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_28" id="item_28">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_28" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_28">Go through the Coastal Cave and summon Old Knight Istvan outside the boss room</label>
-                    <a class="ms-2" href="/map.html?x=3521&amp;y=7326&amp;id=playthrough_28&amp;link=/checklists/walkthrough.html%23item_28&amp;title=Go through the Coastal Cave and summon Old Knight Istvan outside the boss room">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3521&amp;y=7326&amp;id=playthrough_28&amp;link=/checklists/walkthrough.html%23item_28&amp;title=Go through the Coastal Cave and summon Old Knight Istvan outside the boss room"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_29" id="item_29">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_29" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_29">Kill the Demi-Human Chiefs boss and receive the Sewing Needle and Tailoring Tools.</label>
-                    <a class="ms-2" href="/map.html?x=3521&amp;y=7326&amp;id=playthrough_29&amp;link=/checklists/walkthrough.html%23item_29&amp;title=Kill the Demi-Human Chiefs boss and receive the Sewing Needle and Tailoring Tools.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3521&amp;y=7326&amp;id=playthrough_29&amp;link=/checklists/walkthrough.html%23item_29&amp;title=Kill the Demi-Human Chiefs boss and receive the Sewing Needle and Tailoring Tools."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_30" id="item_30">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_30" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_30">Head out through the other side of the boss room and grab the Church of Dragon Communion Grace.</label>
-                    <a class="ms-2" href="/map.html?x=3403&amp;y=7573&amp;id=playthrough_30&amp;link=/checklists/walkthrough.html%23item_30&amp;title=Head out through the other side of the boss room and grab the Church of Dragon Communion Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3403&amp;y=7573&amp;id=playthrough_30&amp;link=/checklists/walkthrough.html%23item_30&amp;title=Head out through the other side of the boss room and grab the Church of Dragon Communion Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_31" id="item_31">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_31" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_31">Go back to Boc and give him the Sewing Needle then exhaust his dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=3504&amp;y=7336&amp;id=playthrough_31&amp;link=/checklists/walkthrough.html%23item_31&amp;title=Go back to Boc and give him the Sewing Needle then exhaust his dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3504&amp;y=7336&amp;id=playthrough_31&amp;link=/checklists/walkthrough.html%23item_31&amp;title=Go back to Boc and give him the Sewing Needle then exhaust his dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_32" id="item_32">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_32" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_32">Head South-East from the First Step Grace and grab the Seaside Ruins Grace along the edge of the cliffs.</label>
-                    <a class="ms-2" href="/map.html?x=3951&amp;y=7503&amp;id=playthrough_32&amp;link=/checklists/walkthrough.html%23item_32&amp;title=Head South-East from the First Step Grace and grab the Seaside Ruins Grace along the edge of the cliffs.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3951&amp;y=7503&amp;id=playthrough_32&amp;link=/checklists/walkthrough.html%23item_32&amp;title=Head South-East from the First Step Grace and grab the Seaside Ruins Grace along the edge of the cliffs."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_33" id="item_33">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_33" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_33">Meet Yura at the ruin next to the Seaside Ruins Grace and exhaust his dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=4013&amp;y=7470&amp;id=playthrough_33&amp;link=/checklists/walkthrough.html%23item_33&amp;title=Meet Yura at the ruin next to the Seaside Ruins Grace and exhaust his dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4013&amp;y=7470&amp;id=playthrough_33&amp;link=/checklists/walkthrough.html%23item_33&amp;title=Meet Yura at the ruin next to the Seaside Ruins Grace and exhaust his dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_34" id="item_34">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_34" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_34">Head North-West into the lake and fight the Flying Dragon Agheel, hitting it at least once, and run away.</label>
-                    <a class="ms-2" href="/map.html?x=3880&amp;y=7216&amp;id=playthrough_34&amp;link=/checklists/walkthrough.html%23item_34&amp;title=Head North-West into the lake and fight the Flying Dragon Agheel, hitting it at least once, and run away.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3880&amp;y=7216&amp;id=playthrough_34&amp;link=/checklists/walkthrough.html%23item_34&amp;title=Head North-West into the lake and fight the Flying Dragon Agheel, hitting it at least once, and run away."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_35" id="item_35">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_35" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_35">Return to Yura after fighting Flying Dragon Agheel without killing it for extra dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=4013&amp;y=7470&amp;id=playthrough_35&amp;link=/checklists/walkthrough.html%23item_35&amp;title=Return to Yura after fighting Flying Dragon Agheel without killing it for extra dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4013&amp;y=7470&amp;id=playthrough_35&amp;link=/checklists/walkthrough.html%23item_35&amp;title=Return to Yura after fighting Flying Dragon Agheel without killing it for extra dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_38" id="item_38">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_38" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_38">Head East from Yura and grab the Agheel Lake South Grace.</label>
-                    <a class="ms-2" href="/map.html?x=4188&amp;y=7505&amp;id=playthrough_38&amp;link=/checklists/walkthrough.html%23item_38&amp;title=Head East from Yura and grab the Agheel Lake South Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4188&amp;y=7505&amp;id=playthrough_38&amp;link=/checklists/walkthrough.html%23item_38&amp;title=Head East from Yura and grab the Agheel Lake South Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_39" id="item_39">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_39" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_39">Head North from the Grace to the Waypoint Ruins and kill the boss Mad Pumpkin Head.</label>
-                    <a class="ms-2" href="/map.html?x=4234&amp;y=7222&amp;id=playthrough_39&amp;link=/checklists/walkthrough.html%23item_39&amp;title=Head North from the Grace to the Waypoint Ruins and kill the boss Mad Pumpkin Head.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4234&amp;y=7222&amp;id=playthrough_39&amp;link=/checklists/walkthrough.html%23item_39&amp;title=Head North from the Grace to the Waypoint Ruins and kill the boss Mad Pumpkin Head."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_40" id="item_40">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_40" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_40">Grab the Waypoint Ruins Grace and meet Sellen. Accept her offer of training and exhaust her dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=4239&amp;y=7258&amp;id=playthrough_40&amp;link=/checklists/walkthrough.html%23item_40&amp;title=Grab the Waypoint Ruins Grace and meet Sellen. Accept her offer of training and exhaust her dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4239&amp;y=7258&amp;id=playthrough_40&amp;link=/checklists/walkthrough.html%23item_40&amp;title=Grab the Waypoint Ruins Grace and meet Sellen. Accept her offer of training and exhaust her dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_41" id="item_41">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_41" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_41">Go West into the lake and head North, under the bridge. Continue along this path and you will be invaded by Bloody Finger Nerijus. Survive against him for a short while and Yura will appear with dialogue then kill Blood Finger Nerijus.</label>
-                    <a class="ms-2" href="/map.html?x=4075&amp;y=6933&amp;id=playthrough_41&amp;link=/checklists/walkthrough.html%23item_41&amp;title=Go West into the lake and head North, under the bridge. Continue along this path and you will be invaded by Bloody Finger Nerijus. Survive against him for a short while and Yura will appear with dialogue then kill Blood Finger Nerijus.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4075&amp;y=6933&amp;id=playthrough_41&amp;link=/checklists/walkthrough.html%23item_41&amp;title=Go West into the lake and head North, under the bridge. Continue along this path and you will be invaded by Bloody Finger Nerijus. Survive against him for a short while and Yura will appear with dialogue then kill Blood Finger Nerijus."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_42" id="item_42">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_42" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_42">Go North from where you fought Nerijus and talk to Yura under the ruin.</label>
-                    <a class="ms-2" href="/map.html?x=4104&amp;y=6831&amp;id=playthrough_42&amp;link=/checklists/walkthrough.html%23item_42&amp;title=Go North from where you fought Nerijus and talk to Yura under the ruin.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4104&amp;y=6831&amp;id=playthrough_42&amp;link=/checklists/walkthrough.html%23item_42&amp;title=Go North from where you fought Nerijus and talk to Yura under the ruin."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_43" id="item_43">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_43" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_43">Go back to where you fought Nerijus and enter Murkwater Cave to grab the Murkwater Cave Grace.</label>
-                    <a class="ms-2" href="/map.html?x=4060&amp;y=6975&amp;id=playthrough_43&amp;link=/checklists/walkthrough.html%23item_43&amp;title=Go back to where you fought Nerijus and enter Murkwater Cave to grab the Murkwater Cave Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4060&amp;y=6975&amp;id=playthrough_43&amp;link=/checklists/walkthrough.html%23item_43&amp;title=Go back to where you fought Nerijus and enter Murkwater Cave to grab the Murkwater Cave Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_44" id="item_44">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_44" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_44">Proceed through the cave and open the obviously unguarded chest in the completely empty room.</label>
-                    <a class="ms-2" href="/map.html?x=4026&amp;y=6962&amp;id=playthrough_44&amp;link=/checklists/walkthrough.html%23item_44&amp;title=Proceed through the cave and open the obviously unguarded chest in the completely empty room.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4026&amp;y=6962&amp;id=playthrough_44&amp;link=/checklists/walkthrough.html%23item_44&amp;title=Proceed through the cave and open the obviously unguarded chest in the completely empty room."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_45" id="item_45">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_45" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_45">Fight Patches until he is at 50% health. As soon as he surrenders, stop attacking and the fight will end.</label>
-                    <a class="ms-2" href="/map.html?x=4026&amp;y=6962&amp;id=playthrough_45&amp;link=/checklists/walkthrough.html%23item_45&amp;title=Fight Patches until he is at 50% health. As soon as he surrenders, stop attacking and the fight will end.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4026&amp;y=6962&amp;id=playthrough_45&amp;link=/checklists/walkthrough.html%23item_45&amp;title=Fight Patches until he is at 50% health. As soon as he surrenders, stop attacking and the fight will end."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_46" id="item_46">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_46" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_46">Attack Patches(very lightly) and he will become hostile again. Let him knock YOU to 50% health and you will receive and emote. Use it to end the fight.</label>
-                    <a class="ms-2" href="/map.html?x=4026&amp;y=6962&amp;id=playthrough_46&amp;link=/checklists/walkthrough.html%23item_46&amp;title=Attack Patches(very lightly) and he will become hostile again. Let him knock YOU to 50% health and you will receive and emote. Use it to end the fight.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4026&amp;y=6962&amp;id=playthrough_46&amp;link=/checklists/walkthrough.html%23item_46&amp;title=Attack Patches(very lightly) and he will become hostile again. Let him knock YOU to 50% health and you will receive and emote. Use it to end the fight."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_47" id="item_47">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_47" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_47">Talk to Patches and exhaust his dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=4026&amp;y=6962&amp;id=playthrough_47&amp;link=/checklists/walkthrough.html%23item_47&amp;title=Talk to Patches and exhaust his dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4026&amp;y=6962&amp;id=playthrough_47&amp;link=/checklists/walkthrough.html%23item_47&amp;title=Talk to Patches and exhaust his dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_48" id="item_48">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_48" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_48">Reload the area and return to him for more dialogue and access to his shop. Buy Margit's Shackle, the Missionary's Cookbook(2) and anything else you like.</label>
-                    <a class="ms-2" href="/map.html?x=4026&amp;y=6962&amp;id=playthrough_48&amp;link=/checklists/walkthrough.html%23item_48&amp;title=Reload the area and return to him for more dialogue and access to his shop. Buy Margit's Shackle, the Missionary's Cookbook(2) and anything else you like.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4026&amp;y=6962&amp;id=playthrough_48&amp;link=/checklists/walkthrough.html%23item_48&amp;title=Reload the area and return to him for more dialogue and access to his shop. Buy Margit's Shackle, the Missionary's Cookbook(2) and anything else you like."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_49" id="item_49">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_49" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_49">Reload the area again after purchasing stuff and talk to Patches again for more dialogue. He will give you permission to open the chest so open the chest.</label>
-                    <a class="ms-2" href="/map.html?x=4026&amp;y=6962&amp;id=playthrough_49&amp;link=/checklists/walkthrough.html%23item_49&amp;title=Reload the area again after purchasing stuff and talk to Patches again for more dialogue. He will give you permission to open the chest so open the chest.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4026&amp;y=6962&amp;id=playthrough_49&amp;link=/checklists/walkthrough.html%23item_49&amp;title=Reload the area again after purchasing stuff and talk to Patches again for more dialogue. He will give you permission to open the chest so open the chest."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_50" id="item_50">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_50" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_50">Head North, back to Kenneth Haight and exhaust his dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=4399&amp;y=6816&amp;id=playthrough_50&amp;link=/checklists/walkthrough.html%23item_50&amp;title=Head North, back to Kenneth Haight and exhaust his dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4399&amp;y=6816&amp;id=playthrough_50&amp;link=/checklists/walkthrough.html%23item_50&amp;title=Head North, back to Kenneth Haight and exhaust his dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_51" id="item_51">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_51" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_51">Go South, back to the Mistwood Ruins, use the Fingersnap emote to call Blaidd down then talk to Blaidd and exhaust his dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=4435&amp;y=7149&amp;id=playthrough_51&amp;link=/checklists/walkthrough.html%23item_51&amp;title=Go South, back to the Mistwood Ruins, use the Fingersnap emote to call Blaidd down then talk to Blaidd and exhaust his dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4435&amp;y=7149&amp;id=playthrough_51&amp;link=/checklists/walkthrough.html%23item_51&amp;title=Go South, back to the Mistwood Ruins, use the Fingersnap emote to call Blaidd down then talk to Blaidd and exhaust his dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_52" id="item_52">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_52" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_52">Head to Fort Haight and talk to Kenneth at the top, where you fought the knight, and exhaust his dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=4727&amp;y=7292&amp;id=playthrough_52&amp;link=/checklists/walkthrough.html%23item_52&amp;title=Head to Fort Haight and talk to Kenneth at the top, where you fought the knight, and exhaust his dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4727&amp;y=7292&amp;id=playthrough_52&amp;link=/checklists/walkthrough.html%23item_52&amp;title=Head to Fort Haight and talk to Kenneth at the top, where you fought the knight, and exhaust his dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_53" id="item_53">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_53" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_53">Go back to Patches in Murkwater Cave and exhaust his dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=4026&amp;y=6962&amp;id=playthrough_53&amp;link=/checklists/walkthrough.html%23item_53&amp;title=Go back to Patches in Murkwater Cave and exhaust his dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4026&amp;y=6962&amp;id=playthrough_53&amp;link=/checklists/walkthrough.html%23item_53&amp;title=Go back to Patches in Murkwater Cave and exhaust his dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_54" id="item_54">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_54" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_54">Go to the Saintsbridge Grace(where you freed Alexander) and head West. You will find the Deathtouched Catacombs in the wall of the cliff on the North side. Go inside and grab the Deathtouched Catacombs Grace.</label>
-                    <a class="ms-2" href="/map.html?x=3897&amp;y=6502&amp;id=playthrough_54&amp;link=/checklists/walkthrough.html%23item_54&amp;title=Go to the Saintsbridge Grace(where you freed Alexander) and head West. You will find the Deathtouched Catacombs in the wall of the cliff on the North side. Go inside and grab the Deathtouched Catacombs Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3897&amp;y=6502&amp;id=playthrough_54&amp;link=/checklists/walkthrough.html%23item_54&amp;title=Go to the Saintsbridge Grace(where you freed Alexander) and head West. You will find the Deathtouched Catacombs in the wall of the cliff on the North side. Go inside and grab the Deathtouched Catacombs Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_55" id="item_55">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_55" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_55">Go through the Deathtouched Catacombs and defeat the boss Black Knife Assassin and collect the Deathroot.</label>
-                    <a class="ms-2" href="/map.html?x=3911&amp;y=6494&amp;id=playthrough_55&amp;link=/checklists/walkthrough.html%23item_55&amp;title=Go through the Deathtouched Catacombs and defeat the boss Black Knife Assassin and collect the Deathroot.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3911&amp;y=6494&amp;id=playthrough_55&amp;link=/checklists/walkthrough.html%23item_55&amp;title=Go through the Deathtouched Catacombs and defeat the boss Black Knife Assassin and collect the Deathroot."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_56" id="item_56">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_56" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_56">Follow the road West from the Deathtouched Catacombs and grab the Warmaster's Shack Grace.</label>
-                    <a class="ms-2" href="/map.html?x=3719&amp;y=6684&amp;id=playthrough_56&amp;link=/checklists/walkthrough.html%23item_56&amp;title=Follow the road West from the Deathtouched Catacombs and grab the Warmaster's Shack Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3719&amp;y=6684&amp;id=playthrough_56&amp;link=/checklists/walkthrough.html%23item_56&amp;title=Follow the road West from the Deathtouched Catacombs and grab the Warmaster's Shack Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_57" id="item_57">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_57" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_57">Meet Knight Bernahl in the Warmaster's Shack and exhaust his dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=3720&amp;y=6696&amp;id=playthrough_57&amp;link=/checklists/walkthrough.html%23item_57&amp;title=Meet Knight Bernahl in the Warmaster's Shack and exhaust his dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3720&amp;y=6696&amp;id=playthrough_57&amp;link=/checklists/walkthrough.html%23item_57&amp;title=Meet Knight Bernahl in the Warmaster's Shack and exhaust his dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_58" id="item_58">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_58" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_58">Follow the road North from the Warmaster's Shack and be invaded by Recusant Henricus. Kill him.</label>
-                    <a class="ms-2" href="/map.html?x=3650&amp;y=6420&amp;id=playthrough_58&amp;link=/checklists/walkthrough.html%23item_58&amp;title=Follow the road North from the Warmaster's Shack and be invaded by Recusant Henricus. Kill him.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3650&amp;y=6420&amp;id=playthrough_58&amp;link=/checklists/walkthrough.html%23item_58&amp;title=Follow the road North from the Warmaster's Shack and be invaded by Recusant Henricus. Kill him."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_59" id="item_59">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_59" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_59">Head West from the Warmaster's Shack, following the road to Stormhill Shack and grab the Stormhill Shack Grace.</label>
-                    <a class="ms-2" href="/map.html?x=3472&amp;y=6764&amp;id=playthrough_59&amp;link=/checklists/walkthrough.html%23item_59&amp;title=Head West from the Warmaster's Shack, following the road to Stormhill Shack and grab the Stormhill Shack Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3472&amp;y=6764&amp;id=playthrough_59&amp;link=/checklists/walkthrough.html%23item_59&amp;title=Head West from the Warmaster's Shack, following the road to Stormhill Shack and grab the Stormhill Shack Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_60" id="item_60">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_60" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_60">Rest at the Stormhill Shack Grace, talk to Melina and exhaust her dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=3472&amp;y=6764&amp;id=playthrough_60&amp;link=/checklists/walkthrough.html%23item_60&amp;title=Rest at the Stormhill Shack Grace, talk to Melina and exhaust her dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3472&amp;y=6764&amp;id=playthrough_60&amp;link=/checklists/walkthrough.html%23item_60&amp;title=Rest at the Stormhill Shack Grace, talk to Melina and exhaust her dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_61" id="item_61">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_61" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_61">Meet Roderika in the Stormhill Shack and exhaust her dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=3491&amp;y=6775&amp;id=playthrough_61&amp;link=/checklists/walkthrough.html%23item_61&amp;title=Meet Roderika in the Stormhill Shack and exhaust her dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3491&amp;y=6775&amp;id=playthrough_61&amp;link=/checklists/walkthrough.html%23item_61&amp;title=Meet Roderika in the Stormhill Shack and exhaust her dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_62" id="item_62">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_62" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_62">Grab the Golden Seed from the Erdtree Sapling just South of the Stormhill Shack.</label>
-                    <a class="ms-2" href="/map.html?x=3501&amp;y=6860&amp;id=playthrough_62&amp;link=/checklists/walkthrough.html%23item_62&amp;title=Grab the Golden Seed from the Erdtree Sapling just South of the Stormhill Shack.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3501&amp;y=6860&amp;id=playthrough_62&amp;link=/checklists/walkthrough.html%23item_62&amp;title=Grab the Golden Seed from the Erdtree Sapling just South of the Stormhill Shack."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_63" id="item_63">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_63" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_63">Head North from the Stormhill Shack, going into the woods and meet the Finger Reader on the broken bridge</label>
-                    <a class="ms-2" href="/map.html?x=3346&amp;y=6512&amp;id=playthrough_63&amp;link=/checklists/walkthrough.html%23item_63&amp;title=Head North from the Stormhill Shack, going into the woods and meet the Finger Reader on the broken bridge">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3346&amp;y=6512&amp;id=playthrough_63&amp;link=/checklists/walkthrough.html%23item_63&amp;title=Head North from the Stormhill Shack, going into the woods and meet the Finger Reader on the broken bridge"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_64" id="item_64">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_64" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_64">Backtrack to the road and head West this time to grab the Castleward Tunnel Grace.</label>
-                    <a class="ms-2" href="/map.html?x=3367&amp;y=6805&amp;id=playthrough_64&amp;link=/checklists/walkthrough.html%23item_64&amp;title=Backtrack to the road and head West this time to grab the Castleward Tunnel Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3367&amp;y=6805&amp;id=playthrough_64&amp;link=/checklists/walkthrough.html%23item_64&amp;title=Backtrack to the road and head West this time to grab the Castleward Tunnel Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_65" id="item_65">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_65" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_65">Rest at the Castleward Tunnel Grace, talk to Melina and exhaust her dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=3367&amp;y=6805&amp;id=playthrough_65&amp;link=/checklists/walkthrough.html%23item_65&amp;title=Rest at the Castleward Tunnel Grace, talk to Melina and exhaust her dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3367&amp;y=6805&amp;id=playthrough_65&amp;link=/checklists/walkthrough.html%23item_65&amp;title=Rest at the Castleward Tunnel Grace, talk to Melina and exhaust her dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_66" id="item_66">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_66" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_66">Go back to the Agheel Lake South Grace in South-East Limgrave and head up the slope to the South to find the Forlorn Hound Evergaol.</label>
-                    <a class="ms-2" href="/map.html?x=4207&amp;y=7666&amp;id=playthrough_66&amp;link=/checklists/walkthrough.html%23item_66&amp;title=Go back to the Agheel Lake South Grace in South-East Limgrave and head up the slope to the South to find the Forlorn Hound Evergaol.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4207&amp;y=7666&amp;id=playthrough_66&amp;link=/checklists/walkthrough.html%23item_66&amp;title=Go back to the Agheel Lake South Grace in South-East Limgrave and head up the slope to the South to find the Forlorn Hound Evergaol."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_67" id="item_67">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_67" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_67">Enter the Evergaol and summon Blaidd for dialogue then defeat the boss Bloodhound Knight Darriwil.</label>
-                    <a class="ms-2" href="/map.html?x=4227&amp;y=7671&amp;id=playthrough_67&amp;link=/checklists/walkthrough.html%23item_67&amp;title=Enter the Evergaol and summon Blaidd for dialogue then defeat the boss Bloodhound Knight Darriwil.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4227&amp;y=7671&amp;id=playthrough_67&amp;link=/checklists/walkthrough.html%23item_67&amp;title=Enter the Evergaol and summon Blaidd for dialogue then defeat the boss Bloodhound Knight Darriwil."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_68" id="item_68">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_68" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_68">After the fight, talk to Blaidd nearby and exhaust his dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=4207&amp;y=7666&amp;id=playthrough_68&amp;link=/checklists/walkthrough.html%23item_68&amp;title=After the fight, talk to Blaidd nearby and exhaust his dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4207&amp;y=7666&amp;id=playthrough_68&amp;link=/checklists/walkthrough.html%23item_68&amp;title=After the fight, talk to Blaidd nearby and exhaust his dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_36" id="item_36">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_36" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_36">Go back to Flying Dragon Agheel and kill him. Yura can be summoned near the Stake of Marika for extra dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=3880&amp;y=7216&amp;id=playthrough_36&amp;link=/checklists/walkthrough.html%23item_36&amp;title=Go back to Flying Dragon Agheel and kill him. Yura can be summoned near the Stake of Marika for extra dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3880&amp;y=7216&amp;id=playthrough_36&amp;link=/checklists/walkthrough.html%23item_36&amp;title=Go back to Flying Dragon Agheel and kill him. Yura can be summoned near the Stake of Marika for extra dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_37" id="item_37">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_37" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_37">Return to Yura and exhaust his dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=4013&amp;y=7470&amp;id=playthrough_37&amp;link=/checklists/walkthrough.html%23item_37&amp;title=Return to Yura and exhaust his dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4013&amp;y=7470&amp;id=playthrough_37&amp;link=/checklists/walkthrough.html%23item_37&amp;title=Return to Yura and exhaust his dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_69" id="item_69">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="0" id="playthrough_69" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_69">Limgrave is now 100% safe to explore! But be warned, if you are teleported by a chest, only grab the nearest Grace. If you grab any Grace besides the nearest one, you MAY break something. In addition, for the purposes of this guide, do not use the Bestial Sanctum Waygate yet. It's safe at this point but will change the order of steps.</label>
-                    <a class="ms-2" href="/map.html?x=4013&amp;y=7470&amp;id=playthrough_69&amp;link=/checklists/walkthrough.html%23item_69&amp;title=Limgrave is now 100% safe to explore! But be warned, if you are teleported by a chest, only grab the nearest Grace. If you grab any Grace besides the nearest one, you MAY break something. In addition, for the purposes of this guide, do not use the Bestial Sanctum Waygate yet. It's safe at this point but will change the order of steps.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4013&amp;y=7470&amp;id=playthrough_69&amp;link=/checklists/walkthrough.html%23item_69&amp;title=Limgrave is now 100% safe to explore! But be warned, if you are teleported by a chest, only grab the nearest Grace. If you grab any Grace besides the nearest one, you MAY break something. In addition, for the purposes of this guide, do not use the Bestial Sanctum Waygate yet. It's safe at this point but will change the order of steps."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -1017,9 +865,7 @@
         <div class="card shadow-sm mb-3" id="playthrough_section_1">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_1Col" data-bs-toggle="collapse" href="#playthrough_1Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_1Col" data-bs-toggle="collapse" href="#playthrough_1Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Weeping Peninsula</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="playthrough_totals_1"></span>
             </h4>
@@ -1029,135 +875,105 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="playthrough_70" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_70">Starting at the Agheel Lake South Grace in South-East Limgrave, follow the road South-East and cross the Bridge of Sacrifice to grab the Bridge of Sacrifice Grace.</label>
-                    <a class="ms-2" href="/map.html?x=4331&amp;y=7806&amp;id=playthrough_70&amp;link=/checklists/walkthrough.html%23item_70&amp;title=Starting at the Agheel Lake South Grace in South-East Limgrave, follow the road South-East and cross the Bridge of Sacrifice to grab the Bridge of Sacrifice Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4331&amp;y=7806&amp;id=playthrough_70&amp;link=/checklists/walkthrough.html%23item_70&amp;title=Starting at the Agheel Lake South Grace in South-East Limgrave, follow the road South-East and cross the Bridge of Sacrifice to grab the Bridge of Sacrifice Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_71" id="item_71">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="playthrough_71" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_71">Meet Irina next to the road nearby and exhaust her dialogue for Irina's Letter.</label>
-                    <a class="ms-2" href="/map.html?x=4378&amp;y=7843&amp;id=playthrough_71&amp;link=/checklists/walkthrough.html%23item_71&amp;title=Meet Irina next to the road nearby and exhaust her dialogue for Irina's Letter.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4378&amp;y=7843&amp;id=playthrough_71&amp;link=/checklists/walkthrough.html%23item_71&amp;title=Meet Irina next to the road nearby and exhaust her dialogue for Irina's Letter."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_72" id="item_72">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="playthrough_72" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_72">Follow the road South and grab the Castle Morne Rampart Grace.</label>
-                    <a class="ms-2" href="/map.html?x=4306&amp;y=8158&amp;id=playthrough_72&amp;link=/checklists/walkthrough.html%23item_72&amp;title=Follow the road South and grab the Castle Morne Rampart Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4306&amp;y=8158&amp;id=playthrough_72&amp;link=/checklists/walkthrough.html%23item_72&amp;title=Follow the road South and grab the Castle Morne Rampart Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_73" id="item_73">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="playthrough_73" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_73">Follow the road going North-West to grab the South of the Lookout Tower Grace</label>
-                    <a class="ms-2" href="/map.html?x=4209&amp;y=7976&amp;id=playthrough_73&amp;link=/checklists/walkthrough.html%23item_73&amp;title=Follow the road going North-West to grab the South of the Lookout Tower Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4209&amp;y=7976&amp;id=playthrough_73&amp;link=/checklists/walkthrough.html%23item_73&amp;title=Follow the road going North-West to grab the South of the Lookout Tower Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_74" id="item_74">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="playthrough_74" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_74">Cross the bridge to the West and follow the road going North to the Church of Pilgrimage and grab the Church of Pilgrimage Grace as well as a Sacred Tear in the church.</label>
-                    <a class="ms-2" href="/map.html?x=3858&amp;y=7699&amp;id=playthrough_74&amp;link=/checklists/walkthrough.html%23item_74&amp;title=Cross the bridge to the West and follow the road going North to the Church of Pilgrimage and grab the Church of Pilgrimage Grace as well as a Sacred Tear in the church.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3858&amp;y=7699&amp;id=playthrough_74&amp;link=/checklists/walkthrough.html%23item_74&amp;title=Cross the bridge to the West and follow the road going North to the Church of Pilgrimage and grab the Church of Pilgrimage Grace as well as a Sacred Tear in the church."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_75" id="item_75">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="playthrough_75" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_75">Rest at the Church of Pilgrimage Grace and talk to Melina until dialogue is exhausted.</label>
-                    <a class="ms-2" href="/map.html?x=3858&amp;y=7699&amp;id=playthrough_75&amp;link=/checklists/walkthrough.html%23item_75&amp;title=Rest at the Church of Pilgrimage Grace and talk to Melina until dialogue is exhausted.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3858&amp;y=7699&amp;id=playthrough_75&amp;link=/checklists/walkthrough.html%23item_75&amp;title=Rest at the Church of Pilgrimage Grace and talk to Melina until dialogue is exhausted."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_76" id="item_76">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="playthrough_76" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_76">Go back to the Castle Morne Rampart Grace and follow the road South to grab the Map (Weeping Peninsula) at the pillar and a Golden Seed from the Erdtree Sapling near it.</label>
-                    <a class="ms-2" href="/map.html?x=4222&amp;y=8334&amp;id=playthrough_76&amp;link=/checklists/walkthrough.html%23item_76&amp;title=Go back to the Castle Morne Rampart Grace and follow the road South to grab the Map (Weeping Peninsula) at the pillar and a Golden Seed from the Erdtree Sapling near it.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4222&amp;y=8334&amp;id=playthrough_76&amp;link=/checklists/walkthrough.html%23item_76&amp;title=Go back to the Castle Morne Rampart Grace and follow the road South to grab the Map (Weeping Peninsula) at the pillar and a Golden Seed from the Erdtree Sapling near it."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_77" id="item_77">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="playthrough_77" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_77">Continue on the road South to reach Castle Morne and grab the Castle Morne Lift Grace.</label>
-                    <a class="ms-2" href="/map.html?x=4071&amp;y=8580&amp;id=playthrough_77&amp;link=/checklists/walkthrough.html%23item_77&amp;title=Continue on the road South to reach Castle Morne and grab the Castle Morne Lift Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4071&amp;y=8580&amp;id=playthrough_77&amp;link=/checklists/walkthrough.html%23item_77&amp;title=Continue on the road South to reach Castle Morne and grab the Castle Morne Lift Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_78" id="item_78">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="playthrough_78" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_78">Go up the lift and pass the praying enemies by sneaking around on the right side. Go into the room and then out through the other side. Climb the ladder to the top then climb the next ladder in front of you. Run to the other side and hop over the edge on the left to the wall below. Run across the bridge and go over the edge to the left again. Run past the enemies to the tower and at the top of that tower you will find Edgar.</label>
-                    <a class="ms-2" href="/map.html?x=4078&amp;y=8627&amp;id=playthrough_78&amp;link=/checklists/walkthrough.html%23item_78&amp;title=Go up the lift and pass the praying enemies by sneaking around on the right side. Go into the room and then out through the other side. Climb the ladder to the top then climb the next ladder in front of you. Run to the other side and hop over the edge on the left to the wall below. Run across the bridge and go over the edge to the left again. Run past the enemies to the tower and at the top of that tower you will find Edgar.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4078&amp;y=8627&amp;id=playthrough_78&amp;link=/checklists/walkthrough.html%23item_78&amp;title=Go up the lift and pass the praying enemies by sneaking around on the right side. Go into the room and then out through the other side. Climb the ladder to the top then climb the next ladder in front of you. Run to the other side and hop over the edge on the left to the wall below. Run across the bridge and go over the edge to the left again. Run past the enemies to the tower and at the top of that tower you will find Edgar."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_79" id="item_79">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="playthrough_79" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_79">Talk to Edgar and exhaust his dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=4078&amp;y=8627&amp;id=playthrough_79&amp;link=/checklists/walkthrough.html%23item_79&amp;title=Talk to Edgar and exhaust his dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4078&amp;y=8627&amp;id=playthrough_79&amp;link=/checklists/walkthrough.html%23item_79&amp;title=Talk to Edgar and exhaust his dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_80" id="item_80">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="playthrough_80" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_80">Turn back and go past the enemies again. At the end of the path, hop the wall on your left to grab the Behind the Castle Grace.</label>
-                    <a class="ms-2" href="/map.html?x=4007&amp;y=8692&amp;id=playthrough_80&amp;link=/checklists/walkthrough.html%23item_80&amp;title=Turn back and go past the enemies again. At the end of the path, hop the wall on your left to grab the Behind the Castle Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4007&amp;y=8692&amp;id=playthrough_80&amp;link=/checklists/walkthrough.html%23item_80&amp;title=Turn back and go past the enemies again. At the end of the path, hop the wall on your left to grab the Behind the Castle Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_81" id="item_81">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="playthrough_81" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_81">Make your way down to the bottom, summon Edgar outside the boss room and then kill the boss Leonine Misbegotten to obtain the Legendary Weapon, the Grafted Greatsword.</label>
-                    <a class="ms-2" href="/map.html?x=3940&amp;y=8834&amp;id=playthrough_81&amp;link=/checklists/walkthrough.html%23item_81&amp;title=Make your way down to the bottom, summon Edgar outside the boss room and then kill the boss Leonine Misbegotten to obtain the Legendary Weapon, the Grafted Greatsword.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3940&amp;y=8834&amp;id=playthrough_81&amp;link=/checklists/walkthrough.html%23item_81&amp;title=Make your way down to the bottom, summon Edgar outside the boss room and then kill the boss Leonine Misbegotten to obtain the Legendary Weapon, the Grafted Greatsword."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_82" id="item_82">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="playthrough_82" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_82">Go back to Edgar where he was on the tower and exhaust his dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=4078&amp;y=8627&amp;id=playthrough_82&amp;link=/checklists/walkthrough.html%23item_82&amp;title=Go back to Edgar where he was on the tower and exhaust his dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4078&amp;y=8627&amp;id=playthrough_82&amp;link=/checklists/walkthrough.html%23item_82&amp;title=Go back to Edgar where he was on the tower and exhaust his dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_83" id="item_83">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="playthrough_83" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_83">Return to Irina's location near the Bridge of Sacrifice Grace, talk to Edgar and exhaust his dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=4378&amp;y=7843&amp;id=playthrough_83&amp;link=/checklists/walkthrough.html%23item_83&amp;title=Return to Irina's location near the Bridge of Sacrifice Grace, talk to Edgar and exhaust his dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4378&amp;y=7843&amp;id=playthrough_83&amp;link=/checklists/walkthrough.html%23item_83&amp;title=Return to Irina's location near the Bridge of Sacrifice Grace, talk to Edgar and exhaust his dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_84" id="item_84">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="1" id="playthrough_84" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_84">Weeping Peninsula is now 100% safe to explore! There should be no warnings required!</label>
-                    <a class="ms-2" href="/map.html?x=4378&amp;y=7843&amp;id=playthrough_84&amp;link=/checklists/walkthrough.html%23item_84&amp;title=Weeping Peninsula is now 100% safe to explore! There should be no warnings required!">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4378&amp;y=7843&amp;id=playthrough_84&amp;link=/checklists/walkthrough.html%23item_84&amp;title=Weeping Peninsula is now 100% safe to explore! There should be no warnings required!"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -1167,9 +983,7 @@
         <div class="card shadow-sm mb-3" id="playthrough_section_2">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_2Col" data-bs-toggle="collapse" href="#playthrough_2Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_2Col" data-bs-toggle="collapse" href="#playthrough_2Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Margit/Roundtable Hold</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="playthrough_totals_2"></span>
             </h4>
@@ -1179,90 +993,70 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="2" id="playthrough_86" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_86">Go back to the Castleward Tunnel Grace in West Limgrave, summon Rogier outside the boss room and kill Margit, The Fell Omen for a Talisman Pouch.</label>
-                    <a class="ms-2" href="/map.html?x=3367&amp;y=6805&amp;id=playthrough_86&amp;link=/checklists/walkthrough.html%23item_86&amp;title=Go back to the Castleward Tunnel Grace in West Limgrave, summon Rogier outside the boss room and kill Margit, The Fell Omen for a Talisman Pouch.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3367&amp;y=6805&amp;id=playthrough_86&amp;link=/checklists/walkthrough.html%23item_86&amp;title=Go back to the Castleward Tunnel Grace in West Limgrave, summon Rogier outside the boss room and kill Margit, The Fell Omen for a Talisman Pouch."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_87" id="item_87">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="2" id="playthrough_87" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_87">Grab the Margit, The Fell Omen Grace and rest at it to talk to Melina and gain access to Roundtable Hold.</label>
-                    <a class="ms-2" href="/map.html?x=3302&amp;y=6827&amp;id=playthrough_87&amp;link=/checklists/walkthrough.html%23item_87&amp;title=Grab the Margit, The Fell Omen Grace and rest at it to talk to Melina and gain access to Roundtable Hold.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3302&amp;y=6827&amp;id=playthrough_87&amp;link=/checklists/walkthrough.html%23item_87&amp;title=Grab the Margit, The Fell Omen Grace and rest at it to talk to Melina and gain access to Roundtable Hold."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_88" id="item_88">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="2" id="playthrough_88" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_88">Talk to Corhyn and exhaust his dialogue</label>
-                    <a class="ms-2" href="/map.html?x=432&amp;y=8475&amp;id=playthrough_88&amp;link=/checklists/walkthrough.html%23item_88&amp;title=Talk to Corhyn and exhaust his dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=432&amp;y=8475&amp;id=playthrough_88&amp;link=/checklists/walkthrough.html%23item_88&amp;title=Talk to Corhyn and exhaust his dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_89" id="item_89">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="2" id="playthrough_89" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_89">Talk to Gideon and exhaust his dialogue</label>
-                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_89&amp;link=/checklists/walkthrough.html%23item_89&amp;title=Talk to Gideon and exhaust his dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_89&amp;link=/checklists/walkthrough.html%23item_89&amp;title=Talk to Gideon and exhaust his dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_90" id="item_90">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="2" id="playthrough_90" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_90">Talk to D, Hunter of the Dead and exhaust his dialogue</label>
-                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_90&amp;link=/checklists/walkthrough.html%23item_90&amp;title=Talk to D, Hunter of the Dead and exhaust his dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_90&amp;link=/checklists/walkthrough.html%23item_90&amp;title=Talk to D, Hunter of the Dead and exhaust his dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_91" id="item_91">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="2" id="playthrough_91" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_91">Talk to Diallos and exhaust his dialogue</label>
-                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_91&amp;link=/checklists/walkthrough.html%23item_91&amp;title=Talk to Diallos and exhaust his dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_91&amp;link=/checklists/walkthrough.html%23item_91&amp;title=Talk to Diallos and exhaust his dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_92" id="item_92">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="2" id="playthrough_92" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_92">Talk to Hewg and exhaust his dialogue</label>
-                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_92&amp;link=/checklists/walkthrough.html%23item_92&amp;title=Talk to Hewg and exhaust his dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_92&amp;link=/checklists/walkthrough.html%23item_92&amp;title=Talk to Hewg and exhaust his dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_93" id="item_93">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="2" id="playthrough_93" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_93">Cuddle with Fia and exhaust her dialogue</label>
-                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_93&amp;link=/checklists/walkthrough.html%23item_93&amp;title=Cuddle with Fia and exhaust her dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_93&amp;link=/checklists/walkthrough.html%23item_93&amp;title=Cuddle with Fia and exhaust her dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_94" id="item_94">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="2" id="playthrough_94" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_94">Talk to Ensha and get edgelorded</label>
-                    <a class="ms-2" href="/map.html?x=502&amp;y=8332&amp;id=playthrough_94&amp;link=/checklists/walkthrough.html%23item_94&amp;title=Talk to Ensha and get edgelorded">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=502&amp;y=8332&amp;id=playthrough_94&amp;link=/checklists/walkthrough.html%23item_94&amp;title=Talk to Ensha and get edgelorded"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_95" id="item_95">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="2" id="playthrough_95" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_95">Hop off the balcony and wait for Mad Tongue Alberich to bow before attacking, then kill him.</label>
-                    <a class="ms-2" href="/map.html?x=582&amp;y=8307&amp;id=playthrough_95&amp;link=/checklists/walkthrough.html%23item_95&amp;title=Hop off the balcony and wait for Mad Tongue Alberich to bow before attacking, then kill him.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=582&amp;y=8307&amp;id=playthrough_95&amp;link=/checklists/walkthrough.html%23item_95&amp;title=Hop off the balcony and wait for Mad Tongue Alberich to bow before attacking, then kill him."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -1272,9 +1066,7 @@
         <div class="card shadow-sm mb-3" id="playthrough_section_3">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_3Col" data-bs-toggle="collapse" href="#playthrough_3Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_3Col" data-bs-toggle="collapse" href="#playthrough_3Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Stormveil</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="playthrough_totals_3"></span>
             </h4>
@@ -1284,225 +1076,175 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="playthrough_96" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_96">Return to the Margit, The Fell Omen Grace and follow the path up to grab the Stormveil Main Gate Grace</label>
-                    <a class="ms-2" href="/map.html?x=3235&amp;y=6791&amp;id=playthrough_96&amp;link=/checklists/walkthrough.html%23item_96&amp;title=Return to the Margit, The Fell Omen Grace and follow the path up to grab the Stormveil Main Gate Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3235&amp;y=6791&amp;id=playthrough_96&amp;link=/checklists/walkthrough.html%23item_96&amp;title=Return to the Margit, The Fell Omen Grace and follow the path up to grab the Stormveil Main Gate Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_97" id="item_97">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="playthrough_97" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_97">Talk to Gostoc in the building nearby and agree first, then talk to him again and reject his advice before walking over to the gate to open it.</label>
-                    <a class="ms-2" href="/map.html?x=3216&amp;y=6798&amp;id=playthrough_97&amp;link=/checklists/walkthrough.html%23item_97&amp;title=Talk to Gostoc in the building nearby and agree first, then talk to him again and reject his advice before walking over to the gate to open it.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3216&amp;y=6798&amp;id=playthrough_97&amp;link=/checklists/walkthrough.html%23item_97&amp;title=Talk to Gostoc in the building nearby and agree first, then talk to him again and reject his advice before walking over to the gate to open it."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_98" id="item_98">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="playthrough_98" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_98">Follow the path that Gostoc originally recommended and grab the Stormveil Cliffside Grace.</label>
-                    <a class="ms-2" href="/map.html?x=3130&amp;y=6827&amp;id=playthrough_98&amp;link=/checklists/walkthrough.html%23item_98&amp;title=Follow the path that Gostoc originally recommended and grab the Stormveil Cliffside Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3130&amp;y=6827&amp;id=playthrough_98&amp;link=/checklists/walkthrough.html%23item_98&amp;title=Follow the path that Gostoc originally recommended and grab the Stormveil Cliffside Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_99" id="item_99">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="playthrough_99" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_99">Go up the steps, enter the building at the top of the steps, and go through the second doorway then turn around walk back to the Stormveil Cliffside Grace but don't rest at it. You will find Gostoc on the cliff above the Grace, talk to him and exhaust his dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=3134&amp;y=6836&amp;id=playthrough_99&amp;link=/checklists/walkthrough.html%23item_99&amp;title=Go up the steps, enter the building at the top of the steps, and go through the second doorway then turn around walk back to the Stormveil Cliffside Grace but don't rest at it. You will find Gostoc on the cliff above the Grace, talk to him and exhaust his dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3134&amp;y=6836&amp;id=playthrough_99&amp;link=/checklists/walkthrough.html%23item_99&amp;title=Go up the steps, enter the building at the top of the steps, and go through the second doorway then turn around walk back to the Stormveil Cliffside Grace but don't rest at it. You will find Gostoc on the cliff above the Grace, talk to him and exhaust his dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_100" id="item_100">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="playthrough_100" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_100">Return to Gostoc next to the castle gate and his shop will now be open.</label>
-                    <a class="ms-2" href="/map.html?x=3216&amp;y=6798&amp;id=playthrough_100&amp;link=/checklists/walkthrough.html%23item_100&amp;title=Return to Gostoc next to the castle gate and his shop will now be open.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3216&amp;y=6798&amp;id=playthrough_100&amp;link=/checklists/walkthrough.html%23item_100&amp;title=Return to Gostoc next to the castle gate and his shop will now be open."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_101" id="item_101">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="playthrough_101" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_101">Proceed up the steps as before and continue on this path to grab the Rampart Tower Grace.</label>
-                    <a class="ms-2" href="/map.html?x=3070&amp;y=6697&amp;id=playthrough_101&amp;link=/checklists/walkthrough.html%23item_101&amp;title=Proceed up the steps as before and continue on this path to grab the Rampart Tower Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3070&amp;y=6697&amp;id=playthrough_101&amp;link=/checklists/walkthrough.html%23item_101&amp;title=Proceed up the steps as before and continue on this path to grab the Rampart Tower Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_102" id="item_102">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="playthrough_102" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_102">Option 1: Go through the door going North-West where all the birds are and go past them and climb down the ladder on the church rooftop.</label>
-                    <a class="ms-2" href="/map.html?x=3080&amp;y=6679&amp;id=playthrough_102&amp;link=/checklists/walkthrough.html%23item_102&amp;title=Option 1: Go through the door going North-West where all the birds are and go past them and climb down the ladder on the church rooftop.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3080&amp;y=6679&amp;id=playthrough_102&amp;link=/checklists/walkthrough.html%23item_102&amp;title=Option 1: Go through the door going North-West where all the birds are and go past them and climb down the ladder on the church rooftop."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_103" id="item_103">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="playthrough_103" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_103">Option 2: Alternatively you can turn to the right before having your first encounter. Jump over the balcony onto the rooftop across the way and hop down onto the path below.</label>
-                    <a class="ms-2" href="/map.html?x=3080&amp;y=6679&amp;id=playthrough_103&amp;link=/checklists/walkthrough.html%23item_103&amp;title=Option 2: Alternatively you can turn to the right before having your first encounter. Jump over the balcony onto the rooftop across the way and hop down onto the path below.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3080&amp;y=6679&amp;id=playthrough_103&amp;link=/checklists/walkthrough.html%23item_103&amp;title=Option 2: Alternatively you can turn to the right before having your first encounter. Jump over the balcony onto the rooftop across the way and hop down onto the path below."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_104" id="item_104">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="playthrough_104" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_104">Follow the path going North-West to the chapel, talk to Rogier and exhaust his dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=3061&amp;y=6633&amp;id=playthrough_104&amp;link=/checklists/walkthrough.html%23item_104&amp;title=Follow the path going North-West to the chapel, talk to Rogier and exhaust his dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3061&amp;y=6633&amp;id=playthrough_104&amp;link=/checklists/walkthrough.html%23item_104&amp;title=Follow the path going North-West to the chapel, talk to Rogier and exhaust his dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_105" id="item_105">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="playthrough_105" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_105">Follow the path going South-East from Rogier into the building until you hit the the room where you can see the Grafted Scion on the ground floor. Go around to the right and go through the doorway. To your left you will see the corpse of a giant hanging upside down. Hop down to the ground below the giant and grab the Chrysalids' Memento.</label>
-                    <a class="ms-2" href="/map.html?x=3118&amp;y=6698&amp;id=playthrough_105&amp;link=/checklists/walkthrough.html%23item_105&amp;title=Follow the path going South-East from Rogier into the building until you hit the the room where you can see the Grafted Scion on the ground floor. Go around to the right and go through the doorway. To your left you will see the corpse of a giant hanging upside down. Hop down to the ground below the giant and grab the Chrysalids' Memento.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3118&amp;y=6698&amp;id=playthrough_105&amp;link=/checklists/walkthrough.html%23item_105&amp;title=Follow the path going South-East from Rogier into the building until you hit the the room where you can see the Grafted Scion on the ground floor. Go around to the right and go through the doorway. To your left you will see the corpse of a giant hanging upside down. Hop down to the ground below the giant and grab the Chrysalids' Memento."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_106" id="item_106">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="playthrough_106" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_106">After grabbing the Chrysalids' Memento, go out the door, turn into the door on the left and go up the lift to unlock the shortcut to Rampart Tower Grace.</label>
-                    <a class="ms-2" href="/map.html?x=3070&amp;y=6697&amp;id=playthrough_106&amp;link=/checklists/walkthrough.html%23item_106&amp;title=After grabbing the Chrysalids' Memento, go out the door, turn into the door on the left and go up the lift to unlock the shortcut to Rampart Tower Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3070&amp;y=6697&amp;id=playthrough_106&amp;link=/checklists/walkthrough.html%23item_106&amp;title=After grabbing the Chrysalids' Memento, go out the door, turn into the door on the left and go up the lift to unlock the shortcut to Rampart Tower Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_107" id="item_107">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="playthrough_107" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_107">Return to Roderika at Stormhill Shack, give her the Chrysalids' Memento and exhaust her dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=3472&amp;y=6764&amp;id=playthrough_107&amp;link=/checklists/walkthrough.html%23item_107&amp;title=Return to Roderika at Stormhill Shack, give her the Chrysalids' Memento and exhaust her dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3472&amp;y=6764&amp;id=playthrough_107&amp;link=/checklists/walkthrough.html%23item_107&amp;title=Return to Roderika at Stormhill Shack, give her the Chrysalids' Memento and exhaust her dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_108" id="item_108">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="playthrough_108" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_108">Return to the Rampart Tower Grace and go back down the lift. Go out the door and kill or run past the Grafted Scion and through the doorway on the far left side. Go outside and turn left, following the wall going North past the enemies and then go into the doorway on your left to grab the Prophecy Painting.</label>
-                    <a class="ms-2" href="/map.html?x=3060&amp;y=6606&amp;id=playthrough_108&amp;link=/checklists/walkthrough.html%23item_108&amp;title=Return to the Rampart Tower Grace and go back down the lift. Go out the door and kill or run past the Grafted Scion and through the doorway on the far left side. Go outside and turn left, following the wall going North past the enemies and then go into the doorway on your left to grab the Prophecy Painting.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3060&amp;y=6606&amp;id=playthrough_108&amp;link=/checklists/walkthrough.html%23item_108&amp;title=Return to the Rampart Tower Grace and go back down the lift. Go out the door and kill or run past the Grafted Scion and through the doorway on the far left side. Go outside and turn left, following the wall going North past the enemies and then go into the doorway on your left to grab the Prophecy Painting."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_109" id="item_109">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="playthrough_109" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_109">Go back outside, turn left and go up the stairs to grab the Liftside Chamber Grace.</label>
-                    <a class="ms-2" href="/map.html?x=3056&amp;y=6569&amp;id=playthrough_109&amp;link=/checklists/walkthrough.html%23item_109&amp;title=Go back outside, turn left and go up the stairs to grab the Liftside Chamber Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3056&amp;y=6569&amp;id=playthrough_109&amp;link=/checklists/walkthrough.html%23item_109&amp;title=Go back outside, turn left and go up the stairs to grab the Liftside Chamber Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_110" id="item_110">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="playthrough_110" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_110">Pull the lever and go up the lift. Follow the path and grab x2 Cracked Pots next to the Living Jar enemies.</label>
-                    <a class="ms-2" href="/map.html?x=3065&amp;y=6545&amp;id=playthrough_110&amp;link=/checklists/walkthrough.html%23item_110&amp;title=Pull the lever and go up the lift. Follow the path and grab x2 Cracked Pots next to the Living Jar enemies.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3065&amp;y=6545&amp;id=playthrough_110&amp;link=/checklists/walkthrough.html%23item_110&amp;title=Pull the lever and go up the lift. Follow the path and grab x2 Cracked Pots next to the Living Jar enemies."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_111" id="item_111">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="playthrough_111" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_111">Go to the end of the path to grab the Secluded Cell Grace.</label>
-                    <a class="ms-2" href="/map.html?x=3141&amp;y=6496&amp;id=playthrough_111&amp;link=/checklists/walkthrough.html%23item_111&amp;title=Go to the end of the path to grab the Secluded Cell Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3141&amp;y=6496&amp;id=playthrough_111&amp;link=/checklists/walkthrough.html%23item_111&amp;title=Go to the end of the path to grab the Secluded Cell Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_112" id="item_112">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="playthrough_112" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_112">Head South-East from the Secluded Cell Grace and grab the Golden Seed by the Erdtree Sapling.</label>
-                    <a class="ms-2" href="/map.html?x=3175&amp;y=6585&amp;id=playthrough_112&amp;link=/checklists/walkthrough.html%23item_112&amp;title=Head South-East from the Secluded Cell Grace and grab the Golden Seed by the Erdtree Sapling.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3175&amp;y=6585&amp;id=playthrough_112&amp;link=/checklists/walkthrough.html%23item_112&amp;title=Head South-East from the Secluded Cell Grace and grab the Golden Seed by the Erdtree Sapling."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_113" id="item_113">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="playthrough_113" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_113">Enter the nearby building, talk to Nepheli Loux and exhaust her dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=3150&amp;y=6596&amp;id=playthrough_113&amp;link=/checklists/walkthrough.html%23item_113&amp;title=Enter the nearby building, talk to Nepheli Loux and exhaust her dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3150&amp;y=6596&amp;id=playthrough_113&amp;link=/checklists/walkthrough.html%23item_113&amp;title=Enter the nearby building, talk to Nepheli Loux and exhaust her dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_114" id="item_114">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="playthrough_114" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_114">Go back to the Secluded Cell Grace, summon Nepheli and then kill the boss Godrick the Grafted.</label>
-                    <a class="ms-2" href="/map.html?x=3087&amp;y=6447&amp;id=playthrough_114&amp;link=/checklists/walkthrough.html%23item_114&amp;title=Go back to the Secluded Cell Grace, summon Nepheli and then kill the boss Godrick the Grafted.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3087&amp;y=6447&amp;id=playthrough_114&amp;link=/checklists/walkthrough.html%23item_114&amp;title=Go back to the Secluded Cell Grace, summon Nepheli and then kill the boss Godrick the Grafted."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_115" id="item_115">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="playthrough_115" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_115">Grab the Godrick the Grafted Grace, talk to Gostoc nearby and exhaust his dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=3099&amp;y=6464&amp;id=playthrough_115&amp;link=/checklists/walkthrough.html%23item_115&amp;title=Grab the Godrick the Grafted Grace, talk to Gostoc nearby and exhaust his dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3099&amp;y=6464&amp;id=playthrough_115&amp;link=/checklists/walkthrough.html%23item_115&amp;title=Grab the Godrick the Grafted Grace, talk to Gostoc nearby and exhaust his dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_116" id="item_116">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="playthrough_116" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_116">Return to the Liftside Chamber Grace and go up the lift to the path heading to the Secluded Chamber Grace again. Instead of going down the slope to the Grace, take the high road and cross the wooden bridge. Hop onto the stone ledge from the wooden bridge and hug the wall going right. Finally jump off the ledge onto the nearby balcony to reach the hidden path.</label>
-                    <a class="ms-2" href="/map.html?x=3130&amp;y=6527&amp;id=playthrough_116&amp;link=/checklists/walkthrough.html%23item_116&amp;title=Return to the Liftside Chamber Grace and go up the lift to the path heading to the Secluded Chamber Grace again. Instead of going down the slope to the Grace, take the high road and cross the wooden bridge. Hop onto the stone ledge from the wooden bridge and hug the wall going right. Finally jump off the ledge onto the nearby balcony to reach the hidden path.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3130&amp;y=6527&amp;id=playthrough_116&amp;link=/checklists/walkthrough.html%23item_116&amp;title=Return to the Liftside Chamber Grace and go up the lift to the path heading to the Secluded Chamber Grace again. Instead of going down the slope to the Grace, take the high road and cross the wooden bridge. Hop onto the stone ledge from the wooden bridge and hug the wall going right. Finally jump off the ledge onto the nearby balcony to reach the hidden path."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_117" id="item_117">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="playthrough_117" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_117">Follow this hidden path until you reach a a message from Rogier that you can read. Just beyond that message is a door that unlocks the shortcut to the Liftside Chamber Grace.</label>
-                    <a class="ms-2" href="/map.html?x=3021&amp;y=6534&amp;id=playthrough_117&amp;link=/checklists/walkthrough.html%23item_117&amp;title=Follow this hidden path until you reach a a message from Rogier that you can read. Just beyond that message is a door that unlocks the shortcut to the Liftside Chamber Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3021&amp;y=6534&amp;id=playthrough_117&amp;link=/checklists/walkthrough.html%23item_117&amp;title=Follow this hidden path until you reach a a message from Rogier that you can read. Just beyond that message is a door that unlocks the shortcut to the Liftside Chamber Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_118" id="item_118">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="playthrough_118" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_118">You can now either follow that path to it's bottom(it will take a bit longer) or you can go out the South door from the Liftside Chamber Grace and turn right. Head to the ledge and drop off of it to the ledge below and make your way to the bottom from there.</label>
-                    <a class="ms-2" href="/map.html?x=3045&amp;y=6583&amp;id=playthrough_118&amp;link=/checklists/walkthrough.html%23item_118&amp;title=You can now either follow that path to it's bottom(it will take a bit longer) or you can go out the South door from the Liftside Chamber Grace and turn right. Head to the ledge and drop off of it to the ledge below and make your way to the bottom from there.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3045&amp;y=6583&amp;id=playthrough_118&amp;link=/checklists/walkthrough.html%23item_118&amp;title=You can now either follow that path to it's bottom(it will take a bit longer) or you can go out the South door from the Liftside Chamber Grace and turn right. Head to the ledge and drop off of it to the ledge below and make your way to the bottom from there."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_119" id="item_119">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="playthrough_119" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_119">At the bottom, past all the rats, will be a Lesser Ulcerated Tree Spirit. Kill it(this is required) for a Golden Seed.</label>
-                    <a class="ms-2" href="/map.html?x=3070&amp;y=6659&amp;id=playthrough_119&amp;link=/checklists/walkthrough.html%23item_119&amp;title=At the bottom, past all the rats, will be a Lesser Ulcerated Tree Spirit. Kill it(this is required) for a Golden Seed.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3070&amp;y=6659&amp;id=playthrough_119&amp;link=/checklists/walkthrough.html%23item_119&amp;title=At the bottom, past all the rats, will be a Lesser Ulcerated Tree Spirit. Kill it(this is required) for a Golden Seed."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_120" id="item_120">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="3" id="playthrough_120" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_120">Past the Lesser Ulcerated Tree Spirit is the Prince of Death's Pustule and beside that is a bloodstain of Rogier. Use it to see what happened.</label>
-                    <a class="ms-2" href="/map.html?x=3088&amp;y=6708&amp;id=playthrough_120&amp;link=/checklists/walkthrough.html%23item_120&amp;title=Past the Lesser Ulcerated Tree Spirit is the Prince of Death's Pustule and beside that is a bloodstain of Rogier. Use it to see what happened.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3088&amp;y=6708&amp;id=playthrough_120&amp;link=/checklists/walkthrough.html%23item_120&amp;title=Past the Lesser Ulcerated Tree Spirit is the Prince of Death's Pustule and beside that is a bloodstain of Rogier. Use it to see what happened."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -1512,9 +1254,7 @@
         <div class="card shadow-sm mb-3" id="playthrough_section_4">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_4Col" data-bs-toggle="collapse" href="#playthrough_4Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_4Col" data-bs-toggle="collapse" href="#playthrough_4Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Limgrave/Roundtable</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="playthrough_totals_4"></span>
             </h4>
@@ -1524,90 +1264,70 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="4" id="playthrough_121" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_121">Go to the Third Church of Marika and use the Waygate to the North to arrive at the Bestial Sanctum.</label>
-                    <a class="ms-2" href="/map.html?x=4662&amp;y=6661&amp;id=playthrough_121&amp;link=/checklists/walkthrough.html%23item_121&amp;title=Go to the Third Church of Marika and use the Waygate to the North to arrive at the Bestial Sanctum.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4662&amp;y=6661&amp;id=playthrough_121&amp;link=/checklists/walkthrough.html%23item_121&amp;title=Go to the Third Church of Marika and use the Waygate to the North to arrive at the Bestial Sanctum."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_122" id="item_122">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="4" id="playthrough_122" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_122">Head inside the sanctum and grab the Bestial Sanctum Grace.</label>
-                    <a class="ms-2" href="/map.html?x=5968&amp;y=5488&amp;id=playthrough_122&amp;link=/checklists/walkthrough.html%23item_122&amp;title=Head inside the sanctum and grab the Bestial Sanctum Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5968&amp;y=5488&amp;id=playthrough_122&amp;link=/checklists/walkthrough.html%23item_122&amp;title=Head inside the sanctum and grab the Bestial Sanctum Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_123" id="item_123">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="4" id="playthrough_123" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_123">Talk to Gurranq, Beast Clergyman and give him your first two Deathroot to receive the Clawmark Seal, Beast Eye and Bestial Sling.</label>
-                    <a class="ms-2" href="/map.html?x=5931&amp;y=5462&amp;id=playthrough_123&amp;link=/checklists/walkthrough.html%23item_123&amp;title=Talk to Gurranq, Beast Clergyman and give him your first two Deathroot to receive the Clawmark Seal, Beast Eye and Bestial Sling.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5931&amp;y=5462&amp;id=playthrough_123&amp;link=/checklists/walkthrough.html%23item_123&amp;title=Talk to Gurranq, Beast Clergyman and give him your first two Deathroot to receive the Clawmark Seal, Beast Eye and Bestial Sling."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_124" id="item_124">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="4" id="playthrough_124" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_124">Go back to Varré at the First Step Grace and exhaust his dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=3701&amp;y=7341&amp;id=playthrough_124&amp;link=/checklists/walkthrough.html%23item_124&amp;title=Go back to Varré at the First Step Grace and exhaust his dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3701&amp;y=7341&amp;id=playthrough_124&amp;link=/checklists/walkthrough.html%23item_124&amp;title=Go back to Varré at the First Step Grace and exhaust his dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_125" id="item_125">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="4" id="playthrough_125" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_125">Return to Roundtable Hold, talk to Enia and Two Fingers until the dialogue of both is exhausted.</label>
-                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_125&amp;link=/checklists/walkthrough.html%23item_125&amp;title=Return to Roundtable Hold, talk to Enia and Two Fingers until the dialogue of both is exhausted.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_125&amp;link=/checklists/walkthrough.html%23item_125&amp;title=Return to Roundtable Hold, talk to Enia and Two Fingers until the dialogue of both is exhausted."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_126" id="item_126">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="4" id="playthrough_126" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_126">Talk to Nepheli and Gideon until the dialogue of both is exhausted.</label>
-                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_126&amp;link=/checklists/walkthrough.html%23item_126&amp;title=Talk to Nepheli and Gideon until the dialogue of both is exhausted.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_126&amp;link=/checklists/walkthrough.html%23item_126&amp;title=Talk to Nepheli and Gideon until the dialogue of both is exhausted."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_127" id="item_127">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="4" id="playthrough_127" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_127">Talk to D, Hunter of the Dead and Rogier until the dialogue of both is exhausted.</label>
-                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_127&amp;link=/checklists/walkthrough.html%23item_127&amp;title=Talk to D, Hunter of the Dead and Rogier until the dialogue of both is exhausted.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_127&amp;link=/checklists/walkthrough.html%23item_127&amp;title=Talk to D, Hunter of the Dead and Rogier until the dialogue of both is exhausted."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_128" id="item_128">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="4" id="playthrough_128" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_128">Talk to Roderika and Hewg until the dialogue of both is exhausted</label>
-                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_128&amp;link=/checklists/walkthrough.html%23item_128&amp;title=Talk to Roderika and Hewg until the dialogue of both is exhausted">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_128&amp;link=/checklists/walkthrough.html%23item_128&amp;title=Talk to Roderika and Hewg until the dialogue of both is exhausted"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_129" id="item_129">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="4" id="playthrough_129" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_129">Cuddle with Fia and exhaust her dialogue for the Knifeprint Clue.</label>
-                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_129&amp;link=/checklists/walkthrough.html%23item_129&amp;title=Cuddle with Fia and exhaust her dialogue for the Knifeprint Clue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_129&amp;link=/checklists/walkthrough.html%23item_129&amp;title=Cuddle with Fia and exhaust her dialogue for the Knifeprint Clue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_130" id="item_130">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="4" id="playthrough_130" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_130">Return to Varré's Location at the First Step Grace and read his message.</label>
-                    <a class="ms-2" href="/map.html?x=3701&amp;y=7341&amp;id=playthrough_130&amp;link=/checklists/walkthrough.html%23item_130&amp;title=Return to Varré's Location at the First Step Grace and read his message.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3701&amp;y=7341&amp;id=playthrough_130&amp;link=/checklists/walkthrough.html%23item_130&amp;title=Return to Varré's Location at the First Step Grace and read his message."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -1617,9 +1337,7 @@
         <div class="card shadow-sm mb-3" id="playthrough_section_5">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_5Col" data-bs-toggle="collapse" href="#playthrough_5Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_5Col" data-bs-toggle="collapse" href="#playthrough_5Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Liurnia Lake Part One</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="playthrough_totals_5"></span>
             </h4>
@@ -1629,477 +1347,371 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="playthrough_131" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_131">Go to the Godrick the Grafted Grace, go through the throne room and grab the Shabriri Grape underneath it</label>
-                    <a class="ms-2" href="/map.html?x=3032&amp;y=6386&amp;id=playthrough_131&amp;link=/checklists/walkthrough.html%23item_131&amp;title=Go to the Godrick the Grafted Grace, go through the throne room and grab the Shabriri Grape underneath it">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3032&amp;y=6386&amp;id=playthrough_131&amp;link=/checklists/walkthrough.html%23item_131&amp;title=Go to the Godrick the Grafted Grace, go through the throne room and grab the Shabriri Grape underneath it"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_132" id="item_132">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="playthrough_132" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_132">Grab the Lake-Facing Cliffs Grace nearby</label>
-                    <a class="ms-2" href="/map.html?x=2959&amp;y=6344&amp;id=playthrough_132&amp;link=/checklists/walkthrough.html%23item_132&amp;title=Grab the Lake-Facing Cliffs Grace nearby">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2959&amp;y=6344&amp;id=playthrough_132&amp;link=/checklists/walkthrough.html%23item_132&amp;title=Grab the Lake-Facing Cliffs Grace nearby"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_133" id="item_133">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="playthrough_133" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_133">Give the Shabriri Grape to Hyetta who is near the Grace(may require resting) and exhaust her dialogue</label>
-                    <a class="ms-2" href="/map.html?x=2951&amp;y=6331&amp;id=playthrough_133&amp;link=/checklists/walkthrough.html%23item_133&amp;title=Give the Shabriri Grape to Hyetta who is near the Grace(may require resting) and exhaust her dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2951&amp;y=6331&amp;id=playthrough_133&amp;link=/checklists/walkthrough.html%23item_133&amp;title=Give the Shabriri Grape to Hyetta who is near the Grace(may require resting) and exhaust her dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_134" id="item_134">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="playthrough_134" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_134">Talk to Boc and exhaust his dialogue</label>
-                    <a class="ms-2" href="/map.html?x=2950&amp;y=6347&amp;id=playthrough_134&amp;link=/checklists/walkthrough.html%23item_134&amp;title=Talk to Boc and exhaust his dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2950&amp;y=6347&amp;id=playthrough_134&amp;link=/checklists/walkthrough.html%23item_134&amp;title=Talk to Boc and exhaust his dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_135" id="item_135">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="playthrough_135" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_135">Go into the Church of Irith and grab the Sacred Tear</label>
-                    <a class="ms-2" href="/map.html?x=2916&amp;y=6433&amp;id=playthrough_135&amp;link=/checklists/walkthrough.html%23item_135&amp;title=Go into the Church of Irith and grab the Sacred Tear">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2916&amp;y=6433&amp;id=playthrough_135&amp;link=/checklists/walkthrough.html%23item_135&amp;title=Go into the Church of Irith and grab the Sacred Tear"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_136" id="item_136">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="playthrough_136" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_136">Talk to Thops in the Church of Irith and exhaust his dialogue</label>
-                    <a class="ms-2" href="/map.html?x=2909&amp;y=6432&amp;id=playthrough_136&amp;link=/checklists/walkthrough.html%23item_136&amp;title=Talk to Thops in the Church of Irith and exhaust his dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2909&amp;y=6432&amp;id=playthrough_136&amp;link=/checklists/walkthrough.html%23item_136&amp;title=Talk to Thops in the Church of Irith and exhaust his dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_137" id="item_137">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="playthrough_137" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_137">Head North-West, down the slope, to the shore and grab the Liurnia Lake Shore Grace(I recommend purchasing a Lantern from the merchant nearby if you don't already have one)</label>
-                    <a class="ms-2" href="/map.html?x=2730&amp;y=6158&amp;id=playthrough_137&amp;link=/checklists/walkthrough.html%23item_137&amp;title=Head North-West, down the slope, to the shore and grab the Liurnia Lake Shore Grace(I recommend purchasing a Lantern from the merchant nearby if you don't already have one)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2730&amp;y=6158&amp;id=playthrough_137&amp;link=/checklists/walkthrough.html%23item_137&amp;title=Head North-West, down the slope, to the shore and grab the Liurnia Lake Shore Grace(I recommend purchasing a Lantern from the merchant nearby if you don't already have one)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_138" id="item_138">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="playthrough_138" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_138">Go North from the shore and grab Map (Liurnia, East)</label>
-                    <a class="ms-2" href="/map.html?x=2699&amp;y=6026&amp;id=playthrough_138&amp;link=/checklists/walkthrough.html%23item_138&amp;title=Go North from the shore and grab Map (Liurnia, East)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2699&amp;y=6026&amp;id=playthrough_138&amp;link=/checklists/walkthrough.html%23item_138&amp;title=Go North from the shore and grab Map (Liurnia, East)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_139" id="item_139">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="playthrough_139" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_139">Continue North to the shore, talk to Hyetta at the Purified Ruins and exhaust her dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=2768&amp;y=5921&amp;id=playthrough_139&amp;link=/checklists/walkthrough.html%23item_139&amp;title=Continue North to the shore, talk to Hyetta at the Purified Ruins and exhaust her dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2768&amp;y=5921&amp;id=playthrough_139&amp;link=/checklists/walkthrough.html%23item_139&amp;title=Continue North to the shore, talk to Hyetta at the Purified Ruins and exhaust her dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_140" id="item_140">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="playthrough_140" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_140">Go East, into the Purified Ruins, and find the hidden stairs underneath some wood boards. Go down the stairs and grab the Shabriri Grape</label>
-                    <a class="ms-2" href="/map.html?x=2870&amp;y=5925&amp;id=playthrough_140&amp;link=/checklists/walkthrough.html%23item_140&amp;title=Go East, into the Purified Ruins, and find the hidden stairs underneath some wood boards. Go down the stairs and grab the Shabriri Grape">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2870&amp;y=5925&amp;id=playthrough_140&amp;link=/checklists/walkthrough.html%23item_140&amp;title=Go East, into the Purified Ruins, and find the hidden stairs underneath some wood boards. Go down the stairs and grab the Shabriri Grape"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_141" id="item_141">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="playthrough_141" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_141">Return to Hyetta, give her the Shabriri Grape and exhaust her dialogue</label>
-                    <a class="ms-2" href="/map.html?x=2768&amp;y=5921&amp;id=playthrough_141&amp;link=/checklists/walkthrough.html%23item_141&amp;title=Return to Hyetta, give her the Shabriri Grape and exhaust her dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2768&amp;y=5921&amp;id=playthrough_141&amp;link=/checklists/walkthrough.html%23item_141&amp;title=Return to Hyetta, give her the Shabriri Grape and exhaust her dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_142" id="item_142">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="playthrough_142" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_142">Head up the slope North-East and grab the Liurnia Highway North Grace for later.</label>
-                    <a class="ms-2" href="/map.html?x=2938&amp;y=5800&amp;id=playthrough_142&amp;link=/checklists/walkthrough.html%23item_142&amp;title=Head up the slope North-East and grab the Liurnia Highway North Grace for later.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2938&amp;y=5800&amp;id=playthrough_142&amp;link=/checklists/walkthrough.html%23item_142&amp;title=Head up the slope North-East and grab the Liurnia Highway North Grace for later."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_143" id="item_143">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="playthrough_143" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_143">Go back down the slope but enter a nearby ruin and use the Waygate inside to grab the South Raya Lucaria Gate Grace and the Meeting Place Map</label>
-                    <a class="ms-2" href="/map.html?x=2836&amp;y=5826&amp;id=playthrough_143&amp;link=/checklists/walkthrough.html%23item_143&amp;title=Go back down the slope but enter a nearby ruin and use the Waygate inside to grab the South Raya Lucaria Gate Grace and the Meeting Place Map">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2836&amp;y=5826&amp;id=playthrough_143&amp;link=/checklists/walkthrough.html%23item_143&amp;title=Go back down the slope but enter a nearby ruin and use the Waygate inside to grab the South Raya Lucaria Gate Grace and the Meeting Place Map"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_144" id="item_144">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="playthrough_144" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_144">Go back to the Liurnia Highway North Grace then go back South-West to the shore. Head to the island to the West, just West of the telescope and grab the Scenic Isle Grace.</label>
-                    <a class="ms-2" href="/map.html?x=2332&amp;y=5734&amp;id=playthrough_144&amp;link=/checklists/walkthrough.html%23item_144&amp;title=Go back to the Liurnia Highway North Grace then go back South-West to the shore. Head to the island to the West, just West of the telescope and grab the Scenic Isle Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2332&amp;y=5734&amp;id=playthrough_144&amp;link=/checklists/walkthrough.html%23item_144&amp;title=Go back to the Liurnia Highway North Grace then go back South-West to the shore. Head to the island to the West, just West of the telescope and grab the Scenic Isle Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_145" id="item_145">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="playthrough_145" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_145">Talk to Patches at the Scenic Isle Grace and exhaust his dialogue</label>
-                    <a class="ms-2" href="/map.html?x=2339&amp;y=5730&amp;id=playthrough_145&amp;link=/checklists/walkthrough.html%23item_145&amp;title=Talk to Patches at the Scenic Isle Grace and exhaust his dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2339&amp;y=5730&amp;id=playthrough_145&amp;link=/checklists/walkthrough.html%23item_145&amp;title=Talk to Patches at the Scenic Isle Grace and exhaust his dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_146" id="item_146">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="playthrough_146" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_146">Go East to the pavillion near the telescope, talk to Rya and exhaust her dialogue</label>
-                    <a class="ms-2" href="/map.html?x=2481&amp;y=5720&amp;id=playthrough_146&amp;link=/checklists/walkthrough.html%23item_146&amp;title=Go East to the pavillion near the telescope, talk to Rya and exhaust her dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2481&amp;y=5720&amp;id=playthrough_146&amp;link=/checklists/walkthrough.html%23item_146&amp;title=Go East to the pavillion near the telescope, talk to Rya and exhaust her dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_148" id="item_148">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="playthrough_148" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_148">Go North-West to find the Boilprawn Shack and grab the Boilprawn Shack Grace</label>
-                    <a class="ms-2" href="/map.html?x=2256&amp;y=5562&amp;id=playthrough_148&amp;link=/checklists/walkthrough.html%23item_148&amp;title=Go North-West to find the Boilprawn Shack and grab the Boilprawn Shack Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2256&amp;y=5562&amp;id=playthrough_148&amp;link=/checklists/walkthrough.html%23item_148&amp;title=Go North-West to find the Boilprawn Shack and grab the Boilprawn Shack Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_149" id="item_149">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="playthrough_149" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_149">Talk to Blackguard Big Boggart at Boilprawn Shack and buy necklace</label>
-                    <a class="ms-2" href="/map.html?x=2256&amp;y=5562&amp;id=playthrough_149&amp;link=/checklists/walkthrough.html%23item_149&amp;title=Talk to Blackguard Big Boggart at Boilprawn Shack and buy necklace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2256&amp;y=5562&amp;id=playthrough_149&amp;link=/checklists/walkthrough.html%23item_149&amp;title=Talk to Blackguard Big Boggart at Boilprawn Shack and buy necklace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_150" id="item_150">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="playthrough_150" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_150">Talk to Blackguard Big Boggart again, buy some Boiled Prawn and exhaust his dialogue</label>
-                    <a class="ms-2" href="/map.html?x=2256&amp;y=5562&amp;id=playthrough_150&amp;link=/checklists/walkthrough.html%23item_150&amp;title=Talk to Blackguard Big Boggart again, buy some Boiled Prawn and exhaust his dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2256&amp;y=5562&amp;id=playthrough_150&amp;link=/checklists/walkthrough.html%23item_150&amp;title=Talk to Blackguard Big Boggart again, buy some Boiled Prawn and exhaust his dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_151" id="item_151">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="playthrough_151" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_151">Return to Rya to give her the necklace and exhaust her dialogue</label>
-                    <a class="ms-2" href="/map.html?x=2481&amp;y=5720&amp;id=playthrough_151&amp;link=/checklists/walkthrough.html%23item_151&amp;title=Return to Rya to give her the necklace and exhaust her dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2481&amp;y=5720&amp;id=playthrough_151&amp;link=/checklists/walkthrough.html%23item_151&amp;title=Return to Rya to give her the necklace and exhaust her dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_152" id="item_152">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="playthrough_152" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_152">Go North to the Academy Gate Town and grab the Academy Gate Town Grace and Map (Liurnia, North)</label>
-                    <a class="ms-2" href="/map.html?x=2401&amp;y=5349&amp;id=playthrough_152&amp;link=/checklists/walkthrough.html%23item_152&amp;title=Go North to the Academy Gate Town and grab the Academy Gate Town Grace and Map (Liurnia, North)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2401&amp;y=5349&amp;id=playthrough_152&amp;link=/checklists/walkthrough.html%23item_152&amp;title=Go North to the Academy Gate Town and grab the Academy Gate Town Grace and Map (Liurnia, North)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_153" id="item_153">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="playthrough_153" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_153">Go North/North-West of the Grace, talk to Diallos and exhaust his dialogue</label>
-                    <a class="ms-2" href="/map.html?x=2368&amp;y=5194&amp;id=playthrough_153&amp;link=/checklists/walkthrough.html%23item_153&amp;title=Go North/North-West of the Grace, talk to Diallos and exhaust his dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2368&amp;y=5194&amp;id=playthrough_153&amp;link=/checklists/walkthrough.html%23item_153&amp;title=Go North/North-West of the Grace, talk to Diallos and exhaust his dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_155" id="item_155">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="playthrough_155" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_155">Go South-West and grab the Fallen Ruins of the Lake Grace</label>
-                    <a class="ms-2" href="/map.html?x=2057&amp;y=5367&amp;id=playthrough_155&amp;link=/checklists/walkthrough.html%23item_155&amp;title=Go South-West and grab the Fallen Ruins of the Lake Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2057&amp;y=5367&amp;id=playthrough_155&amp;link=/checklists/walkthrough.html%23item_155&amp;title=Go South-West and grab the Fallen Ruins of the Lake Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_156" id="item_156">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="playthrough_156" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_156">Head West to the Rose Church, talk to Varre and exhaust his dialogue</label>
-                    <a class="ms-2" href="/map.html?x=1829&amp;y=5363&amp;id=playthrough_156&amp;link=/checklists/walkthrough.html%23item_156&amp;title=Head West to the Rose Church, talk to Varre and exhaust his dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1829&amp;y=5363&amp;id=playthrough_156&amp;link=/checklists/walkthrough.html%23item_156&amp;title=Head West to the Rose Church, talk to Varre and exhaust his dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_157" id="item_157">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="playthrough_157" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_157">Invade other players 3 times(you can invade then leave immediately)</label>
-                    <a class="ms-2" href="/map.html?x=1829&amp;y=5363&amp;id=playthrough_157&amp;link=/checklists/walkthrough.html%23item_157&amp;title=Invade other players 3 times(you can invade then leave immediately)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1829&amp;y=5363&amp;id=playthrough_157&amp;link=/checklists/walkthrough.html%23item_157&amp;title=Invade other players 3 times(you can invade then leave immediately)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_158" id="item_158">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="playthrough_158" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_158">Talk to Varre again and exhaust his dialogue</label>
-                    <a class="ms-2" href="/map.html?x=1829&amp;y=5363&amp;id=playthrough_158&amp;link=/checklists/walkthrough.html%23item_158&amp;title=Talk to Varre again and exhaust his dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1829&amp;y=5363&amp;id=playthrough_158&amp;link=/checklists/walkthrough.html%23item_158&amp;title=Talk to Varre again and exhaust his dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_159" id="item_159">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="playthrough_159" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_159">Go North-West and grab the Temple Quarter Grace</label>
-                    <a class="ms-2" href="/map.html?x=1620&amp;y=5124&amp;id=playthrough_159&amp;link=/checklists/walkthrough.html%23item_159&amp;title=Go North-West and grab the Temple Quarter Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1620&amp;y=5124&amp;id=playthrough_159&amp;link=/checklists/walkthrough.html%23item_159&amp;title=Go North-West and grab the Temple Quarter Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_160" id="item_160">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="playthrough_160" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_160">Head North from the Grace, kill or run past the Glintstone Dragon and grab the Glintstone Key</label>
-                    <a class="ms-2" href="/map.html?x=1620&amp;y=4953&amp;id=playthrough_160&amp;link=/checklists/walkthrough.html%23item_160&amp;title=Head North from the Grace, kill or run past the Glintstone Dragon and grab the Glintstone Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1620&amp;y=4953&amp;id=playthrough_160&amp;link=/checklists/walkthrough.html%23item_160&amp;title=Head North from the Grace, kill or run past the Glintstone Dragon and grab the Glintstone Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_161" id="item_161">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="playthrough_161" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_161">Turn around and head South-West to the shore to find a ghost then follow the trail of bodies up to the Revenger's Shack.</label>
-                    <a class="ms-2" href="/map.html?x=1430&amp;y=5208&amp;id=playthrough_161&amp;link=/checklists/walkthrough.html%23item_161&amp;title=Turn around and head South-West to the shore to find a ghost then follow the trail of bodies up to the Revenger's Shack.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1430&amp;y=5208&amp;id=playthrough_161&amp;link=/checklists/walkthrough.html%23item_161&amp;title=Turn around and head South-West to the shore to find a ghost then follow the trail of bodies up to the Revenger's Shack."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_162" id="item_162">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="playthrough_162" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_162">Kill Edgar the Revenger at Revenger's Shack to receive a Shabriri Grape and grab the Revenger's Shack Grace.</label>
-                    <a class="ms-2" href="/map.html?x=1430&amp;y=5208&amp;id=playthrough_162&amp;link=/checklists/walkthrough.html%23item_162&amp;title=Kill Edgar the Revenger at Revenger's Shack to receive a Shabriri Grape and grab the Revenger's Shack Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1430&amp;y=5208&amp;id=playthrough_162&amp;link=/checklists/walkthrough.html%23item_162&amp;title=Kill Edgar the Revenger at Revenger's Shack to receive a Shabriri Grape and grab the Revenger's Shack Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_162_1" id="item_162_1">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="playthrough_162_1" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_162_1">Follow the road North from the Revenger's Shack and grab the Foot of the Four Belfries Grace</label>
-                    <a class="ms-2" href="/map.html?x=1347&amp;y=4800&amp;id=playthrough_162_1&amp;link=/checklists/walkthrough.html%23item_162_1&amp;title=Follow the road North from the Revenger's Shack and grab the Foot of the Four Belfries Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1347&amp;y=4800&amp;id=playthrough_162_1&amp;link=/checklists/walkthrough.html%23item_162_1&amp;title=Follow the road North from the Revenger's Shack and grab the Foot of the Four Belfries Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_163" id="item_163">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="playthrough_163" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_163">Follow the road East to the top and grab the Imbued Sword Key and The Four Belfries Grace</label>
-                    <a class="ms-2" href="/map.html?x=1469&amp;y=4582&amp;id=playthrough_163&amp;link=/checklists/walkthrough.html%23item_163&amp;title=Follow the road East to the top and grab the Imbued Sword Key and The Four Belfries Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1469&amp;y=4582&amp;id=playthrough_163&amp;link=/checklists/walkthrough.html%23item_163&amp;title=Follow the road East to the top and grab the Imbued Sword Key and The Four Belfries Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_164" id="item_164">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="playthrough_164" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_164">Go East to the nearby Waygate with the message that says Anticipation, use the key to unlock it and enter it</label>
-                    <a class="ms-2" href="/map.html?x=1548&amp;y=4566&amp;id=playthrough_164&amp;link=/checklists/walkthrough.html%23item_164&amp;title=Go East to the nearby Waygate with the message that says Anticipation, use the key to unlock it and enter it">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1548&amp;y=4566&amp;id=playthrough_164&amp;link=/checklists/walkthrough.html%23item_164&amp;title=Go East to the nearby Waygate with the message that says Anticipation, use the key to unlock it and enter it"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_165" id="item_165">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="playthrough_165" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_165">Kill the Boss of the Chapel of Anticipation, Grafted Scion</label>
-                    <a class="ms-2" href="/map.html?x=2776&amp;y=6652&amp;id=playthrough_165&amp;link=/checklists/walkthrough.html%23item_165&amp;title=Kill the Boss of the Chapel of Anticipation, Grafted Scion">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2776&amp;y=6652&amp;id=playthrough_165&amp;link=/checklists/walkthrough.html%23item_165&amp;title=Kill the Boss of the Chapel of Anticipation, Grafted Scion"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_166" id="item_166">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="playthrough_166" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_166">Go through the area to the chapel where you started at and go through the nearby opened door to grab The Stormhawk King ashes</label>
-                    <a class="ms-2" href="/map.html?x=2774&amp;y=6773&amp;id=playthrough_166&amp;link=/checklists/walkthrough.html%23item_166&amp;title=Go through the area to the chapel where you started at and go through the nearby opened door to grab The Stormhawk King ashes">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2774&amp;y=6773&amp;id=playthrough_166&amp;link=/checklists/walkthrough.html%23item_166&amp;title=Go through the area to the chapel where you started at and go through the nearby opened door to grab The Stormhawk King ashes"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_166_1" id="item_166_1">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="playthrough_166_1" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_166_1">Go inside of the church and interract with the dead maiden to dye the cloth Varre gave you to get the Lord of Blood's Favor</label>
-                    <a class="ms-2" href="/map.html?x=2794&amp;y=6793&amp;id=playthrough_166_1&amp;link=/checklists/walkthrough.html%23item_166_1&amp;title=Go inside of the church and interract with the dead maiden to dye the cloth Varre gave you to get the Lord of Blood's Favor">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2794&amp;y=6793&amp;id=playthrough_166_1&amp;link=/checklists/walkthrough.html%23item_166_1&amp;title=Go inside of the church and interract with the dead maiden to dye the cloth Varre gave you to get the Lord of Blood's Favor"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_166_2" id="item_166_2">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="playthrough_166_2" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_166_2">Return to the Fallen Ruins of the Lake Grace and head back to Varre at the Rose Church. Talk with him and exhaust his dialogue to receive the Pureblood Knight's Medal(this can be used to enter Mohgwyn's Palace early for Rune Farming. Just don't kill the boss and nothing should break. This area will be covered later)</label>
-                    <a class="ms-2" href="/map.html?x=1849&amp;y=5341&amp;id=playthrough_166_2&amp;link=/checklists/walkthrough.html%23item_166_2&amp;title=Return to the Fallen Ruins of the Lake Grace and head back to Varre at the Rose Church. Talk with him and exhaust his dialogue to receive the Pureblood Knight's Medal(this can be used to enter Mohgwyn's Palace early for Rune Farming. Just don't kill the boss and nothing should break. This area will be covered later)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1849&amp;y=5341&amp;id=playthrough_166_2&amp;link=/checklists/walkthrough.html%23item_166_2&amp;title=Return to the Fallen Ruins of the Lake Grace and head back to Varre at the Rose Church. Talk with him and exhaust his dialogue to receive the Pureblood Knight's Medal(this can be used to enter Mohgwyn's Palace early for Rune Farming. Just don't kill the boss and nothing should break. This area will be covered later)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_167" id="item_167">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="playthrough_167" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_167">Go back to the Fallen Ruins of the Lake and head South-West to grab the Folly on the Lake Grace</label>
-                    <a class="ms-2" href="/map.html?x=1947&amp;y=5619&amp;id=playthrough_167&amp;link=/checklists/walkthrough.html%23item_167&amp;title=Go back to the Fallen Ruins of the Lake and head South-West to grab the Folly on the Lake Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1947&amp;y=5619&amp;id=playthrough_167&amp;link=/checklists/walkthrough.html%23item_167&amp;title=Go back to the Fallen Ruins of the Lake and head South-West to grab the Folly on the Lake Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_169" id="item_169">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="playthrough_169" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_169">Head South-West, underneath the cliffs and follow the path to talk to Nepheli and exhaust her dialogue</label>
-                    <a class="ms-2" href="/map.html?x=1746&amp;y=5840&amp;id=playthrough_169&amp;link=/checklists/walkthrough.html%23item_169&amp;title=Head South-West, underneath the cliffs and follow the path to talk to Nepheli and exhaust her dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1746&amp;y=5840&amp;id=playthrough_169&amp;link=/checklists/walkthrough.html%23item_169&amp;title=Head South-West, underneath the cliffs and follow the path to talk to Nepheli and exhaust her dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_168" id="item_168">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="playthrough_168" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_168">Continue up the path to grab the Village of the Albinaurics Grace and rest at it</label>
-                    <a class="ms-2" href="/map.html?x=1711&amp;y=5861&amp;id=playthrough_168&amp;link=/checklists/walkthrough.html%23item_168&amp;title=Continue up the path to grab the Village of the Albinaurics Grace and rest at it">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1711&amp;y=5861&amp;id=playthrough_168&amp;link=/checklists/walkthrough.html%23item_168&amp;title=Continue up the path to grab the Village of the Albinaurics Grace and rest at it"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_170" id="item_170">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="playthrough_170" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_170">Proceed through the village to find a giant pot that looks out of place and is making noises, attack or roll into it to reveal Albus.</label>
-                    <a class="ms-2" href="/map.html?x=1752&amp;y=5862&amp;id=playthrough_170&amp;link=/checklists/walkthrough.html%23item_170&amp;title=Proceed through the village to find a giant pot that looks out of place and is making noises, attack or roll into it to reveal Albus.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1752&amp;y=5862&amp;id=playthrough_170&amp;link=/checklists/walkthrough.html%23item_170&amp;title=Proceed through the village to find a giant pot that looks out of place and is making noises, attack or roll into it to reveal Albus."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_171" id="item_171">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="playthrough_171" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_171">Talk to Albus and exhaust his dialogue</label>
-                    <a class="ms-2" href="/map.html?x=1752&amp;y=5862&amp;id=playthrough_171&amp;link=/checklists/walkthrough.html%23item_171&amp;title=Talk to Albus and exhaust his dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1752&amp;y=5862&amp;id=playthrough_171&amp;link=/checklists/walkthrough.html%23item_171&amp;title=Talk to Albus and exhaust his dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_172" id="item_172">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="playthrough_172" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_172">Summon Nepheli and kill the Boss of Village of the Albinaurics, Omenkiller</label>
-                    <a class="ms-2" href="/map.html?x=1763&amp;y=5835&amp;id=playthrough_172&amp;link=/checklists/walkthrough.html%23item_172&amp;title=Summon Nepheli and kill the Boss of Village of the Albinaurics, Omenkiller">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1763&amp;y=5835&amp;id=playthrough_172&amp;link=/checklists/walkthrough.html%23item_172&amp;title=Summon Nepheli and kill the Boss of Village of the Albinaurics, Omenkiller"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_173" id="item_173">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="playthrough_173" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_173">Starting from the Scenic Isle Grace, head South to grab the Lakeside Crystal Cave Grace</label>
-                    <a class="ms-2" href="/map.html?x=2318&amp;y=6018&amp;id=playthrough_173&amp;link=/checklists/walkthrough.html%23item_173&amp;title=Starting from the Scenic Isle Grace, head South to grab the Lakeside Crystal Cave Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2318&amp;y=6018&amp;id=playthrough_173&amp;link=/checklists/walkthrough.html%23item_173&amp;title=Starting from the Scenic Isle Grace, head South to grab the Lakeside Crystal Cave Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_174" id="item_174">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="playthrough_174" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_174">Kill the Boss of Lakeside Crystal Cave, Bloodhound Knight</label>
-                    <a class="ms-2" href="/map.html?x=2307&amp;y=6007&amp;id=playthrough_174&amp;link=/checklists/walkthrough.html%23item_174&amp;title=Kill the Boss of Lakeside Crystal Cave, Bloodhound Knight">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2307&amp;y=6007&amp;id=playthrough_174&amp;link=/checklists/walkthrough.html%23item_174&amp;title=Kill the Boss of Lakeside Crystal Cave, Bloodhound Knight"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_175" id="item_175">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="playthrough_175" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_175">Go through the back exit of the cave and grab the Slumbering Wolf's Shack Grace</label>
-                    <a class="ms-2" href="/map.html?x=2315&amp;y=6076&amp;id=playthrough_175&amp;link=/checklists/walkthrough.html%23item_175&amp;title=Go through the back exit of the cave and grab the Slumbering Wolf's Shack Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2315&amp;y=6076&amp;id=playthrough_175&amp;link=/checklists/walkthrough.html%23item_175&amp;title=Go through the back exit of the cave and grab the Slumbering Wolf's Shack Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_176" id="item_176">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="playthrough_176" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_176">Talk to Latenna and exhaust her dialogue</label>
-                    <a class="ms-2" href="/map.html?x=2315&amp;y=6076&amp;id=playthrough_176&amp;link=/checklists/walkthrough.html%23item_176&amp;title=Talk to Latenna and exhaust her dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2315&amp;y=6076&amp;id=playthrough_176&amp;link=/checklists/walkthrough.html%23item_176&amp;title=Talk to Latenna and exhaust her dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_177" id="item_177">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="playthrough_177" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_177">Starting from the Liurnia Highway North Grace, follow the road North to the Gate Town Bridge Grace</label>
-                    <a class="ms-2" href="/map.html?x=2740&amp;y=5480&amp;id=playthrough_177&amp;link=/checklists/walkthrough.html%23item_177&amp;title=Starting from the Liurnia Highway North Grace, follow the road North to the Gate Town Bridge Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2740&amp;y=5480&amp;id=playthrough_177&amp;link=/checklists/walkthrough.html%23item_177&amp;title=Starting from the Liurnia Highway North Grace, follow the road North to the Gate Town Bridge Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_178" id="item_178">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="playthrough_178" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_178">Talk to Hyetta, give her the Shabriri Grape and exhaust her dialogue</label>
-                    <a class="ms-2" href="/map.html?x=2767&amp;y=5462&amp;id=playthrough_178&amp;link=/checklists/walkthrough.html%23item_178&amp;title=Talk to Hyetta, give her the Shabriri Grape and exhaust her dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2767&amp;y=5462&amp;id=playthrough_178&amp;link=/checklists/walkthrough.html%23item_178&amp;title=Talk to Hyetta, give her the Shabriri Grape and exhaust her dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_179" id="item_179">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="playthrough_179" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_179">Rest at the Grace, talk to Hyetta again and exhaust her dialogue</label>
-                    <a class="ms-2" href="/map.html?x=2767&amp;y=5462&amp;id=playthrough_179&amp;link=/checklists/walkthrough.html%23item_179&amp;title=Rest at the Grace, talk to Hyetta again and exhaust her dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2767&amp;y=5462&amp;id=playthrough_179&amp;link=/checklists/walkthrough.html%23item_179&amp;title=Rest at the Grace, talk to Hyetta again and exhaust her dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_180" id="item_180">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="playthrough_180" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_180">Head East and use the Spiritjump to reach the top of the cliffs then summon D, Hunter of the Dead and head North to kill the Tibia Mariner for your third Deathroot.</label>
-                    <a class="ms-2" href="/map.html?x=2884&amp;y=5340&amp;id=playthrough_180&amp;link=/checklists/walkthrough.html%23item_180&amp;title=Head East and use the Spiritjump to reach the top of the cliffs then summon D, Hunter of the Dead and head North to kill the Tibia Mariner for your third Deathroot.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2884&amp;y=5340&amp;id=playthrough_180&amp;link=/checklists/walkthrough.html%23item_180&amp;title=Head East and use the Spiritjump to reach the top of the cliffs then summon D, Hunter of the Dead and head North to kill the Tibia Mariner for your third Deathroot."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_181" id="item_181">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="playthrough_181" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_181">Go back South-East to the cliffs East of where you killed the Tibia Mariner and use ledges poking out of the cliff to make your way down to grab the Jarburg Grace.</label>
-                    <a class="ms-2" href="/map.html?x=2947&amp;y=5297&amp;id=playthrough_181&amp;link=/checklists/walkthrough.html%23item_181&amp;title=Go back South-East to the cliffs East of where you killed the Tibia Mariner and use ledges poking out of the cliff to make your way down to grab the Jarburg Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2947&amp;y=5297&amp;id=playthrough_181&amp;link=/checklists/walkthrough.html%23item_181&amp;title=Go back South-East to the cliffs East of where you killed the Tibia Mariner and use ledges poking out of the cliff to make your way down to grab the Jarburg Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_182" id="item_182">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="5" id="playthrough_182" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_182">Nearby the Grace, on a porch, is Jar-Bairn. Talk to him and exhaust his dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=2970&amp;y=5277&amp;id=playthrough_182&amp;link=/checklists/walkthrough.html%23item_182&amp;title=Nearby the Grace, on a porch, is Jar-Bairn. Talk to him and exhaust his dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2970&amp;y=5277&amp;id=playthrough_182&amp;link=/checklists/walkthrough.html%23item_182&amp;title=Nearby the Grace, on a porch, is Jar-Bairn. Talk to him and exhaust his dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -2109,9 +1721,7 @@
         <div class="card shadow-sm mb-3" id="playthrough_section_6">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_6Col" data-bs-toggle="collapse" href="#playthrough_6Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_6Col" data-bs-toggle="collapse" href="#playthrough_6Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Raya Lucaria</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="playthrough_totals_6"></span>
             </h4>
@@ -2121,117 +1731,91 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="playthrough_183" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_183">Go back to the South Raya Lucaria Gate Grace and use the Glintstone Key to pass through the seal and grab the Main Academy Gate Grace</label>
-                    <a class="ms-2" href="/map.html?x=2025&amp;y=5056&amp;id=playthrough_183&amp;link=/checklists/walkthrough.html%23item_183&amp;title=Go back to the South Raya Lucaria Gate Grace and use the Glintstone Key to pass through the seal and grab the Main Academy Gate Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2025&amp;y=5056&amp;id=playthrough_183&amp;link=/checklists/walkthrough.html%23item_183&amp;title=Go back to the South Raya Lucaria Gate Grace and use the Glintstone Key to pass through the seal and grab the Main Academy Gate Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_184" id="item_184">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="playthrough_184" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_184">Go North, around the seal, and use the Summon Sign on the ground to help Yura invade and kill Bloody Finger Ravenmount Assassin.</label>
-                    <a class="ms-2" href="/map.html?x=1873&amp;y=4696&amp;id=playthrough_184&amp;link=/checklists/walkthrough.html%23item_184&amp;title=Go North, around the seal, and use the Summon Sign on the ground to help Yura invade and kill Bloody Finger Ravenmount Assassin.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1873&amp;y=4696&amp;id=playthrough_184&amp;link=/checklists/walkthrough.html%23item_184&amp;title=Go North, around the seal, and use the Summon Sign on the ground to help Yura invade and kill Bloody Finger Ravenmount Assassin."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_185" id="item_185">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="playthrough_185" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_185">After the Bloody Finger is dead, talk to Yura nearby and exhaust his dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=1865&amp;y=4704&amp;id=playthrough_185&amp;link=/checklists/walkthrough.html%23item_185&amp;title=After the Bloody Finger is dead, talk to Yura nearby and exhaust his dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1865&amp;y=4704&amp;id=playthrough_185&amp;link=/checklists/walkthrough.html%23item_185&amp;title=After the Bloody Finger is dead, talk to Yura nearby and exhaust his dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_186" id="item_186">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="playthrough_186" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_186">From Main Academy Gate, go into Raya Lucaria up the lift.</label>
-                    <a class="ms-2" href="/map.html?x=1811&amp;y=4791&amp;id=playthrough_186&amp;link=/checklists/walkthrough.html%23item_186&amp;title=From Main Academy Gate, go into Raya Lucaria up the lift.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1811&amp;y=4791&amp;id=playthrough_186&amp;link=/checklists/walkthrough.html%23item_186&amp;title=From Main Academy Gate, go into Raya Lucaria up the lift."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_187" id="item_187">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="playthrough_187" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_187">Go past the enemies, into the church, to the left and another left to the Church of the Cuckoo Grace</label>
-                    <a class="ms-2" href="/map.html?x=1795&amp;y=4894&amp;id=playthrough_187&amp;link=/checklists/walkthrough.html%23item_187&amp;title=Go past the enemies, into the church, to the left and another left to the Church of the Cuckoo Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1795&amp;y=4894&amp;id=playthrough_187&amp;link=/checklists/walkthrough.html%23item_187&amp;title=Go past the enemies, into the church, to the left and another left to the Church of the Cuckoo Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_188" id="item_188">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="playthrough_188" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_188">From the Grace, go down the hall and out the door to the graveyard. Go past the enemies and jump onto the rotating wheel lift and ride it all the way up. Hop off and grab the Schoolhouse Classroom Grace</label>
-                    <a class="ms-2" href="/map.html?x=1943&amp;y=4983&amp;id=playthrough_188&amp;link=/checklists/walkthrough.html%23item_188&amp;title=From the Grace, go down the hall and out the door to the graveyard. Go past the enemies and jump onto the rotating wheel lift and ride it all the way up. Hop off and grab the Schoolhouse Classroom Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1943&amp;y=4983&amp;id=playthrough_188&amp;link=/checklists/walkthrough.html%23item_188&amp;title=From the Grace, go down the hall and out the door to the graveyard. Go past the enemies and jump onto the rotating wheel lift and ride it all the way up. Hop off and grab the Schoolhouse Classroom Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_189" id="item_189">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="playthrough_189" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_189">From the Grace, go into the hallway and go right. Make you're way past the enemies then up the stairs, then up the stairs, then up the stairs, UP ALL THE STAIRS then go down the hall to fight and kill the Boss, Red Wolf of Radagon.</label>
-                    <a class="ms-2" href="/map.html?x=1953&amp;y=5019&amp;id=playthrough_189&amp;link=/checklists/walkthrough.html%23item_189&amp;title=From the Grace, go into the hallway and go right. Make you're way past the enemies then up the stairs, then up the stairs, then up the stairs, UP ALL THE STAIRS then go down the hall to fight and kill the Boss, Red Wolf of Radagon.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1953&amp;y=5019&amp;id=playthrough_189&amp;link=/checklists/walkthrough.html%23item_189&amp;title=From the Grace, go into the hallway and go right. Make you're way past the enemies then up the stairs, then up the stairs, then up the stairs, UP ALL THE STAIRS then go down the hall to fight and kill the Boss, Red Wolf of Radagon."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_190" id="item_190">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="playthrough_190" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_190">After it's dead grab the Debate Hall Grace.</label>
-                    <a class="ms-2" href="/map.html?x=1963&amp;y=5019&amp;id=playthrough_190&amp;link=/checklists/walkthrough.html%23item_190&amp;title=After it's dead grab the Debate Hall Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1963&amp;y=5019&amp;id=playthrough_190&amp;link=/checklists/walkthrough.html%23item_190&amp;title=After it's dead grab the Debate Hall Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_191" id="item_191">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="playthrough_191" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_191">You can now reach the boss but first we are going to collect a couple things so go into the courtyard and to the left to go up the stairs. Head up those stairs and in the room, on the balcony will be the Glintstone Whetblade for you to grab.</label>
-                    <a class="ms-2" href="/map.html?x=1928&amp;y=4942&amp;id=playthrough_191&amp;link=/checklists/walkthrough.html%23item_191&amp;title=You can now reach the boss but first we are going to collect a couple things so go into the courtyard and to the left to go up the stairs. Head up those stairs and in the room, on the balcony will be the Glintstone Whetblade for you to grab.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1928&amp;y=4942&amp;id=playthrough_191&amp;link=/checklists/walkthrough.html%23item_191&amp;title=You can now reach the boss but first we are going to collect a couple things so go into the courtyard and to the left to go up the stairs. Head up those stairs and in the room, on the balcony will be the Glintstone Whetblade for you to grab."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_192" id="item_192">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="playthrough_192" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_192">Continue past and you will find a fence you can jump over to get onto some rooftops. Hop the fence and open the door nearby for a shortcut if you like. From here the rooftops are a mini-maze but at the end of this maze you will arrive inside the Church of the Cuckoo where you can hop onto the chandelier to grab a second Academy Glintstone Key for Thops.</label>
-                    <a class="ms-2" href="/map.html?x=1780&amp;y=4898&amp;id=playthrough_192&amp;link=/checklists/walkthrough.html%23item_192&amp;title=Continue past and you will find a fence you can jump over to get onto some rooftops. Hop the fence and open the door nearby for a shortcut if you like. From here the rooftops are a mini-maze but at the end of this maze you will arrive inside the Church of the Cuckoo where you can hop onto the chandelier to grab a second Academy Glintstone Key for Thops.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1780&amp;y=4898&amp;id=playthrough_192&amp;link=/checklists/walkthrough.html%23item_192&amp;title=Continue past and you will find a fence you can jump over to get onto some rooftops. Hop the fence and open the door nearby for a shortcut if you like. From here the rooftops are a mini-maze but at the end of this maze you will arrive inside the Church of the Cuckoo where you can hop onto the chandelier to grab a second Academy Glintstone Key for Thops."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_193" id="item_193">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="playthrough_193" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_193">Head back to the Debate Parlor Grace and once you enter the courtyard, go to the right side and hop onto once of the archways leading to the path where the metal ball is rolling down. Hop the fence and make your way past the metal ball to reach Moongrum, Carian Knight and kill him.</label>
-                    <a class="ms-2" href="/map.html?x=1928&amp;y=4853&amp;id=playthrough_193&amp;link=/checklists/walkthrough.html%23item_193&amp;title=Head back to the Debate Parlor Grace and once you enter the courtyard, go to the right side and hop onto once of the archways leading to the path where the metal ball is rolling down. Hop the fence and make your way past the metal ball to reach Moongrum, Carian Knight and kill him.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1928&amp;y=4853&amp;id=playthrough_193&amp;link=/checklists/walkthrough.html%23item_193&amp;title=Head back to the Debate Parlor Grace and once you enter the courtyard, go to the right side and hop onto once of the archways leading to the path where the metal ball is rolling down. Hop the fence and make your way past the metal ball to reach Moongrum, Carian Knight and kill him."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_194" id="item_194">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="playthrough_194" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_194">With Moongrum dead, go up the lift to fight and kill the Boss, Rennala, Queen of the Full Moon.</label>
-                    <a class="ms-2" href="/map.html?x=1856&amp;y=4823&amp;id=playthrough_194&amp;link=/checklists/walkthrough.html%23item_194&amp;title=With Moongrum dead, go up the lift to fight and kill the Boss, Rennala, Queen of the Full Moon.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1856&amp;y=4823&amp;id=playthrough_194&amp;link=/checklists/walkthrough.html%23item_194&amp;title=With Moongrum dead, go up the lift to fight and kill the Boss, Rennala, Queen of the Full Moon."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_195" id="item_195">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="6" id="playthrough_195" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_195">Grab the Raya Lucaria Grand Library Grace.</label>
-                    <a class="ms-2" href="/map.html?x=1840&amp;y=4819&amp;id=playthrough_195&amp;link=/checklists/walkthrough.html%23item_195&amp;title=Grab the Raya Lucaria Grand Library Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1840&amp;y=4819&amp;id=playthrough_195&amp;link=/checklists/walkthrough.html%23item_195&amp;title=Grab the Raya Lucaria Grand Library Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -2241,9 +1825,7 @@
         <div class="card shadow-sm mb-3" id="playthrough_section_7">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_7Col" data-bs-toggle="collapse" href="#playthrough_7Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_7Col" data-bs-toggle="collapse" href="#playthrough_7Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Liurnia Lake Part Two</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="playthrough_totals_7"></span>
             </h4>
@@ -2253,63 +1835,49 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="7" id="playthrough_196" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_196">From the Raya Lucaria Grand Library Grace, go back down the lift and into the building just before reaching the metal ball again. To the North will be Waygate, use it to arrive at the Church of Vows and grab the Church of Vows Grace</label>
-                    <a class="ms-2" href="/map.html?x=2405&amp;y=4720&amp;id=playthrough_196&amp;link=/checklists/walkthrough.html%23item_196&amp;title=From the Raya Lucaria Grand Library Grace, go back down the lift and into the building just before reaching the metal ball again. To the North will be Waygate, use it to arrive at the Church of Vows and grab the Church of Vows Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2405&amp;y=4720&amp;id=playthrough_196&amp;link=/checklists/walkthrough.html%23item_196&amp;title=From the Raya Lucaria Grand Library Grace, go back down the lift and into the building just before reaching the metal ball again. To the North will be Waygate, use it to arrive at the Church of Vows and grab the Church of Vows Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_197" id="item_197">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="7" id="playthrough_197" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_197">Talk to Miriel, Pastor of Vows inside the Church of Vows and exhaust his dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=2405&amp;y=4720&amp;id=playthrough_197&amp;link=/checklists/walkthrough.html%23item_197&amp;title=Talk to Miriel, Pastor of Vows inside the Church of Vows and exhaust his dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2405&amp;y=4720&amp;id=playthrough_197&amp;link=/checklists/walkthrough.html%23item_197&amp;title=Talk to Miriel, Pastor of Vows inside the Church of Vows and exhaust his dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_198" id="item_198">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="7" id="playthrough_198" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_198">Grab the Gold Sewing Needle and Gold Tailoring Tools from the chest nearby</label>
-                    <a class="ms-2" href="/map.html?x=2405&amp;y=4720&amp;id=playthrough_198&amp;link=/checklists/walkthrough.html%23item_198&amp;title=Grab the Gold Sewing Needle and Gold Tailoring Tools from the chest nearby">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2405&amp;y=4720&amp;id=playthrough_198&amp;link=/checklists/walkthrough.html%23item_198&amp;title=Grab the Gold Sewing Needle and Gold Tailoring Tools from the chest nearby"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_199" id="item_199">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="7" id="playthrough_199" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_199">Go North-East from the Church of Vows and grab the Ruined Labyrinth Grace</label>
-                    <a class="ms-2" href="/map.html?x=2586&amp;y=4487&amp;id=playthrough_199&amp;link=/checklists/walkthrough.html%23item_199&amp;title=Go North-East from the Church of Vows and grab the Ruined Labyrinth Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2586&amp;y=4487&amp;id=playthrough_199&amp;link=/checklists/walkthrough.html%23item_199&amp;title=Go North-East from the Church of Vows and grab the Ruined Labyrinth Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_200" id="item_200">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="7" id="playthrough_200" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_200">Follow the road East from the Grace to it's end to find the Black Knife Catacombs Grace</label>
-                    <a class="ms-2" href="/map.html?x=2872&amp;y=4108&amp;id=playthrough_200&amp;link=/checklists/walkthrough.html%23item_200&amp;title=Follow the road East from the Grace to it's end to find the Black Knife Catacombs Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2872&amp;y=4108&amp;id=playthrough_200&amp;link=/checklists/walkthrough.html%23item_200&amp;title=Follow the road East from the Grace to it's end to find the Black Knife Catacombs Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_201" id="item_201">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="7" id="playthrough_201" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_201">Proceed through the catacombs to the room with the falling blades then hop onto one of the blades. Ride the blade up and hop onto the ledge to find the hidden path. Follow this path to the end and roll into the Illusory Wall to make it disappear. Summon D, Hunter of the Dead and kill the Boss, Black Knife Assassin for the Black Knifeprint.</label>
-                    <a class="ms-2" href="/map.html?x=2883&amp;y=4091&amp;id=playthrough_201&amp;link=/checklists/walkthrough.html%23item_201&amp;title=Proceed through the catacombs to the room with the falling blades then hop onto one of the blades. Ride the blade up and hop onto the ledge to find the hidden path. Follow this path to the end and roll into the Illusory Wall to make it disappear. Summon D, Hunter of the Dead and kill the Boss, Black Knife Assassin for the Black Knifeprint.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2883&amp;y=4091&amp;id=playthrough_201&amp;link=/checklists/walkthrough.html%23item_201&amp;title=Proceed through the catacombs to the room with the falling blades then hop onto one of the blades. Ride the blade up and hop onto the ledge to find the hidden path. Follow this path to the end and roll into the Illusory Wall to make it disappear. Summon D, Hunter of the Dead and kill the Boss, Black Knife Assassin for the Black Knifeprint."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_202" id="item_202">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="7" id="playthrough_202" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_202">Proceed to the end of the regular path and kill the Boss, Cemetary Shade for the fourth Deathroot.</label>
-                    <a class="ms-2" href="/map.html?x=2867&amp;y=4090&amp;id=playthrough_202&amp;link=/checklists/walkthrough.html%23item_202&amp;title=Proceed to the end of the regular path and kill the Boss, Cemetary Shade for the fourth Deathroot.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2867&amp;y=4090&amp;id=playthrough_202&amp;link=/checklists/walkthrough.html%23item_202&amp;title=Proceed to the end of the regular path and kill the Boss, Cemetary Shade for the fourth Deathroot."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -2319,9 +1887,7 @@
         <div class="card shadow-sm mb-3" id="playthrough_section_8">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_8Col" data-bs-toggle="collapse" href="#playthrough_8Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_8Col" data-bs-toggle="collapse" href="#playthrough_8Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Roundtable Hold</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="playthrough_totals_8"></span>
             </h4>
@@ -2331,81 +1897,63 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="8" id="playthrough_203" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_203">Go back to Roundtable Hold and kill the Invader, Ensha</label>
-                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_203&amp;link=/checklists/walkthrough.html%23item_203&amp;title=Go back to Roundtable Hold and kill the Invader, Ensha">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_203&amp;link=/checklists/walkthrough.html%23item_203&amp;title=Go back to Roundtable Hold and kill the Invader, Ensha"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_204" id="item_204">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="8" id="playthrough_204" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_204">Talk to Gideon and Nepheli until dialogue with both is exhausted</label>
-                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_204&amp;link=/checklists/walkthrough.html%23item_204&amp;title=Talk to Gideon and Nepheli until dialogue with both is exhausted">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_204&amp;link=/checklists/walkthrough.html%23item_204&amp;title=Talk to Gideon and Nepheli until dialogue with both is exhausted"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_205" id="item_205">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="8" id="playthrough_205" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_205">Talk to Hewg until dialogue is exhausted</label>
-                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_205&amp;link=/checklists/walkthrough.html%23item_205&amp;title=Talk to Hewg until dialogue is exhausted">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_205&amp;link=/checklists/walkthrough.html%23item_205&amp;title=Talk to Hewg until dialogue is exhausted"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_206" id="item_206">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="8" id="playthrough_206" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_206">Talk to Roderika until dialogue is exhausted</label>
-                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_206&amp;link=/checklists/walkthrough.html%23item_206&amp;title=Talk to Roderika until dialogue is exhausted">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_206&amp;link=/checklists/walkthrough.html%23item_206&amp;title=Talk to Roderika until dialogue is exhausted"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_206_1" id="item_206_1">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="8" id="playthrough_206_1" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_206_1">Talk to Corhyn until dialogue is exhausted</label>
-                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_206_1&amp;link=/checklists/walkthrough.html%23item_206_1&amp;title=Talk to Corhyn until dialogue is exhausted">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_206_1&amp;link=/checklists/walkthrough.html%23item_206_1&amp;title=Talk to Corhyn until dialogue is exhausted"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_207" id="item_207">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="8" id="playthrough_207" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_207">Talk to Diallos until dialogue is exhausted</label>
-                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_207&amp;link=/checklists/walkthrough.html%23item_207&amp;title=Talk to Diallos until dialogue is exhausted">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_207&amp;link=/checklists/walkthrough.html%23item_207&amp;title=Talk to Diallos until dialogue is exhausted"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_208" id="item_208">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="8" id="playthrough_208" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_208">Talk to Enia until dialogue is exhausted</label>
-                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_208&amp;link=/checklists/walkthrough.html%23item_208&amp;title=Talk to Enia until dialogue is exhausted">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_208&amp;link=/checklists/walkthrough.html%23item_208&amp;title=Talk to Enia until dialogue is exhausted"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_209" id="item_209">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="8" id="playthrough_209" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_209">Cuddle with Fia and talk to Rogier until dialogue with both is exhausted</label>
-                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_209&amp;link=/checklists/walkthrough.html%23item_209&amp;title=Cuddle with Fia and talk to Rogier until dialogue with both is exhausted">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_209&amp;link=/checklists/walkthrough.html%23item_209&amp;title=Cuddle with Fia and talk to Rogier until dialogue with both is exhausted"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_210" id="item_210">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="8" id="playthrough_210" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_210">Reload and talk to Rogier again until dialogue is exhausted.</label>
-                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_210&amp;link=/checklists/walkthrough.html%23item_210&amp;title=Reload and talk to Rogier again until dialogue is exhausted.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_210&amp;link=/checklists/walkthrough.html%23item_210&amp;title=Reload and talk to Rogier again until dialogue is exhausted."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -2415,9 +1963,7 @@
         <div class="card shadow-sm mb-3" id="playthrough_section_9">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_9Col" data-bs-toggle="collapse" href="#playthrough_9Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_9Col" data-bs-toggle="collapse" href="#playthrough_9Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Liurnia Lake Part Three/Roundtable</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="playthrough_totals_9"></span>
             </h4>
@@ -2427,135 +1973,105 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="9" id="playthrough_211" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_211">Start from the Academy Gate Town Grace then head North-West. In a pavillion you will find a Waygate. Use it to appear near and grab the Northern Liurnia Lake Shore Grace.</label>
-                    <a class="ms-2" href="/map.html?x=2275&amp;y=4977&amp;id=playthrough_211&amp;link=/checklists/walkthrough.html%23item_211&amp;title=Start from the Academy Gate Town Grace then head North-West. In a pavillion you will find a Waygate. Use it to appear near and grab the Northern Liurnia Lake Shore Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2275&amp;y=4977&amp;id=playthrough_211&amp;link=/checklists/walkthrough.html%23item_211&amp;title=Start from the Academy Gate Town Grace then head North-West. In a pavillion you will find a Waygate. Use it to appear near and grab the Northern Liurnia Lake Shore Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_212" id="item_212">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="9" id="playthrough_212" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_212">Grab the Map (Liurnia, West) just North-East of the Grace</label>
-                    <a class="ms-2" href="/map.html?x=1643&amp;y=4177&amp;id=playthrough_212&amp;link=/checklists/walkthrough.html%23item_212&amp;title=Grab the Map (Liurnia, West) just North-East of the Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1643&amp;y=4177&amp;id=playthrough_212&amp;link=/checklists/walkthrough.html%23item_212&amp;title=Grab the Map (Liurnia, West) just North-East of the Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_213" id="item_213">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="9" id="playthrough_213" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_213">Head North-East and break the Illusory Wall to grab the Road to the Manor Grace</label>
-                    <a class="ms-2" href="/map.html?x=1718&amp;y=4037&amp;id=playthrough_213&amp;link=/checklists/walkthrough.html%23item_213&amp;title=Head North-East and break the Illusory Wall to grab the Road to the Manor Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1718&amp;y=4037&amp;id=playthrough_213&amp;link=/checklists/walkthrough.html%23item_213&amp;title=Head North-East and break the Illusory Wall to grab the Road to the Manor Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_214" id="item_214">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="9" id="playthrough_214" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_214">Talk to Iji and exhaust his dialogue</label>
-                    <a class="ms-2" href="/map.html?x=1713&amp;y=4026&amp;id=playthrough_214&amp;link=/checklists/walkthrough.html%23item_214&amp;title=Talk to Iji and exhaust his dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1713&amp;y=4026&amp;id=playthrough_214&amp;link=/checklists/walkthrough.html%23item_214&amp;title=Talk to Iji and exhaust his dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_215" id="item_215">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="9" id="playthrough_215" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_215">Head North-East and grab the Main Caria Manor Gate Grace</label>
-                    <a class="ms-2" href="/map.html?x=1902&amp;y=3845&amp;id=playthrough_215&amp;link=/checklists/walkthrough.html%23item_215&amp;title=Head North-East and grab the Main Caria Manor Gate Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1902&amp;y=3845&amp;id=playthrough_215&amp;link=/checklists/walkthrough.html%23item_215&amp;title=Head North-East and grab the Main Caria Manor Gate Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_216" id="item_216">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="9" id="playthrough_216" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_216">Run through the manor to the Manor Lower Level Grace.</label>
-                    <a class="ms-2" href="/map.html?x=1843&amp;y=3749&amp;id=playthrough_216&amp;link=/checklists/walkthrough.html%23item_216&amp;title=Run through the manor to the Manor Lower Level Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1843&amp;y=3749&amp;id=playthrough_216&amp;link=/checklists/walkthrough.html%23item_216&amp;title=Run through the manor to the Manor Lower Level Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_217" id="item_217">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="9" id="playthrough_217" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_217">Run across the bridges then up the lift to the Manor Upper Level Grace.</label>
-                    <a class="ms-2" href="/map.html?x=2023&amp;y=3757&amp;id=playthrough_217&amp;link=/checklists/walkthrough.html%23item_217&amp;title=Run across the bridges then up the lift to the Manor Upper Level Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2023&amp;y=3757&amp;id=playthrough_217&amp;link=/checklists/walkthrough.html%23item_217&amp;title=Run across the bridges then up the lift to the Manor Upper Level Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_218" id="item_218">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="9" id="playthrough_218" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_218">Run past the enemies and kill the boss, Royal Knight Loretta.</label>
-                    <a class="ms-2" href="/map.html?x=1889&amp;y=3612&amp;id=playthrough_218&amp;link=/checklists/walkthrough.html%23item_218&amp;title=Run past the enemies and kill the boss, Royal Knight Loretta.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1889&amp;y=3612&amp;id=playthrough_218&amp;link=/checklists/walkthrough.html%23item_218&amp;title=Run past the enemies and kill the boss, Royal Knight Loretta."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_219" id="item_219">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="9" id="playthrough_219" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_219">Grab the Royal Knight Loretta Grace</label>
-                    <a class="ms-2" href="/map.html?x=1889&amp;y=3612&amp;id=playthrough_219&amp;link=/checklists/walkthrough.html%23item_219&amp;title=Grab the Royal Knight Loretta Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1889&amp;y=3612&amp;id=playthrough_219&amp;link=/checklists/walkthrough.html%23item_219&amp;title=Grab the Royal Knight Loretta Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_220" id="item_220">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="9" id="playthrough_220" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_220">Head outside and go West, fighting or running past the Glintstone Dragon Adula and enter Ranni's Rise and grab the Ranni's Rise Grace.</label>
-                    <a class="ms-2" href="/map.html?x=1576&amp;y=3700&amp;id=playthrough_220&amp;link=/checklists/walkthrough.html%23item_220&amp;title=Head outside and go West, fighting or running past the Glintstone Dragon Adula and enter Ranni's Rise and grab the Ranni's Rise Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1576&amp;y=3700&amp;id=playthrough_220&amp;link=/checklists/walkthrough.html%23item_220&amp;title=Head outside and go West, fighting or running past the Glintstone Dragon Adula and enter Ranni's Rise and grab the Ranni's Rise Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_221" id="item_221">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="9" id="playthrough_221" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_221">Go up the lift and talk to Ranni and get rejected</label>
-                    <a class="ms-2" href="/map.html?x=1596&amp;y=3690&amp;id=playthrough_221&amp;link=/checklists/walkthrough.html%23item_221&amp;title=Go up the lift and talk to Ranni and get rejected">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1596&amp;y=3690&amp;id=playthrough_221&amp;link=/checklists/walkthrough.html%23item_221&amp;title=Go up the lift and talk to Ranni and get rejected"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_222" id="item_222">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="9" id="playthrough_222" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_222">Go back to Rogier get advice</label>
-                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_222&amp;link=/checklists/walkthrough.html%23item_222&amp;title=Go back to Rogier get advice">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_222&amp;link=/checklists/walkthrough.html%23item_222&amp;title=Go back to Rogier get advice"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_223" id="item_223">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="9" id="playthrough_223" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_223">Go back to Ranni and get accepted</label>
-                    <a class="ms-2" href="/map.html?x=1596&amp;y=3690&amp;id=playthrough_223&amp;link=/checklists/walkthrough.html%23item_223&amp;title=Go back to Ranni and get accepted">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1596&amp;y=3690&amp;id=playthrough_223&amp;link=/checklists/walkthrough.html%23item_223&amp;title=Go back to Ranni and get accepted"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_224" id="item_224">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="9" id="playthrough_224" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_224">Talk to Iji, Blaidd and Seluvis then back to Ranni.</label>
-                    <a class="ms-2" href="/map.html?x=1596&amp;y=3690&amp;id=playthrough_224&amp;link=/checklists/walkthrough.html%23item_224&amp;title=Talk to Iji, Blaidd and Seluvis then back to Ranni.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1596&amp;y=3690&amp;id=playthrough_224&amp;link=/checklists/walkthrough.html%23item_224&amp;title=Talk to Iji, Blaidd and Seluvis then back to Ranni."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_225" id="item_225">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="9" id="playthrough_225" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_225">Return to Rogier, reload and talk again</label>
-                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_225&amp;link=/checklists/walkthrough.html%23item_225&amp;title=Return to Rogier, reload and talk again">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_225&amp;link=/checklists/walkthrough.html%23item_225&amp;title=Return to Rogier, reload and talk again"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -2565,9 +2081,7 @@
         <div class="card shadow-sm mb-3" id="playthrough_section_10">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_10Col" data-bs-toggle="collapse" href="#playthrough_10Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_10Col" data-bs-toggle="collapse" href="#playthrough_10Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Caelid</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="playthrough_totals_10"></span>
             </h4>
@@ -2577,207 +2091,161 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="10" id="playthrough_226" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_226">Starting from the Summonwater Village Outskirts in North-East Limgrave, head East to the cliffs and find your way down to find a cave entrance</label>
-                    <a class="ms-2" href="/map.html?x=4681&amp;y=6465&amp;id=playthrough_226&amp;link=/checklists/walkthrough.html%23item_226&amp;title=Starting from the Summonwater Village Outskirts in North-East Limgrave, head East to the cliffs and find your way down to find a cave entrance">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4681&amp;y=6465&amp;id=playthrough_226&amp;link=/checklists/walkthrough.html%23item_226&amp;title=Starting from the Summonwater Village Outskirts in North-East Limgrave, head East to the cliffs and find your way down to find a cave entrance"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_227" id="item_227">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="10" id="playthrough_227" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_227">Go inside, grab Rear Gael Tunnel Enterance grace, and talk to Alexander.</label>
-                    <a class="ms-2" href="/map.html?x=4700&amp;y=6415&amp;id=playthrough_227&amp;link=/checklists/walkthrough.html%23item_227&amp;title=Go inside, grab Rear Gael Tunnel Enterance grace, and talk to Alexander.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4700&amp;y=6415&amp;id=playthrough_227&amp;link=/checklists/walkthrough.html%23item_227&amp;title=Go inside, grab Rear Gael Tunnel Enterance grace, and talk to Alexander."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_228" id="item_228">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="10" id="playthrough_228" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_228">Go back up the cliffs and follow the road North-East to kill Invader, Anastasia, Tarnished Eater at the Smoldering Church</label>
-                    <a class="ms-2" href="/map.html?x=4669&amp;y=6279&amp;id=playthrough_228&amp;link=/checklists/walkthrough.html%23item_228&amp;title=Go back up the cliffs and follow the road North-East to kill Invader, Anastasia, Tarnished Eater at the Smoldering Church">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4669&amp;y=6279&amp;id=playthrough_228&amp;link=/checklists/walkthrough.html%23item_228&amp;title=Go back up the cliffs and follow the road North-East to kill Invader, Anastasia, Tarnished Eater at the Smoldering Church"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_229" id="item_229">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="10" id="playthrough_229" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_229">Continue following the road in Caelid and grab the Rotview Balcony Grace</label>
-                    <a class="ms-2" href="/map.html?x=4842&amp;y=6339&amp;id=playthrough_229&amp;link=/checklists/walkthrough.html%23item_229&amp;title=Continue following the road in Caelid and grab the Rotview Balcony Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4842&amp;y=6339&amp;id=playthrough_229&amp;link=/checklists/walkthrough.html%23item_229&amp;title=Continue following the road in Caelid and grab the Rotview Balcony Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_230" id="item_230">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="10" id="playthrough_230" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_230">Follow the cliffs South of the Grace to reach the Gael Tunnel, enter it and drop down to grab the Gael Tunnel Grace</label>
-                    <a class="ms-2" href="/map.html?x=4794&amp;y=6490&amp;id=playthrough_230&amp;link=/checklists/walkthrough.html%23item_230&amp;title=Follow the cliffs South of the Grace to reach the Gael Tunnel, enter it and drop down to grab the Gael Tunnel Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4794&amp;y=6490&amp;id=playthrough_230&amp;link=/checklists/walkthrough.html%23item_230&amp;title=Follow the cliffs South of the Grace to reach the Gael Tunnel, enter it and drop down to grab the Gael Tunnel Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_231" id="item_231">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="10" id="playthrough_231" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_231">Make your way to the end of Gael Tunnel</label>
-                    <a class="ms-2" href="/map.html?x=4716&amp;y=6414&amp;id=playthrough_231&amp;link=/checklists/walkthrough.html%23item_231&amp;title=Make your way to the end of Gael Tunnel">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4716&amp;y=6414&amp;id=playthrough_231&amp;link=/checklists/walkthrough.html%23item_231&amp;title=Make your way to the end of Gael Tunnel"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_232" id="item_232">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="10" id="playthrough_232" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_232">Open the door at the end, talk to Alexander and exhaust his dialogue</label>
-                    <a class="ms-2" href="/map.html?x=4716&amp;y=6414&amp;id=playthrough_232&amp;link=/checklists/walkthrough.html%23item_232&amp;title=Open the door at the end, talk to Alexander and exhaust his dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4716&amp;y=6414&amp;id=playthrough_232&amp;link=/checklists/walkthrough.html%23item_232&amp;title=Open the door at the end, talk to Alexander and exhaust his dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_233" id="item_233">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="10" id="playthrough_233" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_233">Go back to the Rotview Balcony Grace and follow the road East to grab the Caelem Ruins Grace</label>
-                    <a class="ms-2" href="/map.html?x=5094&amp;y=6292&amp;id=playthrough_233&amp;link=/checklists/walkthrough.html%23item_233&amp;title=Go back to the Rotview Balcony Grace and follow the road East to grab the Caelem Ruins Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5094&amp;y=6292&amp;id=playthrough_233&amp;link=/checklists/walkthrough.html%23item_233&amp;title=Go back to the Rotview Balcony Grace and follow the road East to grab the Caelem Ruins Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_234" id="item_234">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="10" id="playthrough_234" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_234">Follow the road South to grab the Smoldering Wall Grace</label>
-                    <a class="ms-2" href="/map.html?x=5159&amp;y=6524&amp;id=playthrough_234&amp;link=/checklists/walkthrough.html%23item_234&amp;title=Follow the road South to grab the Smoldering Wall Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5159&amp;y=6524&amp;id=playthrough_234&amp;link=/checklists/walkthrough.html%23item_234&amp;title=Follow the road South to grab the Smoldering Wall Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_235" id="item_235">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="10" id="playthrough_235" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_235">Talk to the Finger Reader nearby</label>
-                    <a class="ms-2" href="/map.html?x=5136&amp;y=6526&amp;id=playthrough_235&amp;link=/checklists/walkthrough.html%23item_235&amp;title=Talk to the Finger Reader nearby">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5136&amp;y=6526&amp;id=playthrough_235&amp;link=/checklists/walkthrough.html%23item_235&amp;title=Talk to the Finger Reader nearby"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_236" id="item_236">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="10" id="playthrough_236" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_236">Head into the swamp South-East and kill the Invader, Millicent.</label>
-                    <a class="ms-2" href="/map.html?x=5393&amp;y=6753&amp;id=playthrough_236&amp;link=/checklists/walkthrough.html%23item_236&amp;title=Head into the swamp South-East and kill the Invader, Millicent.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5393&amp;y=6753&amp;id=playthrough_236&amp;link=/checklists/walkthrough.html%23item_236&amp;title=Head into the swamp South-East and kill the Invader, Millicent."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_236_1" id="item_236_1">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="10" id="playthrough_236_1" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_236_1">Head to the North-East side of the swamp and grab the Inner Aeonia Grace</label>
-                    <a class="ms-2" href="/map.html?x=5443&amp;y=6666&amp;id=playthrough_236_1&amp;link=/checklists/walkthrough.html%23item_236_1&amp;title=Head to the North-East side of the swamp and grab the Inner Aeonia Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5443&amp;y=6666&amp;id=playthrough_236_1&amp;link=/checklists/walkthrough.html%23item_236_1&amp;title=Head to the North-East side of the swamp and grab the Inner Aeonia Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_237" id="item_237">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="10" id="playthrough_237" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_237">Continue further North-East to grab the Sellia Under-Stair Grace.</label>
-                    <a class="ms-2" href="/map.html?x=5600&amp;y=6559&amp;id=playthrough_237&amp;link=/checklists/walkthrough.html%23item_237&amp;title=Continue further North-East to grab the Sellia Under-Stair Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5600&amp;y=6559&amp;id=playthrough_237&amp;link=/checklists/walkthrough.html%23item_237&amp;title=Continue further North-East to grab the Sellia Under-Stair Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_238" id="item_238">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="10" id="playthrough_238" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_238">Go into the town up the stairs and head South to find Gowry's Shack. Kill the dog to make sure it doesn't break the quest then talk to Gowry in his shack and exhaust his dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=5672&amp;y=6738&amp;id=playthrough_238&amp;link=/checklists/walkthrough.html%23item_238&amp;title=Go into the town up the stairs and head South to find Gowry's Shack. Kill the dog to make sure it doesn't break the quest then talk to Gowry in his shack and exhaust his dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5672&amp;y=6738&amp;id=playthrough_238&amp;link=/checklists/walkthrough.html%23item_238&amp;title=Go into the town up the stairs and head South to find Gowry's Shack. Kill the dog to make sure it doesn't break the quest then talk to Gowry in his shack and exhaust his dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_239" id="item_239">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="10" id="playthrough_239" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_239">Follow the swamp heading South from the Inner Aeonia Grace to summon Polyanna, Adopted Daughter and kill Commander O'Neil in the South-East section of the swamp.</label>
-                    <a class="ms-2" href="/map.html?x=5481&amp;y=6734&amp;id=playthrough_239&amp;link=/checklists/walkthrough.html%23item_239&amp;title=Follow the swamp heading South from the Inner Aeonia Grace to summon Polyanna, Adopted Daughter and kill Commander O'Neil in the South-East section of the swamp.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5481&amp;y=6734&amp;id=playthrough_239&amp;link=/checklists/walkthrough.html%23item_239&amp;title=Follow the swamp heading South from the Inner Aeonia Grace to summon Polyanna, Adopted Daughter and kill Commander O'Neil in the South-East section of the swamp."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_240" id="item_240">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="10" id="playthrough_240" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_240">Return to Gowry and give him the needle then reload, talk to him again and exhaust his dialogue</label>
-                    <a class="ms-2" href="/map.html?x=5672&amp;y=6738&amp;id=playthrough_240&amp;link=/checklists/walkthrough.html%23item_240&amp;title=Return to Gowry and give him the needle then reload, talk to him again and exhaust his dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5672&amp;y=6738&amp;id=playthrough_240&amp;link=/checklists/walkthrough.html%23item_240&amp;title=Return to Gowry and give him the needle then reload, talk to him again and exhaust his dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_241" id="item_241">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="10" id="playthrough_241" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_241">Light the fires on top of the buildings in Sellia to undo the seal, then go through the seal North of town to grab the Sellia Backstreets Grace</label>
-                    <a class="ms-2" href="/map.html?x=5631&amp;y=6471&amp;id=playthrough_241&amp;link=/checklists/walkthrough.html%23item_241&amp;title=Light the fires on top of the buildings in Sellia to undo the seal, then go through the seal North of town to grab the Sellia Backstreets Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5631&amp;y=6471&amp;id=playthrough_241&amp;link=/checklists/walkthrough.html%23item_241&amp;title=Light the fires on top of the buildings in Sellia to undo the seal, then go through the seal North of town to grab the Sellia Backstreets Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_242" id="item_242">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="10" id="playthrough_242" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_242">Follow the road North-East and then South to grab the Church of the Plague Grace</label>
-                    <a class="ms-2" href="/map.html?x=5771&amp;y=6646&amp;id=playthrough_242&amp;link=/checklists/walkthrough.html%23item_242&amp;title=Follow the road North-East and then South to grab the Church of the Plague Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5771&amp;y=6646&amp;id=playthrough_242&amp;link=/checklists/walkthrough.html%23item_242&amp;title=Follow the road North-East and then South to grab the Church of the Plague Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_243" id="item_243">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="10" id="playthrough_243" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_243">Talk to Millicent and exhaust her dialogue, then reload, talk to her again and exhaust her dialogue</label>
-                    <a class="ms-2" href="/map.html?x=5771&amp;y=6646&amp;id=playthrough_243&amp;link=/checklists/walkthrough.html%23item_243&amp;title=Talk to Millicent and exhaust her dialogue, then reload, talk to her again and exhaust her dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5771&amp;y=6646&amp;id=playthrough_243&amp;link=/checklists/walkthrough.html%23item_243&amp;title=Talk to Millicent and exhaust her dialogue, then reload, talk to her again and exhaust her dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_244" id="item_244">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="10" id="playthrough_244" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_244">Return to Gowry and exhaust his dialogue. If Millicent is there, exhaust her dialogue, then reload to talk to Gowry.</label>
-                    <a class="ms-2" href="/map.html?x=5672&amp;y=6738&amp;id=playthrough_244&amp;link=/checklists/walkthrough.html%23item_244&amp;title=Return to Gowry and exhaust his dialogue. If Millicent is there, exhaust her dialogue, then reload to talk to Gowry.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5672&amp;y=6738&amp;id=playthrough_244&amp;link=/checklists/walkthrough.html%23item_244&amp;title=Return to Gowry and exhaust his dialogue. If Millicent is there, exhaust her dialogue, then reload to talk to Gowry."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_245" id="item_245">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="10" id="playthrough_245" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_245">Head South and grab the Southern Aeonia Swamp Grace</label>
-                    <a class="ms-2" href="/map.html?x=5507&amp;y=6975&amp;id=playthrough_245&amp;link=/checklists/walkthrough.html%23item_245&amp;title=Head South and grab the Southern Aeonia Swamp Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5507&amp;y=6975&amp;id=playthrough_245&amp;link=/checklists/walkthrough.html%23item_245&amp;title=Head South and grab the Southern Aeonia Swamp Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_246" id="item_246">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="10" id="playthrough_246" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_246">Follow the road South-East to the bridge to grab the Impassable Greatbridge Grace for later.</label>
-                    <a class="ms-2" href="/map.html?x=5693&amp;y=7378&amp;id=playthrough_246&amp;link=/checklists/walkthrough.html%23item_246&amp;title=Follow the road South-East to the bridge to grab the Impassable Greatbridge Grace for later.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5693&amp;y=7378&amp;id=playthrough_246&amp;link=/checklists/walkthrough.html%23item_246&amp;title=Follow the road South-East to the bridge to grab the Impassable Greatbridge Grace for later."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_247" id="item_247">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="10" id="playthrough_247" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_247">Caelid/Dragonburrow is now 100% safe to explore! There should be no warnings required!</label>
-                    <a class="ms-2" href="/map.html?x=5693&amp;y=7378&amp;id=playthrough_247&amp;link=/checklists/walkthrough.html%23item_247&amp;title=Caelid/Dragonburrow is now 100% safe to explore! There should be no warnings required!">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5693&amp;y=7378&amp;id=playthrough_247&amp;link=/checklists/walkthrough.html%23item_247&amp;title=Caelid/Dragonburrow is now 100% safe to explore! There should be no warnings required!"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -2787,9 +2255,7 @@
         <div class="card shadow-sm mb-3" id="playthrough_section_11">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_11Col" data-bs-toggle="collapse" href="#playthrough_11Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_11Col" data-bs-toggle="collapse" href="#playthrough_11Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Underground Siofra/Liurnia Lake/Castle Redmane</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="playthrough_totals_11"></span>
             </h4>
@@ -2799,171 +2265,133 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="11" id="playthrough_248" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_248">Starting from the Third Church of Marika, go South and find the Siofra River Well. Go down the lift and grab the Siofra River Well Depths Grace.</label>
-                    <a class="ms-2" href="/map.html?x=4581&amp;y=7032&amp;id=playthrough_248&amp;link=/checklists/walkthrough.html%23item_248&amp;title=Starting from the Third Church of Marika, go South and find the Siofra River Well. Go down the lift and grab the Siofra River Well Depths Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4581&amp;y=7032&amp;id=playthrough_248&amp;link=/checklists/walkthrough.html%23item_248&amp;title=Starting from the Third Church of Marika, go South and find the Siofra River Well. Go down the lift and grab the Siofra River Well Depths Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_249" id="item_249">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="11" id="playthrough_249" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_249">Go through the area and go up the lift then grab the Siofra River Bank Grace</label>
-                    <a class="ms-2" href="/map.html?x=6131&amp;y=14519&amp;id=playthrough_249&amp;link=/checklists/walkthrough.html%23item_249&amp;title=Go through the area and go up the lift then grab the Siofra River Bank Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6131&amp;y=14519&amp;id=playthrough_249&amp;link=/checklists/walkthrough.html%23item_249&amp;title=Go through the area and go up the lift then grab the Siofra River Bank Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_250" id="item_250">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="11" id="playthrough_250" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_250">Head East to the cliffs to talk to Blaidd and exhaust his dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=6366&amp;y=14511&amp;id=playthrough_250&amp;link=/checklists/walkthrough.html%23item_250&amp;title=Head East to the cliffs to talk to Blaidd and exhaust his dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6366&amp;y=14511&amp;id=playthrough_250&amp;link=/checklists/walkthrough.html%23item_250&amp;title=Head East to the cliffs to talk to Blaidd and exhaust his dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_251" id="item_251">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="11" id="playthrough_251" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_251">Talk to Thops at Church of Irith, exhaust his dialogue before giving him the second Glintstone Key.</label>
-                    <a class="ms-2" href="/map.html?x=2911&amp;y=6414&amp;id=playthrough_251&amp;link=/checklists/walkthrough.html%23item_251&amp;title=Talk to Thops at Church of Irith, exhaust his dialogue before giving him the second Glintstone Key.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2911&amp;y=6414&amp;id=playthrough_251&amp;link=/checklists/walkthrough.html%23item_251&amp;title=Talk to Thops at Church of Irith, exhaust his dialogue before giving him the second Glintstone Key."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_252" id="item_252">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="11" id="playthrough_252" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_252">Go to the Schoolhouse Classroom Grace in Raya Lucaria and find Thops corpse just outside, around the corner.</label>
-                    <a class="ms-2" href="/map.html?x=1943&amp;y=4983&amp;id=playthrough_252&amp;link=/checklists/walkthrough.html%23item_252&amp;title=Go to the Schoolhouse Classroom Grace in Raya Lucaria and find Thops corpse just outside, around the corner.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1943&amp;y=4983&amp;id=playthrough_252&amp;link=/checklists/walkthrough.html%23item_252&amp;title=Go to the Schoolhouse Classroom Grace in Raya Lucaria and find Thops corpse just outside, around the corner."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_253" id="item_253">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="11" id="playthrough_253" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_253">Go to Ranni's Rise and head South to Seluvis' Rise, talk to Seluvis and exhaust his dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=1732&amp;y=3803&amp;id=playthrough_253&amp;link=/checklists/walkthrough.html%23item_253&amp;title=Go to Ranni's Rise and head South to Seluvis' Rise, talk to Seluvis and exhaust his dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1732&amp;y=3803&amp;id=playthrough_253&amp;link=/checklists/walkthrough.html%23item_253&amp;title=Go to Ranni's Rise and head South to Seluvis' Rise, talk to Seluvis and exhaust his dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_254" id="item_254">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="11" id="playthrough_254" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_254">Leave Seluvis' Rise and go to the cliffs to the East and hop onto the rampart below. Follow the path and hop down into the building to talk to Pidia and exhaust his dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=1811&amp;y=3730&amp;id=playthrough_254&amp;link=/checklists/walkthrough.html%23item_254&amp;title=Leave Seluvis' Rise and go to the cliffs to the East and hop onto the rampart below. Follow the path and hop down into the building to talk to Pidia and exhaust his dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1811&amp;y=3730&amp;id=playthrough_254&amp;link=/checklists/walkthrough.html%23item_254&amp;title=Leave Seluvis' Rise and go to the cliffs to the East and hop onto the rampart below. Follow the path and hop down into the building to talk to Pidia and exhaust his dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_255" id="item_255">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="11" id="playthrough_255" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_255">Go to Waypoint Ruins, talk to Sellen and exhaust her dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=4239&amp;y=7258&amp;id=playthrough_255&amp;link=/checklists/walkthrough.html%23item_255&amp;title=Go to Waypoint Ruins, talk to Sellen and exhaust her dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4239&amp;y=7258&amp;id=playthrough_255&amp;link=/checklists/walkthrough.html%23item_255&amp;title=Go to Waypoint Ruins, talk to Sellen and exhaust her dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_256" id="item_256">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="11" id="playthrough_256" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_256">Return to Blaidd in Siofra River Well and exhaust his dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=6366&amp;y=14511&amp;id=playthrough_256&amp;link=/checklists/walkthrough.html%23item_256&amp;title=Return to Blaidd in Siofra River Well and exhaust his dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6366&amp;y=14511&amp;id=playthrough_256&amp;link=/checklists/walkthrough.html%23item_256&amp;title=Return to Blaidd in Siofra River Well and exhaust his dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_257" id="item_257">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="11" id="playthrough_257" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_257">Head North to the ruins and climb the staircase onto the wooden platform. Follow this platform to the North-West and find the Nomadic Merchant. Purchase the Nomadic Warriors Cookbook 17 from him.</label>
-                    <a class="ms-2" href="/map.html?x=6392&amp;y=14302&amp;id=playthrough_257&amp;link=/checklists/walkthrough.html%23item_257&amp;title=Head North to the ruins and climb the staircase onto the wooden platform. Follow this platform to the North-West and find the Nomadic Merchant. Purchase the Nomadic Warriors Cookbook 17 from him.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6392&amp;y=14302&amp;id=playthrough_257&amp;link=/checklists/walkthrough.html%23item_257&amp;title=Head North to the ruins and climb the staircase onto the wooden platform. Follow this platform to the North-West and find the Nomadic Merchant. Purchase the Nomadic Warriors Cookbook 17 from him."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_258" id="item_258">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="11" id="playthrough_258" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_258">Go to the Impassable Greatbridge Grace and use the nearby Waypoint to enter Castle Redmane. Proceed through to grab the Chamber Outside the Plaza Grace.</label>
-                    <a class="ms-2" href="/map.html?x=6110&amp;y=7341&amp;id=playthrough_258&amp;link=/checklists/walkthrough.html%23item_258&amp;title=Go to the Impassable Greatbridge Grace and use the nearby Waypoint to enter Castle Redmane. Proceed through to grab the Chamber Outside the Plaza Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6110&amp;y=7341&amp;id=playthrough_258&amp;link=/checklists/walkthrough.html%23item_258&amp;title=Go to the Impassable Greatbridge Grace and use the nearby Waypoint to enter Castle Redmane. Proceed through to grab the Chamber Outside the Plaza Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_259" id="item_259">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="11" id="playthrough_259" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_259">Go into the plaza and talk to Therolina for an emote.</label>
-                    <a class="ms-2" href="/map.html?x=6083&amp;y=7271&amp;id=playthrough_259&amp;link=/checklists/walkthrough.html%23item_259&amp;title=Go into the plaza and talk to Therolina for an emote.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6083&amp;y=7271&amp;id=playthrough_259&amp;link=/checklists/walkthrough.html%23item_259&amp;title=Go into the plaza and talk to Therolina for an emote."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_260" id="item_260">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="11" id="playthrough_260" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_260">Talk to Alexander and Blaidd and exhaust their dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=6104&amp;y=7272&amp;id=playthrough_260&amp;link=/checklists/walkthrough.html%23item_260&amp;title=Talk to Alexander and Blaidd and exhaust their dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6104&amp;y=7272&amp;id=playthrough_260&amp;link=/checklists/walkthrough.html%23item_260&amp;title=Talk to Alexander and Blaidd and exhaust their dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_261" id="item_261">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="11" id="playthrough_261" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_261">Talk to Jerren to unlock Radahn's boss fight.</label>
-                    <a class="ms-2" href="/map.html?x=6095&amp;y=7245&amp;id=playthrough_261&amp;link=/checklists/walkthrough.html%23item_261&amp;title=Talk to Jerren to unlock Radahn's boss fight.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6095&amp;y=7245&amp;id=playthrough_261&amp;link=/checklists/walkthrough.html%23item_261&amp;title=Talk to Jerren to unlock Radahn's boss fight."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_262" id="item_262">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="11" id="playthrough_262" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_262">Go through the church and down the lift to the Waygate that will lead to Radahn then kill Starscourge Radahn (Summoning as many as possible)</label>
-                    <a class="ms-2" href="/map.html?x=6085&amp;y=7119&amp;id=playthrough_262&amp;link=/checklists/walkthrough.html%23item_262&amp;title=Go through the church and down the lift to the Waygate that will lead to Radahn then kill Starscourge Radahn (Summoning as many as possible)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6085&amp;y=7119&amp;id=playthrough_262&amp;link=/checklists/walkthrough.html%23item_262&amp;title=Go through the church and down the lift to the Waygate that will lead to Radahn then kill Starscourge Radahn (Summoning as many as possible)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_263" id="item_263">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="11" id="playthrough_263" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_263">Grab the Starscourge Radahn Grace</label>
-                    <a class="ms-2" href="/map.html?x=6226&amp;y=6824&amp;id=playthrough_263&amp;link=/checklists/walkthrough.html%23item_263&amp;title=Grab the Starscourge Radahn Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6226&amp;y=6824&amp;id=playthrough_263&amp;link=/checklists/walkthrough.html%23item_263&amp;title=Grab the Starscourge Radahn Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_264" id="item_264">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="11" id="playthrough_264" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_264">Talk to Blaidd and exhaust his dialogue</label>
-                    <a class="ms-2" href="/map.html?x=6226&amp;y=6824&amp;id=playthrough_264&amp;link=/checklists/walkthrough.html%23item_264&amp;title=Talk to Blaidd and exhaust his dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6226&amp;y=6824&amp;id=playthrough_264&amp;link=/checklists/walkthrough.html%23item_264&amp;title=Talk to Blaidd and exhaust his dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_265" id="item_265">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="11" id="playthrough_265" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_265">Talk to Alexander and exhaust his dialogue</label>
-                    <a class="ms-2" href="/map.html?x=6226&amp;y=6824&amp;id=playthrough_265&amp;link=/checklists/walkthrough.html%23item_265&amp;title=Talk to Alexander and exhaust his dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6226&amp;y=6824&amp;id=playthrough_265&amp;link=/checklists/walkthrough.html%23item_265&amp;title=Talk to Alexander and exhaust his dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_266" id="item_266">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="11" id="playthrough_266" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_266">Go back to the Chamber Outside the Plaza Grace then go back to the church in the plaza to talk to Jerren and exhaust his dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=6073&amp;y=7197&amp;id=playthrough_266&amp;link=/checklists/walkthrough.html%23item_266&amp;title=Go back to the Chamber Outside the Plaza Grace then go back to the church in the plaza to talk to Jerren and exhaust his dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6073&amp;y=7197&amp;id=playthrough_266&amp;link=/checklists/walkthrough.html%23item_266&amp;title=Go back to the Chamber Outside the Plaza Grace then go back to the church in the plaza to talk to Jerren and exhaust his dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -2973,9 +2401,7 @@
         <div class="card shadow-sm mb-3" id="playthrough_section_12">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_12Col" data-bs-toggle="collapse" href="#playthrough_12Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_12Col" data-bs-toggle="collapse" href="#playthrough_12Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Liurnia Lake/Roundtable</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="playthrough_totals_12"></span>
             </h4>
@@ -2985,162 +2411,126 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="12" id="playthrough_267" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_267">Go to Enia in Roundtable Hold and purchase Radahn's Lion Armor (12,000 runes) from her (it must be a Demigod piece that can be altered).</label>
-                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_267&amp;link=/checklists/walkthrough.html%23item_267&amp;title=Go to Enia in Roundtable Hold and purchase Radahn's Lion Armor (12,000 runes) from her (it must be a Demigod piece that can be altered).">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_267&amp;link=/checklists/walkthrough.html%23item_267&amp;title=Go to Enia in Roundtable Hold and purchase Radahn's Lion Armor (12,000 runes) from her (it must be a Demigod piece that can be altered)."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_268" id="item_268">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="12" id="playthrough_268" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_268">Start at the Liurnia Highway North Grace and then follow the road North to find Alexander again. Craft an Oil Pot using the Nomadic Warriors Cookbook 17. Toss the Oil Pot at him to free him then exhaust his dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=2936&amp;y=5337&amp;id=playthrough_268&amp;link=/checklists/walkthrough.html%23item_268&amp;title=Start at the Liurnia Highway North Grace and then follow the road North to find Alexander again. Craft an Oil Pot using the Nomadic Warriors Cookbook 17. Toss the Oil Pot at him to free him then exhaust his dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2936&amp;y=5337&amp;id=playthrough_268&amp;link=/checklists/walkthrough.html%23item_268&amp;title=Start at the Liurnia Highway North Grace and then follow the road North to find Alexander again. Craft an Oil Pot using the Nomadic Warriors Cookbook 17. Toss the Oil Pot at him to free him then exhaust his dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_269" id="item_269">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="12" id="playthrough_269" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_269">Go to the Main Academy Gate Grace the use the Seal to the North-East to grab the East Raya Lucaria Gate Grace.</label>
-                    <a class="ms-2" href="/map.html?x=1842&amp;y=4745&amp;id=playthrough_269&amp;link=/checklists/walkthrough.html%23item_269&amp;title=Go to the Main Academy Gate Grace the use the Seal to the North-East to grab the East Raya Lucaria Gate Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1842&amp;y=4745&amp;id=playthrough_269&amp;link=/checklists/walkthrough.html%23item_269&amp;title=Go to the Main Academy Gate Grace the use the Seal to the North-East to grab the East Raya Lucaria Gate Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_270" id="item_270">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="12" id="playthrough_270" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_270">Rest at the Grace, talk to Melina and exhaust her dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=2088&amp;y=4323&amp;id=playthrough_270&amp;link=/checklists/walkthrough.html%23item_270&amp;title=Rest at the Grace, talk to Melina and exhaust her dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2088&amp;y=4323&amp;id=playthrough_270&amp;link=/checklists/walkthrough.html%23item_270&amp;title=Rest at the Grace, talk to Melina and exhaust her dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_271" id="item_271">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="12" id="playthrough_271" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_271">Talk to Boc, give him the Gold Sewing Needle and exhaust his dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=2088&amp;y=4323&amp;id=playthrough_271&amp;link=/checklists/walkthrough.html%23item_271&amp;title=Talk to Boc, give him the Gold Sewing Needle and exhaust his dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2088&amp;y=4323&amp;id=playthrough_271&amp;link=/checklists/walkthrough.html%23item_271&amp;title=Talk to Boc, give him the Gold Sewing Needle and exhaust his dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_272" id="item_272">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="12" id="playthrough_272" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_272">Talk to the Finger Reader and exhaust her dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=2122&amp;y=4333&amp;id=playthrough_272&amp;link=/checklists/walkthrough.html%23item_272&amp;title=Talk to the Finger Reader and exhaust her dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2122&amp;y=4333&amp;id=playthrough_272&amp;link=/checklists/walkthrough.html%23item_272&amp;title=Talk to the Finger Reader and exhaust her dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_273" id="item_273">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="12" id="playthrough_273" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_273">Go North-East, into the Grand Lift of Dectus and grab the Grand Lift of Dectus Grace.</label>
-                    <a class="ms-2" href="/map.html?x=2671&amp;y=3774&amp;id=playthrough_273&amp;link=/checklists/walkthrough.html%23item_273&amp;title=Go North-East, into the Grand Lift of Dectus and grab the Grand Lift of Dectus Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2671&amp;y=3774&amp;id=playthrough_273&amp;link=/checklists/walkthrough.html%23item_273&amp;title=Go North-East, into the Grand Lift of Dectus and grab the Grand Lift of Dectus Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_274" id="item_274">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="12" id="playthrough_274" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_274">Rest at the Grace, talk to Melina and exhaust her dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=2671&amp;y=3774&amp;id=playthrough_274&amp;link=/checklists/walkthrough.html%23item_274&amp;title=Rest at the Grace, talk to Melina and exhaust her dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2671&amp;y=3774&amp;id=playthrough_274&amp;link=/checklists/walkthrough.html%23item_274&amp;title=Rest at the Grace, talk to Melina and exhaust her dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_275" id="item_275">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="12" id="playthrough_275" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_275">Go South from the Grand Lift of Dectus and around the cliffs. BEWARE THE EYE OF SAURON! You can choose to go to the tower where the eye is and kill the enemies at the top to destroy the eye, or FLY YOU FOOL! to the South, through the Frenzied Flame Village and up the slope going North to kill the Invader, Festering Fingerprint Vyke for the Fingerprint Grape.</label>
-                    <a class="ms-2" href="/map.html?x=2533&amp;y=4099&amp;id=playthrough_275&amp;link=/checklists/walkthrough.html%23item_275&amp;title=Go South from the Grand Lift of Dectus and around the cliffs. BEWARE THE EYE OF SAURON! You can choose to go to the tower where the eye is and kill the enemies at the top to destroy the eye, or FLY YOU FOOL! to the South, through the Frenzied Flame Village and up the slope going North to kill the Invader, Festering Fingerprint Vyke for the Fingerprint Grape.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2533&amp;y=4099&amp;id=playthrough_275&amp;link=/checklists/walkthrough.html%23item_275&amp;title=Go South from the Grand Lift of Dectus and around the cliffs. BEWARE THE EYE OF SAURON! You can choose to go to the tower where the eye is and kill the enemies at the top to destroy the eye, or FLY YOU FOOL! to the South, through the Frenzied Flame Village and up the slope going North to kill the Invader, Festering Fingerprint Vyke for the Fingerprint Grape."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_276" id="item_276">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="12" id="playthrough_276" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_276">Grab the nearby Church of Inhibition Grace.</label>
-                    <a class="ms-2" href="/map.html?x=2507&amp;y=3999&amp;id=playthrough_276&amp;link=/checklists/walkthrough.html%23item_276&amp;title=Grab the nearby Church of Inhibition Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2507&amp;y=3999&amp;id=playthrough_276&amp;link=/checklists/walkthrough.html%23item_276&amp;title=Grab the nearby Church of Inhibition Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_277" id="item_277">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="12" id="playthrough_277" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_277">Go back to the East Raya Lucaria Gate Grace and head North to grab the Bellum Church Grace.</label>
-                    <a class="ms-2" href="/map.html?x=2185&amp;y=4061&amp;id=playthrough_277&amp;link=/checklists/walkthrough.html%23item_277&amp;title=Go back to the East Raya Lucaria Gate Grace and head North to grab the Bellum Church Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2185&amp;y=4061&amp;id=playthrough_277&amp;link=/checklists/walkthrough.html%23item_277&amp;title=Go back to the East Raya Lucaria Gate Grace and head North to grab the Bellum Church Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_278" id="item_278">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="12" id="playthrough_278" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_278">Talk to Hyetta nearby to give her the Fingerprint Grape and exhaust her dialogue</label>
-                    <a class="ms-2" href="/map.html?x=2185&amp;y=4061&amp;id=playthrough_278&amp;link=/checklists/walkthrough.html%23item_278&amp;title=Talk to Hyetta nearby to give her the Fingerprint Grape and exhaust her dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2185&amp;y=4061&amp;id=playthrough_278&amp;link=/checklists/walkthrough.html%23item_278&amp;title=Talk to Hyetta nearby to give her the Fingerprint Grape and exhaust her dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_279" id="item_279">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="12" id="playthrough_279" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_279">Go down the slope going North/North-East and follow the river to grab the Golden Seed at the end.</label>
-                    <a class="ms-2" href="/map.html?x=2490&amp;y=3661&amp;id=playthrough_279&amp;link=/checklists/walkthrough.html%23item_279&amp;title=Go down the slope going North/North-East and follow the river to grab the Golden Seed at the end.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2490&amp;y=3661&amp;id=playthrough_279&amp;link=/checklists/walkthrough.html%23item_279&amp;title=Go down the slope going North/North-East and follow the river to grab the Golden Seed at the end."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_280" id="item_280">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="12" id="playthrough_280" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_280">Grab the Ravine-Veiled Village Grace nearby.</label>
-                    <a class="ms-2" href="/map.html?x=2562&amp;y=3617&amp;id=playthrough_280&amp;link=/checklists/walkthrough.html%23item_280&amp;title=Grab the Ravine-Veiled Village Grace nearby.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2562&amp;y=3617&amp;id=playthrough_280&amp;link=/checklists/walkthrough.html%23item_280&amp;title=Grab the Ravine-Veiled Village Grace nearby."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_281" id="item_281">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="12" id="playthrough_281" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_281">Climb the ladder and go through the cave to the lift. Continue going from the top of the lift until you make it outside to grab the Ruin-Strewn Precipice Grace.</label>
-                    <a class="ms-2" href="/map.html?x=2571&amp;y=3606&amp;id=playthrough_281&amp;link=/checklists/walkthrough.html%23item_281&amp;title=Climb the ladder and go through the cave to the lift. Continue going from the top of the lift until you make it outside to grab the Ruin-Strewn Precipice Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2571&amp;y=3606&amp;id=playthrough_281&amp;link=/checklists/walkthrough.html%23item_281&amp;title=Climb the ladder and go through the cave to the lift. Continue going from the top of the lift until you make it outside to grab the Ruin-Strewn Precipice Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_282" id="item_282">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="12" id="playthrough_282" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_282">Go up the nearby lift, up the ladder, up the next ladder, and up one more ladder. Then go up the lift to reach the Ruin-Strewn Precipice Overlook Grace.</label>
-                    <a class="ms-2" href="/map.html?x=2468&amp;y=3640&amp;id=playthrough_282&amp;link=/checklists/walkthrough.html%23item_282&amp;title=Go up the nearby lift, up the ladder, up the next ladder, and up one more ladder. Then go up the lift to reach the Ruin-Strewn Precipice Overlook Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2468&amp;y=3640&amp;id=playthrough_282&amp;link=/checklists/walkthrough.html%23item_282&amp;title=Go up the nearby lift, up the ladder, up the next ladder, and up one more ladder. Then go up the lift to reach the Ruin-Strewn Precipice Overlook Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_283" id="item_283">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="12" id="playthrough_283" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_283">Continue forward to the boss room and kill Magma Wyrm Makar (Summoning Great Horned Tragoth, and either Millicent or Blackguard Big Boggart)</label>
-                    <a class="ms-2" href="/map.html?x=2448&amp;y=3607&amp;id=playthrough_283&amp;link=/checklists/walkthrough.html%23item_283&amp;title=Continue forward to the boss room and kill Magma Wyrm Makar (Summoning Great Horned Tragoth, and either Millicent or Blackguard Big Boggart)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2448&amp;y=3607&amp;id=playthrough_283&amp;link=/checklists/walkthrough.html%23item_283&amp;title=Continue forward to the boss room and kill Magma Wyrm Makar (Summoning Great Horned Tragoth, and either Millicent or Blackguard Big Boggart)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_284" id="item_284">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="12" id="playthrough_284" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_284">Grab the Magma Wyrm Makar Grace</label>
-                    <a class="ms-2" href="/map.html?x=2358&amp;y=3594&amp;id=playthrough_284&amp;link=/checklists/walkthrough.html%23item_284&amp;title=Grab the Magma Wyrm Makar Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2358&amp;y=3594&amp;id=playthrough_284&amp;link=/checklists/walkthrough.html%23item_284&amp;title=Grab the Magma Wyrm Makar Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -3150,9 +2540,7 @@
         <div class="card shadow-sm mb-3" id="playthrough_section_13">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_13Col" data-bs-toggle="collapse" href="#playthrough_13Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_13Col" data-bs-toggle="collapse" href="#playthrough_13Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Altus Plateau/Mt. Gelmir</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="playthrough_totals_13"></span>
             </h4>
@@ -3162,306 +2550,238 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="13" id="playthrough_285" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_285">Go up the lift and grab the Abandoned Coffin Grace</label>
-                    <a class="ms-2" href="/map.html?x=2385&amp;y=3516&amp;id=playthrough_285&amp;link=/checklists/walkthrough.html%23item_285&amp;title=Go up the lift and grab the Abandoned Coffin Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2385&amp;y=3516&amp;id=playthrough_285&amp;link=/checklists/walkthrough.html%23item_285&amp;title=Go up the lift and grab the Abandoned Coffin Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_286" id="item_286">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="13" id="playthrough_286" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_286">Head North-East to fight or run past Ancient Dragon Lansseax and grab the Erdtree-Gazing Hill Grace.</label>
-                    <a class="ms-2" href="/map.html?x=2666&amp;y=3407&amp;id=playthrough_286&amp;link=/checklists/walkthrough.html%23item_286&amp;title=Head North-East to fight or run past Ancient Dragon Lansseax and grab the Erdtree-Gazing Hill Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2666&amp;y=3407&amp;id=playthrough_286&amp;link=/checklists/walkthrough.html%23item_286&amp;title=Head North-East to fight or run past Ancient Dragon Lansseax and grab the Erdtree-Gazing Hill Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_287" id="item_287">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="13" id="playthrough_287" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_287">Talk to Millicent nearby</label>
-                    <a class="ms-2" href="/map.html?x=2705&amp;y=3384&amp;id=playthrough_287&amp;link=/checklists/walkthrough.html%23item_287&amp;title=Talk to Millicent nearby">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2705&amp;y=3384&amp;id=playthrough_287&amp;link=/checklists/walkthrough.html%23item_287&amp;title=Talk to Millicent nearby"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_288" id="item_288">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="13" id="playthrough_288" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_288">Go North up the slope to kill the Tibia Mariner at Wyndham Ruins for the Fifth Deathroot</label>
-                    <a class="ms-2" href="/map.html?x=2647&amp;y=3224&amp;id=playthrough_288&amp;link=/checklists/walkthrough.html%23item_288&amp;title=Go North up the slope to kill the Tibia Mariner at Wyndham Ruins for the Fifth Deathroot">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2647&amp;y=3224&amp;id=playthrough_288&amp;link=/checklists/walkthrough.html%23item_288&amp;title=Go North up the slope to kill the Tibia Mariner at Wyndham Ruins for the Fifth Deathroot"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_289" id="item_289">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="13" id="playthrough_289" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_289">Go down the slope East of the Erdtree-Gazing Hill Grace then head North. Hug the cliffs to the right and look for a Spiritjump then use it. Use the next one then go across the bridge to grab the Bridge of Iniquity Grace.</label>
-                    <a class="ms-2" href="/map.html?x=2844&amp;y=2906&amp;id=playthrough_289&amp;link=/checklists/walkthrough.html%23item_289&amp;title=Go down the slope East of the Erdtree-Gazing Hill Grace then head North. Hug the cliffs to the right and look for a Spiritjump then use it. Use the next one then go across the bridge to grab the Bridge of Iniquity Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2844&amp;y=2906&amp;id=playthrough_289&amp;link=/checklists/walkthrough.html%23item_289&amp;title=Go down the slope East of the Erdtree-Gazing Hill Grace then head North. Hug the cliffs to the right and look for a Spiritjump then use it. Use the next one then go across the bridge to grab the Bridge of Iniquity Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_290" id="item_290">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="13" id="playthrough_290" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_290">Continue North-West go past all the Iron Virgins to the end of the path. Kill the Invader Anastasia, Tarnished-Eater at the Corpse-Stench Shack.</label>
-                    <a class="ms-2" href="/map.html?x=2587&amp;y=2688&amp;id=playthrough_290&amp;link=/checklists/walkthrough.html%23item_290&amp;title=Continue North-West go past all the Iron Virgins to the end of the path. Kill the Invader Anastasia, Tarnished-Eater at the Corpse-Stench Shack.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2587&amp;y=2688&amp;id=playthrough_290&amp;link=/checklists/walkthrough.html%23item_290&amp;title=Continue North-West go past all the Iron Virgins to the end of the path. Kill the Invader Anastasia, Tarnished-Eater at the Corpse-Stench Shack."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_291" id="item_291">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="13" id="playthrough_291" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_291">Turn back around and hug the cliffs to the South on your way back until you find a ladder. Climb it to grab the First Mt. Gelmir Campsite Grace.</label>
-                    <a class="ms-2" href="/map.html?x=2715&amp;y=2811&amp;id=playthrough_291&amp;link=/checklists/walkthrough.html%23item_291&amp;title=Turn back around and hug the cliffs to the South on your way back until you find a ladder. Climb it to grab the First Mt. Gelmir Campsite Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2715&amp;y=2811&amp;id=playthrough_291&amp;link=/checklists/walkthrough.html%23item_291&amp;title=Turn back around and hug the cliffs to the South on your way back until you find a ladder. Climb it to grab the First Mt. Gelmir Campsite Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_292" id="item_292">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="13" id="playthrough_292" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_292">Follow the path West until you find a glowing message on the ground telling you to follow the rainbow stones. Follow the stones leading South and look over the edge near the last one to see your good friend Patches again.</label>
-                    <a class="ms-2" href="/map.html?x=2518&amp;y=2743&amp;id=playthrough_292&amp;link=/checklists/walkthrough.html%23item_292&amp;title=Follow the path West until you find a glowing message on the ground telling you to follow the rainbow stones. Follow the stones leading South and look over the edge near the last one to see your good friend Patches again.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2518&amp;y=2743&amp;id=playthrough_292&amp;link=/checklists/walkthrough.html%23item_292&amp;title=Follow the path West until you find a glowing message on the ground telling you to follow the rainbow stones. Follow the stones leading South and look over the edge near the last one to see your good friend Patches again."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_293" id="item_293">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="13" id="playthrough_293" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_293">Follow the path going West to grab the Seethewater Terminus Grace</label>
-                    <a class="ms-2" href="/map.html?x=2045&amp;y=2864&amp;id=playthrough_293&amp;link=/checklists/walkthrough.html%23item_293&amp;title=Follow the path going West to grab the Seethewater Terminus Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2045&amp;y=2864&amp;id=playthrough_293&amp;link=/checklists/walkthrough.html%23item_293&amp;title=Follow the path going West to grab the Seethewater Terminus Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_294" id="item_294">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="13" id="playthrough_294" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_294">Go South-West and kill the Magma Wyrm (optional).</label>
-                    <a class="ms-2" href="/map.html?x=1925&amp;y=3007&amp;id=playthrough_294&amp;link=/checklists/walkthrough.html%23item_294&amp;title=Go South-West and kill the Magma Wyrm (optional).">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1925&amp;y=3007&amp;id=playthrough_294&amp;link=/checklists/walkthrough.html%23item_294&amp;title=Go South-West and kill the Magma Wyrm (optional)."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_295" id="item_295">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="13" id="playthrough_295" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_295">Talk to Alexander who is soaking himself in the lava near the cliffside and exhaust his dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=1967&amp;y=3043&amp;id=playthrough_295&amp;link=/checklists/walkthrough.html%23item_295&amp;title=Talk to Alexander who is soaking himself in the lava near the cliffside and exhaust his dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1967&amp;y=3043&amp;id=playthrough_295&amp;link=/checklists/walkthrough.html%23item_295&amp;title=Talk to Alexander who is soaking himself in the lava near the cliffside and exhaust his dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_296" id="item_296">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="13" id="playthrough_296" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_296">Continue going South-East then East to grab the Craftsman's Shack Grace.</label>
-                    <a class="ms-2" href="/map.html?x=2279&amp;y=3226&amp;id=playthrough_296&amp;link=/checklists/walkthrough.html%23item_296&amp;title=Continue going South-East then East to grab the Craftsman's Shack Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2279&amp;y=3226&amp;id=playthrough_296&amp;link=/checklists/walkthrough.html%23item_296&amp;title=Continue going South-East then East to grab the Craftsman's Shack Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_297" id="item_297">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="13" id="playthrough_297" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_297">Continue East and look to the houses on the left to grab Prattling Pate "You're Beautiful"</label>
-                    <a class="ms-2" href="/map.html?x=2434&amp;y=3129&amp;id=playthrough_297&amp;link=/checklists/walkthrough.html%23item_297&amp;title=Continue East and look to the houses on the left to grab Prattling Pate &quot;You're Beautiful&quot;">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2434&amp;y=3129&amp;id=playthrough_297&amp;link=/checklists/walkthrough.html%23item_297&amp;title=Continue East and look to the houses on the left to grab Prattling Pate &quot;You're Beautiful&quot;"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_298" id="item_298">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="13" id="playthrough_298" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_298">Keep going and fight or run past Demi-Human Queen Maggie to grab the Primeval Sorcerer Azur Grace</label>
-                    <a class="ms-2" href="/map.html?x=2437&amp;y=2997&amp;id=playthrough_298&amp;link=/checklists/walkthrough.html%23item_298&amp;title=Keep going and fight or run past Demi-Human Queen Maggie to grab the Primeval Sorcerer Azur Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2437&amp;y=2997&amp;id=playthrough_298&amp;link=/checklists/walkthrough.html%23item_298&amp;title=Keep going and fight or run past Demi-Human Queen Maggie to grab the Primeval Sorcerer Azur Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_299" id="item_299">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="13" id="playthrough_299" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_299">Talk to Primeval Sorcerer Azur nearby to get the Comet Azur Legendary Sorcery.</label>
-                    <a class="ms-2" href="/map.html?x=2437&amp;y=2997&amp;id=playthrough_299&amp;link=/checklists/walkthrough.html%23item_299&amp;title=Talk to Primeval Sorcerer Azur nearby to get the Comet Azur Legendary Sorcery.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2437&amp;y=2997&amp;id=playthrough_299&amp;link=/checklists/walkthrough.html%23item_299&amp;title=Talk to Primeval Sorcerer Azur nearby to get the Comet Azur Legendary Sorcery."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_300" id="item_300">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="13" id="playthrough_300" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_300">Use the rock bridge nearby to reach and grab the Gelmir Hero's Grave Grace, inside the building and down the elevator.</label>
-                    <a class="ms-2" href="/map.html?x=2537&amp;y=2928&amp;id=playthrough_300&amp;link=/checklists/walkthrough.html%23item_300&amp;title=Use the rock bridge nearby to reach and grab the Gelmir Hero's Grave Grace, inside the building and down the elevator.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2537&amp;y=2928&amp;id=playthrough_300&amp;link=/checklists/walkthrough.html%23item_300&amp;title=Use the rock bridge nearby to reach and grab the Gelmir Hero's Grave Grace, inside the building and down the elevator."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_301" id="item_301">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="13" id="playthrough_301" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_301">Like all the Hero's Graves, the cave is a combat puzzle. The TL;DR is beat the Grave for the Sixth Deathroot, but I'll try to explain how to get through it with the steps below.</label>
-                    <a class="ms-2" href="/map.html?x=2537&amp;y=2928&amp;id=playthrough_301&amp;link=/checklists/walkthrough.html%23item_301&amp;title=Like all the Hero's Graves, the cave is a combat puzzle. The TL;DR is beat the Grave for the Sixth Deathroot, but I'll try to explain how to get through it with the steps below.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2537&amp;y=2928&amp;id=playthrough_301&amp;link=/checklists/walkthrough.html%23item_301&amp;title=Like all the Hero's Graves, the cave is a combat puzzle. The TL;DR is beat the Grave for the Sixth Deathroot, but I'll try to explain how to get through it with the steps below."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_302" id="item_302">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="13" id="playthrough_302" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_302">Start going down the slope, using the opening on either side to dodge the chariots when they come by. For the First Chariot, you will enter a doorway on the left to continue on.</label>
-                    <a class="ms-2" href="/map.html?x=2537&amp;y=2928&amp;id=playthrough_302&amp;link=/checklists/walkthrough.html%23item_302&amp;title=Start going down the slope, using the opening on either side to dodge the chariots when they come by. For the First Chariot, you will enter a doorway on the left to continue on.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2537&amp;y=2928&amp;id=playthrough_302&amp;link=/checklists/walkthrough.html%23item_302&amp;title=Start going down the slope, using the opening on either side to dodge the chariots when they come by. For the First Chariot, you will enter a doorway on the left to continue on."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_303" id="item_303">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="13" id="playthrough_303" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_303">Once you have escaped the First Chariot, go past the enemies and past the Imp Statue Fire Trap. You can hit the trap to turn it off.</label>
-                    <a class="ms-2" href="/map.html?x=2537&amp;y=2928&amp;id=playthrough_303&amp;link=/checklists/walkthrough.html%23item_303&amp;title=Once you have escaped the First Chariot, go past the enemies and past the Imp Statue Fire Trap. You can hit the trap to turn it off.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2537&amp;y=2928&amp;id=playthrough_303&amp;link=/checklists/walkthrough.html%23item_303&amp;title=Once you have escaped the First Chariot, go past the enemies and past the Imp Statue Fire Trap. You can hit the trap to turn it off."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_304" id="item_304">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="13" id="playthrough_304" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_304">Go down the next slope, avoiding the Second Chariot with the openings until you reach the bridge. Fall off the bridge on either side, hugging the edge, to fall onto the ledge below.</label>
-                    <a class="ms-2" href="/map.html?x=2537&amp;y=2928&amp;id=playthrough_304&amp;link=/checklists/walkthrough.html%23item_304&amp;title=Go down the next slope, avoiding the Second Chariot with the openings until you reach the bridge. Fall off the bridge on either side, hugging the edge, to fall onto the ledge below.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2537&amp;y=2928&amp;id=playthrough_304&amp;link=/checklists/walkthrough.html%23item_304&amp;title=Go down the next slope, avoiding the Second Chariot with the openings until you reach the bridge. Fall off the bridge on either side, hugging the edge, to fall onto the ledge below."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_305" id="item_305">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="13" id="playthrough_305" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_305">Go through the doorway the ledge leads you to find a Bloodhound Knight and a ladder. Climb the ladder to find a window, hop out the window onto the wooden rafters and make your way to the center of of it.</label>
-                    <a class="ms-2" href="/map.html?x=2537&amp;y=2928&amp;id=playthrough_305&amp;link=/checklists/walkthrough.html%23item_305&amp;title=Go through the doorway the ledge leads you to find a Bloodhound Knight and a ladder. Climb the ladder to find a window, hop out the window onto the wooden rafters and make your way to the center of of it.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2537&amp;y=2928&amp;id=playthrough_305&amp;link=/checklists/walkthrough.html%23item_305&amp;title=Go through the doorway the ledge leads you to find a Bloodhound Knight and a ladder. Climb the ladder to find a window, hop out the window onto the wooden rafters and make your way to the center of of it."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_306" id="item_306">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="13" id="playthrough_306" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_306">Wait at the center of the rafters for the Second Chariot to slow down just below you then hop onto the open seat on top of it. If you miss, you can easily use the ledge nearby again.</label>
-                    <a class="ms-2" href="/map.html?x=2537&amp;y=2928&amp;id=playthrough_306&amp;link=/checklists/walkthrough.html%23item_306&amp;title=Wait at the center of the rafters for the Second Chariot to slow down just below you then hop onto the open seat on top of it. If you miss, you can easily use the ledge nearby again.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2537&amp;y=2928&amp;id=playthrough_306&amp;link=/checklists/walkthrough.html%23item_306&amp;title=Wait at the center of the rafters for the Second Chariot to slow down just below you then hop onto the open seat on top of it. If you miss, you can easily use the ledge nearby again."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_307" id="item_307">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="13" id="playthrough_307" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_307">Ride it down to the bottom then wait for it to turn around and start going back up to hop off behind and go up the ladder and open the door nearby.</label>
-                    <a class="ms-2" href="/map.html?x=2537&amp;y=2928&amp;id=playthrough_307&amp;link=/checklists/walkthrough.html%23item_307&amp;title=Ride it down to the bottom then wait for it to turn around and start going back up to hop off behind and go up the ladder and open the door nearby.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2537&amp;y=2928&amp;id=playthrough_307&amp;link=/checklists/walkthrough.html%23item_307&amp;title=Ride it down to the bottom then wait for it to turn around and start going back up to hop off behind and go up the ladder and open the door nearby."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_308" id="item_308">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="13" id="playthrough_308" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_308">Go down the stairs and into the boss room to fight and kill the Red Wolf of the Champion to get the Sixth Deathroot.</label>
-                    <a class="ms-2" href="/map.html?x=2537&amp;y=2928&amp;id=playthrough_308&amp;link=/checklists/walkthrough.html%23item_308&amp;title=Go down the stairs and into the boss room to fight and kill the Red Wolf of the Champion to get the Sixth Deathroot.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2537&amp;y=2928&amp;id=playthrough_308&amp;link=/checklists/walkthrough.html%23item_308&amp;title=Go down the stairs and into the boss room to fight and kill the Red Wolf of the Champion to get the Sixth Deathroot."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_309" id="item_309">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="13" id="playthrough_309" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_309">Go back to the Erdtree-Gazing Hill and talk to Rya nearby to enter Volcano Manor</label>
-                    <a class="ms-2" href="/map.html?x=2666&amp;y=3407&amp;id=playthrough_309&amp;link=/checklists/walkthrough.html%23item_309&amp;title=Go back to the Erdtree-Gazing Hill and talk to Rya nearby to enter Volcano Manor">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2666&amp;y=3407&amp;id=playthrough_309&amp;link=/checklists/walkthrough.html%23item_309&amp;title=Go back to the Erdtree-Gazing Hill and talk to Rya nearby to enter Volcano Manor"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_310" id="item_310">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="13" id="playthrough_310" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_310">Grab the Volcano Manor Grace</label>
-                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_310&amp;link=/checklists/walkthrough.html%23item_310&amp;title=Grab the Volcano Manor Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_310&amp;link=/checklists/walkthrough.html%23item_310&amp;title=Grab the Volcano Manor Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_311" id="item_311">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="13" id="playthrough_311" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_311">Talk to Tanith and join the Manor</label>
-                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_311&amp;link=/checklists/walkthrough.html%23item_311&amp;title=Talk to Tanith and join the Manor">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_311&amp;link=/checklists/walkthrough.html%23item_311&amp;title=Talk to Tanith and join the Manor"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_312" id="item_312">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="13" id="playthrough_312" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_312">Open the doors in the hallway to talk to Rya and exhaust her dialogue</label>
-                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_312&amp;link=/checklists/walkthrough.html%23item_312&amp;title=Open the doors in the hallway to talk to Rya and exhaust her dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_312&amp;link=/checklists/walkthrough.html%23item_312&amp;title=Open the doors in the hallway to talk to Rya and exhaust her dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_313" id="item_313">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="13" id="playthrough_313" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_313">Talk to Bernahl and exhaust his dialogue</label>
-                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_313&amp;link=/checklists/walkthrough.html%23item_313&amp;title=Talk to Bernahl and exhaust his dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_313&amp;link=/checklists/walkthrough.html%23item_313&amp;title=Talk to Bernahl and exhaust his dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_314" id="item_314">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="13" id="playthrough_314" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_314">Grab the Letter from Volcano Manor from the table nearby</label>
-                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_314&amp;link=/checklists/walkthrough.html%23item_314&amp;title=Grab the Letter from Volcano Manor from the table nearby">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_314&amp;link=/checklists/walkthrough.html%23item_314&amp;title=Grab the Letter from Volcano Manor from the table nearby"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_315" id="item_315">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="13" id="playthrough_315" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_315">Talk to Diallos and exhaust his dialogue</label>
-                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_315&amp;link=/checklists/walkthrough.html%23item_315&amp;title=Talk to Diallos and exhaust his dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_315&amp;link=/checklists/walkthrough.html%23item_315&amp;title=Talk to Diallos and exhaust his dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_316" id="item_316">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="13" id="playthrough_316" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_316">Talk to Tanith again and exhaust her dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_316&amp;link=/checklists/walkthrough.html%23item_316&amp;title=Talk to Tanith again and exhaust her dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_316&amp;link=/checklists/walkthrough.html%23item_316&amp;title=Talk to Tanith again and exhaust her dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_317" id="item_317">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="13" id="playthrough_317" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_317">Go upstairs and kill the Invader Inquisitor Ghiza</label>
-                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_317&amp;link=/checklists/walkthrough.html%23item_317&amp;title=Go upstairs and kill the Invader Inquisitor Ghiza">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_317&amp;link=/checklists/walkthrough.html%23item_317&amp;title=Go upstairs and kill the Invader Inquisitor Ghiza"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_318" id="item_318">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="13" id="playthrough_318" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_318">Go back down an rest at the Grace then talk to Patches on the way outside and exhaust his dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_318&amp;link=/checklists/walkthrough.html%23item_318&amp;title=Go back down an rest at the Grace then talk to Patches on the way outside and exhaust his dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_318&amp;link=/checklists/walkthrough.html%23item_318&amp;title=Go back down an rest at the Grace then talk to Patches on the way outside and exhaust his dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -3471,9 +2791,7 @@
         <div class="card shadow-sm mb-3" id="playthrough_section_14">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_14Col" data-bs-toggle="collapse" href="#playthrough_14Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_14Col" data-bs-toggle="collapse" href="#playthrough_14Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Sellen Part 1/Volcano Manor Quests Part 1</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="playthrough_totals_14"></span>
             </h4>
@@ -3483,153 +2801,119 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="14" id="playthrough_319" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_319">Go to the Warmaster's Shack Grace in Limgrave and head North to invade and kill Old Knight Istvan at location indicated by the Letter from Volcano Manor</label>
-                    <a class="ms-2" href="/map.html?x=3625&amp;y=6473&amp;id=playthrough_319&amp;link=/checklists/walkthrough.html%23item_319&amp;title=Go to the Warmaster's Shack Grace in Limgrave and head North to invade and kill Old Knight Istvan at location indicated by the Letter from Volcano Manor">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3625&amp;y=6473&amp;id=playthrough_319&amp;link=/checklists/walkthrough.html%23item_319&amp;title=Go to the Warmaster's Shack Grace in Limgrave and head North to invade and kill Old Knight Istvan at location indicated by the Letter from Volcano Manor"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_320" id="item_320">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="14" id="playthrough_320" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_320">Go back to the Waypoint Ruins and talk to Sellen and exhaust her dialogue for the Sellian Sealbreaker</label>
-                    <a class="ms-2" href="/map.html?x=4239&amp;y=7258&amp;id=playthrough_320&amp;link=/checklists/walkthrough.html%23item_320&amp;title=Go back to the Waypoint Ruins and talk to Sellen and exhaust her dialogue for the Sellian Sealbreaker">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4239&amp;y=7258&amp;id=playthrough_320&amp;link=/checklists/walkthrough.html%23item_320&amp;title=Go back to the Waypoint Ruins and talk to Sellen and exhaust her dialogue for the Sellian Sealbreaker"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_321" id="item_321">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="14" id="playthrough_321" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_321">Go to the Church of the Plague Grace and head North-East to find a very large tombstone. Attack or roll into the cliff wall behind the tombstone to grab the Sellia Hideaway Grace.</label>
-                    <a class="ms-2" href="/map.html?x=5873&amp;y=6481&amp;id=playthrough_321&amp;link=/checklists/walkthrough.html%23item_321&amp;title=Go to the Church of the Plague Grace and head North-East to find a very large tombstone. Attack or roll into the cliff wall behind the tombstone to grab the Sellia Hideaway Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5873&amp;y=6481&amp;id=playthrough_321&amp;link=/checklists/walkthrough.html%23item_321&amp;title=Go to the Church of the Plague Grace and head North-East to find a very large tombstone. Attack or roll into the cliff wall behind the tombstone to grab the Sellia Hideaway Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_322" id="item_322">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="14" id="playthrough_322" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_322">Make your way down to the bottom and open the seal to talk to Master Lusat and acquire the Stars of Ruin Legendary Sorcery</label>
-                    <a class="ms-2" href="/map.html?x=5873&amp;y=6481&amp;id=playthrough_322&amp;link=/checklists/walkthrough.html%23item_322&amp;title=Make your way down to the bottom and open the seal to talk to Master Lusat and acquire the Stars of Ruin Legendary Sorcery">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5873&amp;y=6481&amp;id=playthrough_322&amp;link=/checklists/walkthrough.html%23item_322&amp;title=Make your way down to the bottom and open the seal to talk to Master Lusat and acquire the Stars of Ruin Legendary Sorcery"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_323" id="item_323">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="14" id="playthrough_323" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_323">Go just West of the entrance to Sellia Hideaway and use the Spiritjump to grab the Fort Faroth Grace. Head inside Fort Faroth and climb the ladder to grab the Grand Lift of Dectus Medallion(Right)</label>
-                    <a class="ms-2" href="/map.html?x=5938&amp;y=6406&amp;id=playthrough_323&amp;link=/checklists/walkthrough.html%23item_323&amp;title=Go just West of the entrance to Sellia Hideaway and use the Spiritjump to grab the Fort Faroth Grace. Head inside Fort Faroth and climb the ladder to grab the Grand Lift of Dectus Medallion(Right)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5938&amp;y=6406&amp;id=playthrough_323&amp;link=/checklists/walkthrough.html%23item_323&amp;title=Go just West of the entrance to Sellia Hideaway and use the Spiritjump to grab the Fort Faroth Grace. Head inside Fort Faroth and climb the ladder to grab the Grand Lift of Dectus Medallion(Right)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_324" id="item_324">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="14" id="playthrough_324" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_324">Return to Sellen in Waypoint Ruins and exhaust her dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=4239&amp;y=7258&amp;id=playthrough_324&amp;link=/checklists/walkthrough.html%23item_324&amp;title=Return to Sellen in Waypoint Ruins and exhaust her dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4239&amp;y=7258&amp;id=playthrough_324&amp;link=/checklists/walkthrough.html%23item_324&amp;title=Return to Sellen in Waypoint Ruins and exhaust her dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_325" id="item_325">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="14" id="playthrough_325" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_325">Go to the Church of Pilgrimage Grace in Weeping Peninsula and go South-West to grab the Fourth Church of Marika Grace.</label>
-                    <a class="ms-2" href="/map.html?x=3507&amp;y=8001&amp;id=playthrough_325&amp;link=/checklists/walkthrough.html%23item_325&amp;title=Go to the Church of Pilgrimage Grace in Weeping Peninsula and go South-West to grab the Fourth Church of Marika Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3507&amp;y=8001&amp;id=playthrough_325&amp;link=/checklists/walkthrough.html%23item_325&amp;title=Go to the Church of Pilgrimage Grace in Weeping Peninsula and go South-West to grab the Fourth Church of Marika Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_326" id="item_326">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="14" id="playthrough_326" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_326">Go just South of the Fourth Church of Marika and enter the Witchbane Ruins to talk to Sellen and receive Sellen's Primal Glintstone.</label>
-                    <a class="ms-2" href="/map.html?x=3510&amp;y=8063&amp;id=playthrough_326&amp;link=/checklists/walkthrough.html%23item_326&amp;title=Go just South of the Fourth Church of Marika and enter the Witchbane Ruins to talk to Sellen and receive Sellen's Primal Glintstone.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3510&amp;y=8063&amp;id=playthrough_326&amp;link=/checklists/walkthrough.html%23item_326&amp;title=Go just South of the Fourth Church of Marika and enter the Witchbane Ruins to talk to Sellen and receive Sellen's Primal Glintstone."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_327" id="item_327">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="14" id="playthrough_327" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_327">Reload the area to talk to Jerren and exhaust his dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=3510&amp;y=8063&amp;id=playthrough_327&amp;link=/checklists/walkthrough.html%23item_327&amp;title=Reload the area to talk to Jerren and exhaust his dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3510&amp;y=8063&amp;id=playthrough_327&amp;link=/checklists/walkthrough.html%23item_327&amp;title=Reload the area to talk to Jerren and exhaust his dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_328" id="item_328">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="14" id="playthrough_328" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_328">Return to Volcano Manor and talk to Tanith and exhaust her dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_328&amp;link=/checklists/walkthrough.html%23item_328&amp;title=Return to Volcano Manor and talk to Tanith and exhaust her dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_328&amp;link=/checklists/walkthrough.html%23item_328&amp;title=Return to Volcano Manor and talk to Tanith and exhaust her dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_329" id="item_329">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="14" id="playthrough_329" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_329">Talk to Patches for the Letter to Patches and exhaust his dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_329&amp;link=/checklists/walkthrough.html%23item_329&amp;title=Talk to Patches for the Letter to Patches and exhaust his dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_329&amp;link=/checklists/walkthrough.html%23item_329&amp;title=Talk to Patches for the Letter to Patches and exhaust his dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_330" id="item_330">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="14" id="playthrough_330" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_330">Talk to Rya and exhaust her dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_330&amp;link=/checklists/walkthrough.html%23item_330&amp;title=Talk to Rya and exhaust her dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_330&amp;link=/checklists/walkthrough.html%23item_330&amp;title=Talk to Rya and exhaust her dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_331" id="item_331">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="14" id="playthrough_331" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_331">Talk to Bernahl and exhaust his dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_331&amp;link=/checklists/walkthrough.html%23item_331&amp;title=Talk to Bernahl and exhaust his dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_331&amp;link=/checklists/walkthrough.html%23item_331&amp;title=Talk to Bernahl and exhaust his dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_332" id="item_332">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="14" id="playthrough_332" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_332">Grab the second Letter from Volcano Manor on the table</label>
-                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_332&amp;link=/checklists/walkthrough.html%23item_332&amp;title=Grab the second Letter from Volcano Manor on the table">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_332&amp;link=/checklists/walkthrough.html%23item_332&amp;title=Grab the second Letter from Volcano Manor on the table"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_333" id="item_333">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="14" id="playthrough_333" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_333">Talk to Diallos and exhaust his dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_333&amp;link=/checklists/walkthrough.html%23item_333&amp;title=Talk to Diallos and exhaust his dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_333&amp;link=/checklists/walkthrough.html%23item_333&amp;title=Talk to Diallos and exhaust his dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_334" id="item_334">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="14" id="playthrough_334" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_334">Talk to the ghost and exhaust his dialogue. If he is not there, pass time until nightfall.</label>
-                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_334&amp;link=/checklists/walkthrough.html%23item_334&amp;title=Talk to the ghost and exhaust his dialogue. If he is not there, pass time until nightfall.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_334&amp;link=/checklists/walkthrough.html%23item_334&amp;title=Talk to the ghost and exhaust his dialogue. If he is not there, pass time until nightfall."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_336" id="item_336">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="14" id="playthrough_336" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_336">Return to the Bridge of Iniquity Grace and cross the bridge East then use the Spiritjump to the South to jump down the cliff. Use the next Spiritjump to the West to get down to the bottom and head North to invade and kill Rileigh the Idle at the location indicated by the Letter from Volcano Manor.</label>
-                    <a class="ms-2" href="/map.html?x=2874&amp;y=2982&amp;id=playthrough_336&amp;link=/checklists/walkthrough.html%23item_336&amp;title=Return to the Bridge of Iniquity Grace and cross the bridge East then use the Spiritjump to the South to jump down the cliff. Use the next Spiritjump to the West to get down to the bottom and head North to invade and kill Rileigh the Idle at the location indicated by the Letter from Volcano Manor.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2874&amp;y=2982&amp;id=playthrough_336&amp;link=/checklists/walkthrough.html%23item_336&amp;title=Return to the Bridge of Iniquity Grace and cross the bridge East then use the Spiritjump to the South to jump down the cliff. Use the next Spiritjump to the West to get down to the bottom and head North to invade and kill Rileigh the Idle at the location indicated by the Letter from Volcano Manor."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -3639,9 +2923,7 @@
         <div class="card shadow-sm mb-3" id="playthrough_section_15">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_15Col" data-bs-toggle="collapse" href="#playthrough_15Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_15Col" data-bs-toggle="collapse" href="#playthrough_15Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Millicent/Roundtable Hold</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="playthrough_totals_15"></span>
             </h4>
@@ -3651,99 +2933,77 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="15" id="playthrough_337" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_337">Continue North-West to kill the Maleigh Marais, Shaded Castle Castellan.</label>
-                    <a class="ms-2" href="/map.html?x=2717&amp;y=2644&amp;id=playthrough_337&amp;link=/checklists/walkthrough.html%23item_337&amp;title=Continue North-West to kill the Maleigh Marais, Shaded Castle Castellan.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2717&amp;y=2644&amp;id=playthrough_337&amp;link=/checklists/walkthrough.html%23item_337&amp;title=Continue North-West to kill the Maleigh Marais, Shaded Castle Castellan."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_338" id="item_338">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="15" id="playthrough_338" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_338">Go East and find an opening on the West side of the wall you can use to jump onto the ramparts of the Shaded Castle. Follow the rampart South to the end then hop off to climb the ladder to the East. At the top, follow the path North to open the chest and grab the Valkyrie's Prosthesis.</label>
-                    <a class="ms-2" href="/map.html?x=2851&amp;y=2622&amp;id=playthrough_338&amp;link=/checklists/walkthrough.html%23item_338&amp;title=Go East and find an opening on the West side of the wall you can use to jump onto the ramparts of the Shaded Castle. Follow the rampart South to the end then hop off to climb the ladder to the East. At the top, follow the path North to open the chest and grab the Valkyrie's Prosthesis.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2851&amp;y=2622&amp;id=playthrough_338&amp;link=/checklists/walkthrough.html%23item_338&amp;title=Go East and find an opening on the West side of the wall you can use to jump onto the ramparts of the Shaded Castle. Follow the rampart South to the end then hop off to climb the ladder to the East. At the top, follow the path North to open the chest and grab the Valkyrie's Prosthesis."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_339" id="item_339">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="15" id="playthrough_339" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_339">Turn back around and take the path East from the ladder this time. Hop onto the roof below and hop from rooftop to rooftop to grab the Shaded Castle Inner Gate Grace for using at a later time.</label>
-                    <a class="ms-2" href="/map.html?x=2893&amp;y=2639&amp;id=playthrough_339&amp;link=/checklists/walkthrough.html%23item_339&amp;title=Turn back around and take the path East from the ladder this time. Hop onto the roof below and hop from rooftop to rooftop to grab the Shaded Castle Inner Gate Grace for using at a later time.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2893&amp;y=2639&amp;id=playthrough_339&amp;link=/checklists/walkthrough.html%23item_339&amp;title=Turn back around and take the path East from the ladder this time. Hop onto the roof below and hop from rooftop to rooftop to grab the Shaded Castle Inner Gate Grace for using at a later time."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_340" id="item_340">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="15" id="playthrough_340" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_340">Go back to Roundtable Hold, talk to Brother Corhyn and exhaust his dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_340&amp;link=/checklists/walkthrough.html%23item_340&amp;title=Go back to Roundtable Hold, talk to Brother Corhyn and exhaust his dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_340&amp;link=/checklists/walkthrough.html%23item_340&amp;title=Go back to Roundtable Hold, talk to Brother Corhyn and exhaust his dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_341" id="item_341">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="15" id="playthrough_341" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_341">Cuddle with Fia and talk to her to get the Weathered Dagger</label>
-                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_341&amp;link=/checklists/walkthrough.html%23item_341&amp;title=Cuddle with Fia and talk to her to get the Weathered Dagger">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_341&amp;link=/checklists/walkthrough.html%23item_341&amp;title=Cuddle with Fia and talk to her to get the Weathered Dagger"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_342" id="item_342">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="15" id="playthrough_342" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_342">Talk to Roderika and exhaust her dialogue</label>
-                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_342&amp;link=/checklists/walkthrough.html%23item_342&amp;title=Talk to Roderika and exhaust her dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_342&amp;link=/checklists/walkthrough.html%23item_342&amp;title=Talk to Roderika and exhaust her dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_344" id="item_344">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="15" id="playthrough_344" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_344">Talk to D, give him the Weathered Dagger and exhaust his dialogue</label>
-                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_344&amp;link=/checklists/walkthrough.html%23item_344&amp;title=Talk to D, give him the Weathered Dagger and exhaust his dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_344&amp;link=/checklists/walkthrough.html%23item_344&amp;title=Talk to D, give him the Weathered Dagger and exhaust his dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_345" id="item_345">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="15" id="playthrough_345" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_345">Talk to Dung Eater and exhaust his dialogue</label>
-                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_345&amp;link=/checklists/walkthrough.html%23item_345&amp;title=Talk to Dung Eater and exhaust his dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_345&amp;link=/checklists/walkthrough.html%23item_345&amp;title=Talk to Dung Eater and exhaust his dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_346" id="item_346">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="15" id="playthrough_346" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_346">Reload and go into the now open room past the blacksmith to find and loot D's corpse for his armor and Bell Bearing</label>
-                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_346&amp;link=/checklists/walkthrough.html%23item_346&amp;title=Reload and go into the now open room past the blacksmith to find and loot D's corpse for his armor and Bell Bearing">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_346&amp;link=/checklists/walkthrough.html%23item_346&amp;title=Reload and go into the now open room past the blacksmith to find and loot D's corpse for his armor and Bell Bearing"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_347" id="item_347">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="15" id="playthrough_347" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_347">Talk to Fia and exhaust her dialogue</label>
-                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_347&amp;link=/checklists/walkthrough.html%23item_347&amp;title=Talk to Fia and exhaust her dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_347&amp;link=/checklists/walkthrough.html%23item_347&amp;title=Talk to Fia and exhaust her dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_348" id="item_348">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="15" id="playthrough_348" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_348">Return to the Erdtree-Gazing Hill Grace, talk to Millicent nearby to give her the Valkyrie's Prosthesis and exhaust her dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=2666&amp;y=3407&amp;id=playthrough_348&amp;link=/checklists/walkthrough.html%23item_348&amp;title=Return to the Erdtree-Gazing Hill Grace, talk to Millicent nearby to give her the Valkyrie's Prosthesis and exhaust her dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2666&amp;y=3407&amp;id=playthrough_348&amp;link=/checklists/walkthrough.html%23item_348&amp;title=Return to the Erdtree-Gazing Hill Grace, talk to Millicent nearby to give her the Valkyrie's Prosthesis and exhaust her dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -3753,9 +3013,7 @@
         <div class="card shadow-sm mb-3" id="playthrough_section_16">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_16Col" data-bs-toggle="collapse" href="#playthrough_16Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_16Col" data-bs-toggle="collapse" href="#playthrough_16Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Altus Plateau Part One</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="playthrough_totals_16"></span>
             </h4>
@@ -3765,72 +3023,56 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="16" id="playthrough_349" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_349">Head East, across the battlefield and to the road to grab the Altus Highway Junction Grace.</label>
-                    <a class="ms-2" href="/map.html?x=3037&amp;y=3452&amp;id=playthrough_349&amp;link=/checklists/walkthrough.html%23item_349&amp;title=Head East, across the battlefield and to the road to grab the Altus Highway Junction Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3037&amp;y=3452&amp;id=playthrough_349&amp;link=/checklists/walkthrough.html%23item_349&amp;title=Head East, across the battlefield and to the road to grab the Altus Highway Junction Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_350" id="item_350">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="16" id="playthrough_350" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_350">Rest at the Grace, talk to Melina and exhaust her dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=3037&amp;y=3452&amp;id=playthrough_350&amp;link=/checklists/walkthrough.html%23item_350&amp;title=Rest at the Grace, talk to Melina and exhaust her dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3037&amp;y=3452&amp;id=playthrough_350&amp;link=/checklists/walkthrough.html%23item_350&amp;title=Rest at the Grace, talk to Melina and exhaust her dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_351" id="item_351">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="16" id="playthrough_351" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_351">Talk to Boc and exhaust his dialogue</label>
-                    <a class="ms-2" href="/map.html?x=3037&amp;y=3452&amp;id=playthrough_351&amp;link=/checklists/walkthrough.html%23item_351&amp;title=Talk to Boc and exhaust his dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3037&amp;y=3452&amp;id=playthrough_351&amp;link=/checklists/walkthrough.html%23item_351&amp;title=Talk to Boc and exhaust his dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_352" id="item_352">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="16" id="playthrough_352" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_352">Go North-East from the Grace and through the passage to grab the Amber Starlight Shard.</label>
-                    <a class="ms-2" href="/map.html?x=3196&amp;y=3268&amp;id=playthrough_352&amp;link=/checklists/walkthrough.html%23item_352&amp;title=Go North-East from the Grace and through the passage to grab the Amber Starlight Shard.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3196&amp;y=3268&amp;id=playthrough_352&amp;link=/checklists/walkthrough.html%23item_352&amp;title=Go North-East from the Grace and through the passage to grab the Amber Starlight Shard."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_353" id="item_353">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="16" id="playthrough_353" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_353">Follow the road North of the Altus Highway Junction to talk to Brother Corhyn and exhaust his dialogue</label>
-                    <a class="ms-2" href="/map.html?x=3088&amp;y=3323&amp;id=playthrough_353&amp;link=/checklists/walkthrough.html%23item_353&amp;title=Follow the road North of the Altus Highway Junction to talk to Brother Corhyn and exhaust his dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3088&amp;y=3323&amp;id=playthrough_353&amp;link=/checklists/walkthrough.html%23item_353&amp;title=Follow the road North of the Altus Highway Junction to talk to Brother Corhyn and exhaust his dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_354" id="item_354">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="16" id="playthrough_354" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_354">Grab Map (Altus Plateau) nearby</label>
-                    <a class="ms-2" href="/map.html?x=3096&amp;y=3270&amp;id=playthrough_354&amp;link=/checklists/walkthrough.html%23item_354&amp;title=Grab Map (Altus Plateau) nearby">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3096&amp;y=3270&amp;id=playthrough_354&amp;link=/checklists/walkthrough.html%23item_354&amp;title=Grab Map (Altus Plateau) nearby"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_355" id="item_355">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="16" id="playthrough_355" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_355">Go North-West to find the Second Church of Marika. Talk to Yura and exhaust his dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=2989&amp;y=3151&amp;id=playthrough_355&amp;link=/checklists/walkthrough.html%23item_355&amp;title=Go North-West to find the Second Church of Marika. Talk to Yura and exhaust his dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2989&amp;y=3151&amp;id=playthrough_355&amp;link=/checklists/walkthrough.html%23item_355&amp;title=Go North-West to find the Second Church of Marika. Talk to Yura and exhaust his dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_356" id="item_356">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="16" id="playthrough_356" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_356">Kill the Invader Eleonora, Violet Bloody Finger</label>
-                    <a class="ms-2" href="/map.html?x=2989&amp;y=3151&amp;id=playthrough_356&amp;link=/checklists/walkthrough.html%23item_356&amp;title=Kill the Invader Eleonora, Violet Bloody Finger">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2989&amp;y=3151&amp;id=playthrough_356&amp;link=/checklists/walkthrough.html%23item_356&amp;title=Kill the Invader Eleonora, Violet Bloody Finger"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -3840,9 +3082,7 @@
         <div class="card shadow-sm mb-3" id="playthrough_section_17">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_17Col" data-bs-toggle="collapse" href="#playthrough_17Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_17Col" data-bs-toggle="collapse" href="#playthrough_17Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Underground Crater</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="playthrough_totals_17"></span>
             </h4>
@@ -3852,135 +3092,105 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="17" id="playthrough_357" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_357">Go back to East Limgrave and find a note from Blaidd just outside of the newly formed crater, West of Fort Haight</label>
-                    <a class="ms-2" href="/map.html?x=4458&amp;y=7207&amp;id=playthrough_357&amp;link=/checklists/walkthrough.html%23item_357&amp;title=Go back to East Limgrave and find a note from Blaidd just outside of the newly formed crater, West of Fort Haight">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4458&amp;y=7207&amp;id=playthrough_357&amp;link=/checklists/walkthrough.html%23item_357&amp;title=Go back to East Limgrave and find a note from Blaidd just outside of the newly formed crater, West of Fort Haight"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_358" id="item_358">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="17" id="playthrough_358" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_358">Go to the Forlorn Hound Evergaol and free Blaidd</label>
-                    <a class="ms-2" href="/map.html?x=4207&amp;y=7666&amp;id=playthrough_358&amp;link=/checklists/walkthrough.html%23item_358&amp;title=Go to the Forlorn Hound Evergaol and free Blaidd">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4207&amp;y=7666&amp;id=playthrough_358&amp;link=/checklists/walkthrough.html%23item_358&amp;title=Go to the Forlorn Hound Evergaol and free Blaidd"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_359" id="item_359">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="17" id="playthrough_359" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_359">Go to the Road to the Manor Grace, talk to Iji and exhaust his dialogue</label>
-                    <a class="ms-2" href="/map.html?x=1718&amp;y=4037&amp;id=playthrough_359&amp;link=/checklists/walkthrough.html%23item_359&amp;title=Go to the Road to the Manor Grace, talk to Iji and exhaust his dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1718&amp;y=4037&amp;id=playthrough_359&amp;link=/checklists/walkthrough.html%23item_359&amp;title=Go to the Road to the Manor Grace, talk to Iji and exhaust his dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_360" id="item_360">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="17" id="playthrough_360" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_360">Head into the crater West of Fort Haight and grab the Nokron, Eternal City Grace.</label>
-                    <a class="ms-2" href="/map.html?x=5747&amp;y=14546&amp;id=playthrough_360&amp;link=/checklists/walkthrough.html%23item_360&amp;title=Head into the crater West of Fort Haight and grab the Nokron, Eternal City Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5747&amp;y=14546&amp;id=playthrough_360&amp;link=/checklists/walkthrough.html%23item_360&amp;title=Head into the crater West of Fort Haight and grab the Nokron, Eternal City Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_361" id="item_361">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="17" id="playthrough_361" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_361">Follow the path forward to reach and kill the boss, Mimic Tear</label>
-                    <a class="ms-2" href="/map.html?x=6054&amp;y=14623&amp;id=playthrough_361&amp;link=/checklists/walkthrough.html%23item_361&amp;title=Follow the path forward to reach and kill the boss, Mimic Tear">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6054&amp;y=14623&amp;id=playthrough_361&amp;link=/checklists/walkthrough.html%23item_361&amp;title=Follow the path forward to reach and kill the boss, Mimic Tear"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_362" id="item_362">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="17" id="playthrough_362" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_362">Grab the Mimic Tear Grace</label>
-                    <a class="ms-2" href="/map.html?x=6054&amp;y=14623&amp;id=playthrough_362&amp;link=/checklists/walkthrough.html%23item_362&amp;title=Grab the Mimic Tear Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6054&amp;y=14623&amp;id=playthrough_362&amp;link=/checklists/walkthrough.html%23item_362&amp;title=Grab the Mimic Tear Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_363" id="item_363">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="17" id="playthrough_363" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_363">Cross the bridge going North-East and then follow the cliffs to the West to find the Ancestral Woods Grace hidden in the cliffs.</label>
-                    <a class="ms-2" href="/map.html?x=6059&amp;y=14320&amp;id=playthrough_363&amp;link=/checklists/walkthrough.html%23item_363&amp;title=Cross the bridge going North-East and then follow the cliffs to the West to find the Ancestral Woods Grace hidden in the cliffs.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6059&amp;y=14320&amp;id=playthrough_363&amp;link=/checklists/walkthrough.html%23item_363&amp;title=Cross the bridge going North-East and then follow the cliffs to the West to find the Ancestral Woods Grace hidden in the cliffs."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_364" id="item_364">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="17" id="playthrough_364" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_364">Follow the path of rooftops South-West and on the way you can find the Black Whetblade</label>
-                    <a class="ms-2" href="/map.html?x=6068&amp;y=14426&amp;id=playthrough_364&amp;link=/checklists/walkthrough.html%23item_364&amp;title=Follow the path of rooftops South-West and on the way you can find the Black Whetblade">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6068&amp;y=14426&amp;id=playthrough_364&amp;link=/checklists/walkthrough.html%23item_364&amp;title=Follow the path of rooftops South-West and on the way you can find the Black Whetblade"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_365" id="item_365">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="17" id="playthrough_365" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_365">Keep following the path to the bottom to find the Night's Sacred Ground Grace</label>
-                    <a class="ms-2" href="/map.html?x=5996&amp;y=14480&amp;id=playthrough_365&amp;link=/checklists/walkthrough.html%23item_365&amp;title=Keep following the path to the bottom to find the Night's Sacred Ground Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5996&amp;y=14480&amp;id=playthrough_365&amp;link=/checklists/walkthrough.html%23item_365&amp;title=Keep following the path to the bottom to find the Night's Sacred Ground Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_366" id="item_366">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="17" id="playthrough_366" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_366">From the Grace, go North-East and into the building to find the Fingerslayer Blade inside of the chest(For the purposes of this Walkthrough DO NOT GIVE IT TO RANNI YET)</label>
-                    <a class="ms-2" href="/map.html?x=6070&amp;y=14348&amp;id=playthrough_366&amp;link=/checklists/walkthrough.html%23item_366&amp;title=From the Grace, go North-East and into the building to find the Fingerslayer Blade inside of the chest(For the purposes of this Walkthrough DO NOT GIVE IT TO RANNI YET)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6070&amp;y=14348&amp;id=playthrough_366&amp;link=/checklists/walkthrough.html%23item_366&amp;title=From the Grace, go North-East and into the building to find the Fingerslayer Blade inside of the chest(For the purposes of this Walkthrough DO NOT GIVE IT TO RANNI YET)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_367" id="item_367">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="17" id="playthrough_367" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_367">Use the Waygate nearby to return to the Ancestral Woods.</label>
-                    <a class="ms-2" href="/map.html?x=6052&amp;y=14354&amp;id=playthrough_367&amp;link=/checklists/walkthrough.html%23item_367&amp;title=Use the Waygate nearby to return to the Ancestral Woods.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6052&amp;y=14354&amp;id=playthrough_367&amp;link=/checklists/walkthrough.html%23item_367&amp;title=Use the Waygate nearby to return to the Ancestral Woods."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_368" id="item_368">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="17" id="playthrough_368" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_368">Head North-East from the Ancestral Woods Grace, past the altar, into the forest and along the hidden path to reach the Aqueduct-Facing Cliffs Grace.</label>
-                    <a class="ms-2" href="/map.html?x=6219&amp;y=14020&amp;id=playthrough_368&amp;link=/checklists/walkthrough.html%23item_368&amp;title=Head North-East from the Ancestral Woods Grace, past the altar, into the forest and along the hidden path to reach the Aqueduct-Facing Cliffs Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6219&amp;y=14020&amp;id=playthrough_368&amp;link=/checklists/walkthrough.html%23item_368&amp;title=Head North-East from the Ancestral Woods Grace, past the altar, into the forest and along the hidden path to reach the Aqueduct-Facing Cliffs Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_369" id="item_369">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="17" id="playthrough_369" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_369">Follow this path until you find a man kneeling next to a balcony outside the boss room. This man is D's Brother, D, Beholder of Death and he wants you to give him D's Armor</label>
-                    <a class="ms-2" href="/map.html?x=6380&amp;y=13929&amp;id=playthrough_369&amp;link=/checklists/walkthrough.html%23item_369&amp;title=Follow this path until you find a man kneeling next to a balcony outside the boss room. This man is D's Brother, D, Beholder of Death and he wants you to give him D's Armor">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6380&amp;y=13929&amp;id=playthrough_369&amp;link=/checklists/walkthrough.html%23item_369&amp;title=Follow this path until you find a man kneeling next to a balcony outside the boss room. This man is D's Brother, D, Beholder of Death and he wants you to give him D's Armor"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_370" id="item_370">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="17" id="playthrough_370" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_370">Summon D, Beholder of Death and go into the boss room to kill the boss, Valiant Gargoyle Duo</label>
-                    <a class="ms-2" href="/map.html?x=6360&amp;y=13912&amp;id=playthrough_370&amp;link=/checklists/walkthrough.html%23item_370&amp;title=Summon D, Beholder of Death and go into the boss room to kill the boss, Valiant Gargoyle Duo">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6360&amp;y=13912&amp;id=playthrough_370&amp;link=/checklists/walkthrough.html%23item_370&amp;title=Summon D, Beholder of Death and go into the boss room to kill the boss, Valiant Gargoyle Duo"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_371" id="item_371">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="17" id="playthrough_371" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_371">Grab the Great Waterfall Basin Grace.</label>
-                    <a class="ms-2" href="/map.html?x=6224&amp;y=13874&amp;id=playthrough_371&amp;link=/checklists/walkthrough.html%23item_371&amp;title=Grab the Great Waterfall Basin Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6224&amp;y=13874&amp;id=playthrough_371&amp;link=/checklists/walkthrough.html%23item_371&amp;title=Grab the Great Waterfall Basin Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -3990,9 +3200,7 @@
         <div class="card shadow-sm mb-3" id="playthrough_section_18">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_18Col" data-bs-toggle="collapse" href="#playthrough_18Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_18Col" data-bs-toggle="collapse" href="#playthrough_18Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Altus Plateau Part Two</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="playthrough_totals_18"></span>
             </h4>
@@ -4002,180 +3210,140 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="18" id="playthrough_372" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_372">Go to the Altus Highway Junction Grace, follow the road North until you reach the bridge and grab the Forest-Spanning Greatbridge Grace</label>
-                    <a class="ms-2" href="/map.html?x=3310&amp;y=3063&amp;id=playthrough_372&amp;link=/checklists/walkthrough.html%23item_372&amp;title=Go to the Altus Highway Junction Grace, follow the road North until you reach the bridge and grab the Forest-Spanning Greatbridge Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3310&amp;y=3063&amp;id=playthrough_372&amp;link=/checklists/walkthrough.html%23item_372&amp;title=Go to the Altus Highway Junction Grace, follow the road North until you reach the bridge and grab the Forest-Spanning Greatbridge Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_373" id="item_373">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="18" id="playthrough_373" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_373">Talk to the Finger Reader nearby and exhaust her dialogue</label>
-                    <a class="ms-2" href="/map.html?x=3307&amp;y=3074&amp;id=playthrough_373&amp;link=/checklists/walkthrough.html%23item_373&amp;title=Talk to the Finger Reader nearby and exhaust her dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3307&amp;y=3074&amp;id=playthrough_373&amp;link=/checklists/walkthrough.html%23item_373&amp;title=Talk to the Finger Reader nearby and exhaust her dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_374" id="item_374">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="18" id="playthrough_374" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_374">Use the Waygate on the bridge to reach the other side of the bridge and talk to Goldmask</label>
-                    <a class="ms-2" href="/map.html?x=3310&amp;y=3063&amp;id=playthrough_374&amp;link=/checklists/walkthrough.html%23item_374&amp;title=Use the Waygate on the bridge to reach the other side of the bridge and talk to Goldmask">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3310&amp;y=3063&amp;id=playthrough_374&amp;link=/checklists/walkthrough.html%23item_374&amp;title=Use the Waygate on the bridge to reach the other side of the bridge and talk to Goldmask"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_375" id="item_375">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="18" id="playthrough_375" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_375">Return to Brother Corhyn and exhaust his dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_375&amp;link=/checklists/walkthrough.html%23item_375&amp;title=Return to Brother Corhyn and exhaust his dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_375&amp;link=/checklists/walkthrough.html%23item_375&amp;title=Return to Brother Corhyn and exhaust his dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_376" id="item_376">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="18" id="playthrough_376" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_376">Return to Goldmask's location, talk to Brother Corhyn and exhaust his dialogue</label>
-                    <a class="ms-2" href="/map.html?x=3274&amp;y=2645&amp;id=playthrough_376&amp;link=/checklists/walkthrough.html%23item_376&amp;title=Return to Goldmask's location, talk to Brother Corhyn and exhaust his dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3274&amp;y=2645&amp;id=playthrough_376&amp;link=/checklists/walkthrough.html%23item_376&amp;title=Return to Goldmask's location, talk to Brother Corhyn and exhaust his dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_377" id="item_377">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="18" id="playthrough_377" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_377">Talk to Goldmask</label>
-                    <a class="ms-2" href="/map.html?x=3274&amp;y=2645&amp;id=playthrough_377&amp;link=/checklists/walkthrough.html%23item_377&amp;title=Talk to Goldmask">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3274&amp;y=2645&amp;id=playthrough_377&amp;link=/checklists/walkthrough.html%23item_377&amp;title=Talk to Goldmask"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_378" id="item_378">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="18" id="playthrough_378" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_378">Follow the road East from the bridge and grab the Windmill Village Grace.</label>
-                    <a class="ms-2" href="/map.html?x=3534&amp;y=2631&amp;id=playthrough_378&amp;link=/checklists/walkthrough.html%23item_378&amp;title=Follow the road East from the bridge and grab the Windmill Village Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3534&amp;y=2631&amp;id=playthrough_378&amp;link=/checklists/walkthrough.html%23item_378&amp;title=Follow the road East from the bridge and grab the Windmill Village Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_379" id="item_379">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="18" id="playthrough_379" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_379">Go through the village and kill the boss, Godskin Apostle</label>
-                    <a class="ms-2" href="/map.html?x=3669&amp;y=2509&amp;id=playthrough_379&amp;link=/checklists/walkthrough.html%23item_379&amp;title=Go through the village and kill the boss, Godskin Apostle">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3669&amp;y=2509&amp;id=playthrough_379&amp;link=/checklists/walkthrough.html%23item_379&amp;title=Go through the village and kill the boss, Godskin Apostle"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_380" id="item_380">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="18" id="playthrough_380" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_380">Grab the Windmill Heights Grace</label>
-                    <a class="ms-2" href="/map.html?x=3673&amp;y=2469&amp;id=playthrough_380&amp;link=/checklists/walkthrough.html%23item_380&amp;title=Grab the Windmill Heights Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3673&amp;y=2469&amp;id=playthrough_380&amp;link=/checklists/walkthrough.html%23item_380&amp;title=Grab the Windmill Heights Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_381" id="item_381">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="18" id="playthrough_381" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_381">Talk to Millicent nearby and exhaust her dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=3675&amp;y=2481&amp;id=playthrough_381&amp;link=/checklists/walkthrough.html%23item_381&amp;title=Talk to Millicent nearby and exhaust her dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3675&amp;y=2481&amp;id=playthrough_381&amp;link=/checklists/walkthrough.html%23item_381&amp;title=Talk to Millicent nearby and exhaust her dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_382" id="item_382">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="18" id="playthrough_382" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_382">Follow the road South-East from the Windmill Village, through the opening in the wall and grab the Outer Wall Battleground Grace</label>
-                    <a class="ms-2" href="/map.html?x=3914&amp;y=3021&amp;id=playthrough_382&amp;link=/checklists/walkthrough.html%23item_382&amp;title=Follow the road South-East from the Windmill Village, through the opening in the wall and grab the Outer Wall Battleground Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3914&amp;y=3021&amp;id=playthrough_382&amp;link=/checklists/walkthrough.html%23item_382&amp;title=Follow the road South-East from the Windmill Village, through the opening in the wall and grab the Outer Wall Battleground Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_383" id="item_383">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="18" id="playthrough_383" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_383">Rest at the Grace, talk to Melina and exhaust her dialogue</label>
-                    <a class="ms-2" href="/map.html?x=3914&amp;y=3021&amp;id=playthrough_383&amp;link=/checklists/walkthrough.html%23item_383&amp;title=Rest at the Grace, talk to Melina and exhaust her dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3914&amp;y=3021&amp;id=playthrough_383&amp;link=/checklists/walkthrough.html%23item_383&amp;title=Rest at the Grace, talk to Melina and exhaust her dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_383_1" id="item_383_1">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="18" id="playthrough_383_1" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_383_1">Head South-East and fight Margit, The Fell Omen who is currently disguised as a common servant on the battlefield</label>
-                    <a class="ms-2" href="/map.html?x=3870&amp;y=3099&amp;id=playthrough_383_1&amp;link=/checklists/walkthrough.html%23item_383_1&amp;title=Head South-East and fight Margit, The Fell Omen who is currently disguised as a common servant on the battlefield">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3870&amp;y=3099&amp;id=playthrough_383_1&amp;link=/checklists/walkthrough.html%23item_383_1&amp;title=Head South-East and fight Margit, The Fell Omen who is currently disguised as a common servant on the battlefield"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_384" id="item_384">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="18" id="playthrough_384" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_384">Follow the road South and talk to the Finger Reader</label>
-                    <a class="ms-2" href="/map.html?x=3845&amp;y=3253&amp;id=playthrough_384&amp;link=/checklists/walkthrough.html%23item_384&amp;title=Follow the road South and talk to the Finger Reader">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3845&amp;y=3253&amp;id=playthrough_384&amp;link=/checklists/walkthrough.html%23item_384&amp;title=Follow the road South and talk to the Finger Reader"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_385" id="item_385">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="18" id="playthrough_385" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_385">Head South-West and grab the Outer Wall Phantom Tree Grace</label>
-                    <a class="ms-2" href="/map.html?x=3661&amp;y=3502&amp;id=playthrough_385&amp;link=/checklists/walkthrough.html%23item_385&amp;title=Head South-West and grab the Outer Wall Phantom Tree Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3661&amp;y=3502&amp;id=playthrough_385&amp;link=/checklists/walkthrough.html%23item_385&amp;title=Head South-West and grab the Outer Wall Phantom Tree Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_386" id="item_386">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="18" id="playthrough_386" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_386">Grab Map (Leyndell, Royal Capital)</label>
-                    <a class="ms-2" href="/map.html?x=3683&amp;y=3497&amp;id=playthrough_386&amp;link=/checklists/walkthrough.html%23item_386&amp;title=Grab Map (Leyndell, Royal Capital)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3683&amp;y=3497&amp;id=playthrough_386&amp;link=/checklists/walkthrough.html%23item_386&amp;title=Grab Map (Leyndell, Royal Capital)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_387" id="item_387">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="18" id="playthrough_387" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_387">Follow the road South-East and grab the Minor Erdtree Church Grace</label>
-                    <a class="ms-2" href="/map.html?x=3851&amp;y=3767&amp;id=playthrough_387&amp;link=/checklists/walkthrough.html%23item_387&amp;title=Follow the road South-East and grab the Minor Erdtree Church Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3851&amp;y=3767&amp;id=playthrough_387&amp;link=/checklists/walkthrough.html%23item_387&amp;title=Follow the road South-East and grab the Minor Erdtree Church Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_388" id="item_388">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="18" id="playthrough_388" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_388">Rest at the Grace, talk to Melina and exhaust her dialogue</label>
-                    <a class="ms-2" href="/map.html?x=3851&amp;y=3767&amp;id=playthrough_388&amp;link=/checklists/walkthrough.html%23item_388&amp;title=Rest at the Grace, talk to Melina and exhaust her dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3851&amp;y=3767&amp;id=playthrough_388&amp;link=/checklists/walkthrough.html%23item_388&amp;title=Rest at the Grace, talk to Melina and exhaust her dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_389" id="item_389">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="18" id="playthrough_389" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_389">Return to the Outer Wall Battleground Grace and head East to summon Millicent and Great Horned Tragoth and kill the boss, Draconic Tree Sentinel</label>
-                    <a class="ms-2" href="/map.html?x=4498&amp;y=3179&amp;id=playthrough_389&amp;link=/checklists/walkthrough.html%23item_389&amp;title=Return to the Outer Wall Battleground Grace and head East to summon Millicent and Great Horned Tragoth and kill the boss, Draconic Tree Sentinel">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4498&amp;y=3179&amp;id=playthrough_389&amp;link=/checklists/walkthrough.html%23item_389&amp;title=Return to the Outer Wall Battleground Grace and head East to summon Millicent and Great Horned Tragoth and kill the boss, Draconic Tree Sentinel"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_390" id="item_390">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="18" id="playthrough_390" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_390">Go onto the bridge South-West and grab the Capital Rampart Grace.</label>
-                    <a class="ms-2" href="/map.html?x=4443&amp;y=3255&amp;id=playthrough_390&amp;link=/checklists/walkthrough.html%23item_390&amp;title=Go onto the bridge South-West and grab the Capital Rampart Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4443&amp;y=3255&amp;id=playthrough_390&amp;link=/checklists/walkthrough.html%23item_390&amp;title=Go onto the bridge South-West and grab the Capital Rampart Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -4185,9 +3353,7 @@
         <div class="card shadow-sm mb-3" id="playthrough_section_19">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_19Col" data-bs-toggle="collapse" href="#playthrough_19Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_19Col" data-bs-toggle="collapse" href="#playthrough_19Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Volcano Manor Part Two</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="playthrough_totals_19"></span>
             </h4>
@@ -4197,180 +3363,140 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="19" id="playthrough_335" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_335">Return to the Magma Wyrm Makar Grace to invade and kill Great Horned Tragoth at the location indicated by the Letter to Patches.</label>
-                    <a class="ms-2" href="/map.html?x=2372&amp;y=3603&amp;id=playthrough_335&amp;link=/checklists/walkthrough.html%23item_335&amp;title=Return to the Magma Wyrm Makar Grace to invade and kill Great Horned Tragoth at the location indicated by the Letter to Patches.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2372&amp;y=3603&amp;id=playthrough_335&amp;link=/checklists/walkthrough.html%23item_335&amp;title=Return to the Magma Wyrm Makar Grace to invade and kill Great Horned Tragoth at the location indicated by the Letter to Patches."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_391" id="item_391">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="19" id="playthrough_391" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_391">Return to Volcano Manor, talk to Patches and exhaust his dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_391&amp;link=/checklists/walkthrough.html%23item_391&amp;title=Return to Volcano Manor, talk to Patches and exhaust his dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_391&amp;link=/checklists/walkthrough.html%23item_391&amp;title=Return to Volcano Manor, talk to Patches and exhaust his dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_392" id="item_392">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="19" id="playthrough_392" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_392">Talk to Tanith and exhaust her dialogue</label>
-                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_392&amp;link=/checklists/walkthrough.html%23item_392&amp;title=Talk to Tanith and exhaust her dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_392&amp;link=/checklists/walkthrough.html%23item_392&amp;title=Talk to Tanith and exhaust her dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_393" id="item_393">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="19" id="playthrough_393" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_393">Talk to Rya and exhaust her dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_393&amp;link=/checklists/walkthrough.html%23item_393&amp;title=Talk to Rya and exhaust her dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_393&amp;link=/checklists/walkthrough.html%23item_393&amp;title=Talk to Rya and exhaust her dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_394" id="item_394">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="19" id="playthrough_394" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_394">Talk to Bernahl and exhaust his dialogue for Letter to Bernahl</label>
-                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_394&amp;link=/checklists/walkthrough.html%23item_394&amp;title=Talk to Bernahl and exhaust his dialogue for Letter to Bernahl">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_394&amp;link=/checklists/walkthrough.html%23item_394&amp;title=Talk to Bernahl and exhaust his dialogue for Letter to Bernahl"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_395" id="item_395">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="19" id="playthrough_395" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_395">Grab the Red Letter from the table.</label>
-                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_395&amp;link=/checklists/walkthrough.html%23item_395&amp;title=Grab the Red Letter from the table.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_395&amp;link=/checklists/walkthrough.html%23item_395&amp;title=Grab the Red Letter from the table."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_396" id="item_396">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="19" id="playthrough_396" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_396">Talk to Tanith and exhaust her dialogue</label>
-                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_396&amp;link=/checklists/walkthrough.html%23item_396&amp;title=Talk to Tanith and exhaust her dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_396&amp;link=/checklists/walkthrough.html%23item_396&amp;title=Talk to Tanith and exhaust her dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_397" id="item_397">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="19" id="playthrough_397" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_397">Reload, talk to Patches again and exhaust his dialogue</label>
-                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_397&amp;link=/checklists/walkthrough.html%23item_397&amp;title=Reload, talk to Patches again and exhaust his dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_397&amp;link=/checklists/walkthrough.html%23item_397&amp;title=Reload, talk to Patches again and exhaust his dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_398" id="item_398">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="19" id="playthrough_398" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_398">Talk to Rya again and exhaust her dialogue</label>
-                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_398&amp;link=/checklists/walkthrough.html%23item_398&amp;title=Talk to Rya again and exhaust her dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_398&amp;link=/checklists/walkthrough.html%23item_398&amp;title=Talk to Rya again and exhaust her dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_399" id="item_399">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="19" id="playthrough_399" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_399">Go into the first room on the right down the hall and roll into the wall to break the illusion. Follow the path down the stairs to grab the Prison Town Church Grace.</label>
-                    <a class="ms-2" href="/map.html?x=2127&amp;y=2948&amp;id=playthrough_399&amp;link=/checklists/walkthrough.html%23item_399&amp;title=Go into the first room on the right down the hall and roll into the wall to break the illusion. Follow the path down the stairs to grab the Prison Town Church Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2127&amp;y=2948&amp;id=playthrough_399&amp;link=/checklists/walkthrough.html%23item_399&amp;title=Go into the first room on the right down the hall and roll into the wall to break the illusion. Follow the path down the stairs to grab the Prison Town Church Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_400" id="item_400">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="19" id="playthrough_400" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_400">Follow the path down to the bottom, into the lava then going South-West, up the stairs, up the lift and use the lever next to the boss room to raise the bridge for a shortcut.</label>
-                    <a class="ms-2" href="/map.html?x=2208&amp;y=3019&amp;id=playthrough_400&amp;link=/checklists/walkthrough.html%23item_400&amp;title=Follow the path down to the bottom, into the lava then going South-West, up the stairs, up the lift and use the lever next to the boss room to raise the bridge for a shortcut.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2208&amp;y=3019&amp;id=playthrough_400&amp;link=/checklists/walkthrough.html%23item_400&amp;title=Follow the path down to the bottom, into the lava then going South-West, up the stairs, up the lift and use the lever next to the boss room to raise the bridge for a shortcut."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_401" id="item_401">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="19" id="playthrough_401" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_401">Go into the boss room and kill the boss, Godskin Noble.</label>
-                    <a class="ms-2" href="/map.html?x=2249&amp;y=3052&amp;id=playthrough_401&amp;link=/checklists/walkthrough.html%23item_401&amp;title=Go into the boss room and kill the boss, Godskin Noble.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2249&amp;y=3052&amp;id=playthrough_401&amp;link=/checklists/walkthrough.html%23item_401&amp;title=Go into the boss room and kill the boss, Godskin Noble."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_402" id="item_402">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="19" id="playthrough_402" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_402">Grab the Temple of Eiglay Grace</label>
-                    <a class="ms-2" href="/map.html?x=2242&amp;y=3043&amp;id=playthrough_402&amp;link=/checklists/walkthrough.html%23item_402&amp;title=Grab the Temple of Eiglay Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2242&amp;y=3043&amp;id=playthrough_402&amp;link=/checklists/walkthrough.html%23item_402&amp;title=Grab the Temple of Eiglay Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_403" id="item_403">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="19" id="playthrough_403" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_403">Grab the Serpent's Amnion from the altar.</label>
-                    <a class="ms-2" href="/map.html?x=2251&amp;y=3053&amp;id=playthrough_403&amp;link=/checklists/walkthrough.html%23item_403&amp;title=Grab the Serpent's Amnion from the altar.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2251&amp;y=3053&amp;id=playthrough_403&amp;link=/checklists/walkthrough.html%23item_403&amp;title=Grab the Serpent's Amnion from the altar."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_404" id="item_404">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="19" id="playthrough_404" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_404">Return to Rya and exhaust her dialogue</label>
-                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_404&amp;link=/checklists/walkthrough.html%23item_404&amp;title=Return to Rya and exhaust her dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_404&amp;link=/checklists/walkthrough.html%23item_404&amp;title=Return to Rya and exhaust her dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_405" id="item_405">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="19" id="playthrough_405" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_405">Reload, talk to Tanith and exhaust her dialogue</label>
-                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_405&amp;link=/checklists/walkthrough.html%23item_405&amp;title=Reload, talk to Tanith and exhaust her dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_405&amp;link=/checklists/walkthrough.html%23item_405&amp;title=Reload, talk to Tanith and exhaust her dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_406" id="item_406">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="19" id="playthrough_406" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_406">Return to the Temple of Eiglay and tak the lift up. Go outside and hop off the balcony to the lava below. Cross the bridge of slugs, across the gap, up the slope and run past the Iron Virgin into the lava to find a room where you will find Rya. (You have the option to give her the potion but I don't recommend it)</label>
-                    <a class="ms-2" href="/map.html?x=2205&amp;y=2978&amp;id=playthrough_406&amp;link=/checklists/walkthrough.html%23item_406&amp;title=Return to the Temple of Eiglay and tak the lift up. Go outside and hop off the balcony to the lava below. Cross the bridge of slugs, across the gap, up the slope and run past the Iron Virgin into the lava to find a room where you will find Rya. (You have the option to give her the potion but I don't recommend it)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2205&amp;y=2978&amp;id=playthrough_406&amp;link=/checklists/walkthrough.html%23item_406&amp;title=Return to the Temple of Eiglay and tak the lift up. Go outside and hop off the balcony to the lava below. Cross the bridge of slugs, across the gap, up the slope and run past the Iron Virgin into the lava to find a room where you will find Rya. (You have the option to give her the potion but I don't recommend it)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_407" id="item_407">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="19" id="playthrough_407" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_407">Follow the path out and then up the ladder and take the path going left. Go into the temple, open the door, then up the stairs and into the room above the entrance where you will find an Imp Statue and use it (if you accidentally go the path with the Waygate, DO NOT TAKE THE WAYGATE)</label>
-                    <a class="ms-2" href="/map.html?x=2146&amp;y=2887&amp;id=playthrough_407&amp;link=/checklists/walkthrough.html%23item_407&amp;title=Follow the path out and then up the ladder and take the path going left. Go into the temple, open the door, then up the stairs and into the room above the entrance where you will find an Imp Statue and use it (if you accidentally go the path with the Waygate, DO NOT TAKE THE WAYGATE)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2146&amp;y=2887&amp;id=playthrough_407&amp;link=/checklists/walkthrough.html%23item_407&amp;title=Follow the path out and then up the ladder and take the path going left. Go into the temple, open the door, then up the stairs and into the room above the entrance where you will find an Imp Statue and use it (if you accidentally go the path with the Waygate, DO NOT TAKE THE WAYGATE)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_408" id="item_408">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="19" id="playthrough_408" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_408">Go into the room and make your way to the bottom and grab the Seedbed Curse.</label>
-                    <a class="ms-2" href="/map.html?x=2126&amp;y=2898&amp;id=playthrough_408&amp;link=/checklists/walkthrough.html%23item_408&amp;title=Go into the room and make your way to the bottom and grab the Seedbed Curse.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2126&amp;y=2898&amp;id=playthrough_408&amp;link=/checklists/walkthrough.html%23item_408&amp;title=Go into the room and make your way to the bottom and grab the Seedbed Curse."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_409" id="item_409">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="19" id="playthrough_409" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_409">You can now continue along this path to unlock a shortcut to this area by opening the door in front of Patches</label>
-                    <a class="ms-2" href="/map.html?x=2202&amp;y=2873&amp;id=playthrough_409&amp;link=/checklists/walkthrough.html%23item_409&amp;title=You can now continue along this path to unlock a shortcut to this area by opening the door in front of Patches">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2202&amp;y=2873&amp;id=playthrough_409&amp;link=/checklists/walkthrough.html%23item_409&amp;title=You can now continue along this path to unlock a shortcut to this area by opening the door in front of Patches"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -4380,9 +3506,7 @@
         <div class="card shadow-sm mb-3" id="playthrough_section_20">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_20Col" data-bs-toggle="collapse" href="#playthrough_20Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_20Col" data-bs-toggle="collapse" href="#playthrough_20Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Loathsome Dung-Eater</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="playthrough_totals_20"></span>
             </h4>
@@ -4392,126 +3516,98 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="20" id="playthrough_410" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_410">Return to Roundtable Hold and talk to the Dung Eater and exhaust his dialogue for the Sewer-Gaol Key</label>
-                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_410&amp;link=/checklists/walkthrough.html%23item_410&amp;title=Return to Roundtable Hold and talk to the Dung Eater and exhaust his dialogue for the Sewer-Gaol Key">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_410&amp;link=/checklists/walkthrough.html%23item_410&amp;title=Return to Roundtable Hold and talk to the Dung Eater and exhaust his dialogue for the Sewer-Gaol Key"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_411" id="item_411">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="20" id="playthrough_411" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_411">Go to the Capital Rampart Grace just inside of Leyndell and follow the path into the city to grab the East Capital Rampart Grace.</label>
-                    <a class="ms-2" href="/map.html?x=4465&amp;y=3400&amp;id=playthrough_411&amp;link=/checklists/walkthrough.html%23item_411&amp;title=Go to the Capital Rampart Grace just inside of Leyndell and follow the path into the city to grab the East Capital Rampart Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4465&amp;y=3400&amp;id=playthrough_411&amp;link=/checklists/walkthrough.html%23item_411&amp;title=Go to the Capital Rampart Grace just inside of Leyndell and follow the path into the city to grab the East Capital Rampart Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_412" id="item_412">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="20" id="playthrough_412" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_412">Rest at the Grace to talk to Melina and exhaust her dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=4465&amp;y=3400&amp;id=playthrough_412&amp;link=/checklists/walkthrough.html%23item_412&amp;title=Rest at the Grace to talk to Melina and exhaust her dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4465&amp;y=3400&amp;id=playthrough_412&amp;link=/checklists/walkthrough.html%23item_412&amp;title=Rest at the Grace to talk to Melina and exhaust her dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_413" id="item_413">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="20" id="playthrough_413" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_413">Talk to Boc and exhaust his dialogue. When he asks for a Larval Tear, Use Prattling Pate You're Beautiful on him then talk to him again and exhaust his dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=4465&amp;y=3400&amp;id=playthrough_413&amp;link=/checklists/walkthrough.html%23item_413&amp;title=Talk to Boc and exhaust his dialogue. When he asks for a Larval Tear, Use Prattling Pate You're Beautiful on him then talk to him again and exhaust his dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4465&amp;y=3400&amp;id=playthrough_413&amp;link=/checklists/walkthrough.html%23item_413&amp;title=Talk to Boc and exhaust his dialogue. When he asks for a Larval Tear, Use Prattling Pate You're Beautiful on him then talk to him again and exhaust his dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_477" id="item_477">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="20" id="playthrough_477" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_477">Starting from the East Capital Rampart Grace, make your way to the center of Leyndell and grab the Avenue Balcony Grace.</label>
-                    <a class="ms-2" href="/map.html?x=4316&amp;y=3506&amp;id=playthrough_477&amp;link=/checklists/walkthrough.html%23item_477&amp;title=Starting from the East Capital Rampart Grace, make your way to the center of Leyndell and grab the Avenue Balcony Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4316&amp;y=3506&amp;id=playthrough_477&amp;link=/checklists/walkthrough.html%23item_477&amp;title=Starting from the East Capital Rampart Grace, make your way to the center of Leyndell and grab the Avenue Balcony Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_414" id="item_414">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="20" id="playthrough_414" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_414">Go down the stairs and then jump off the ledge to the left and find the nearby well to enter the sewers and grab the Underground Roadside Grace</label>
-                    <a class="ms-2" href="/map.html?x=4350&amp;y=3486&amp;id=playthrough_414&amp;link=/checklists/walkthrough.html%23item_414&amp;title=Go down the stairs and then jump off the ledge to the left and find the nearby well to enter the sewers and grab the Underground Roadside Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4350&amp;y=3486&amp;id=playthrough_414&amp;link=/checklists/walkthrough.html%23item_414&amp;title=Go down the stairs and then jump off the ledge to the left and find the nearby well to enter the sewers and grab the Underground Roadside Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_415" id="item_415">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="20" id="playthrough_415" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_415">From the Grace, leave the room and go left and hop down the open grate on the left. Run past all the rats and plants to climb the ladder. Kill or run past the giants hands and open the door to the cell to find and talk to the Dung Eater and exhaust his dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=4302&amp;y=3441&amp;id=playthrough_415&amp;link=/checklists/walkthrough.html%23item_415&amp;title=From the Grace, leave the room and go left and hop down the open grate on the left. Run past all the rats and plants to climb the ladder. Kill or run past the giants hands and open the door to the cell to find and talk to the Dung Eater and exhaust his dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4302&amp;y=3441&amp;id=playthrough_415&amp;link=/checklists/walkthrough.html%23item_415&amp;title=From the Grace, leave the room and go left and hop down the open grate on the left. Run past all the rats and plants to climb the ladder. Kill or run past the giants hands and open the door to the cell to find and talk to the Dung Eater and exhaust his dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_416" id="item_416">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="20" id="playthrough_416" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_416">Return to Roundtable Hold and read the note where Dung-Eater was</label>
-                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_416&amp;link=/checklists/walkthrough.html%23item_416&amp;title=Return to Roundtable Hold and read the note where Dung-Eater was">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_416&amp;link=/checklists/walkthrough.html%23item_416&amp;title=Return to Roundtable Hold and read the note where Dung-Eater was"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_417" id="item_417">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="20" id="playthrough_417" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_417">Talk to Roderika and exhaust her dialogue</label>
-                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_417&amp;link=/checklists/walkthrough.html%23item_417&amp;title=Talk to Roderika and exhaust her dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_417&amp;link=/checklists/walkthrough.html%23item_417&amp;title=Talk to Roderika and exhaust her dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_418" id="item_418">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="20" id="playthrough_418" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_418">From the Capital Rampart Grace, go North-East then follow the road until you can take the path South to reach the moat just outside the wall. Once there, talk to Blackguard Big Boggart, buy some Boiled Crab and exhaust his dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=4259&amp;y=3153&amp;id=playthrough_418&amp;link=/checklists/walkthrough.html%23item_418&amp;title=From the Capital Rampart Grace, go North-East then follow the road until you can take the path South to reach the moat just outside the wall. Once there, talk to Blackguard Big Boggart, buy some Boiled Crab and exhaust his dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4259&amp;y=3153&amp;id=playthrough_418&amp;link=/checklists/walkthrough.html%23item_418&amp;title=From the Capital Rampart Grace, go North-East then follow the road until you can take the path South to reach the moat just outside the wall. Once there, talk to Blackguard Big Boggart, buy some Boiled Crab and exhaust his dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_419" id="item_419">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="20" id="playthrough_419" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_419">Reload the area and talk to Blackguard Big Boggart again and exhaust his dialogue to loot him.</label>
-                    <a class="ms-2" href="/map.html?x=4259&amp;y=3153&amp;id=playthrough_419&amp;link=/checklists/walkthrough.html%23item_419&amp;title=Reload the area and talk to Blackguard Big Boggart again and exhaust his dialogue to loot him.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4259&amp;y=3153&amp;id=playthrough_419&amp;link=/checklists/walkthrough.html%23item_419&amp;title=Reload the area and talk to Blackguard Big Boggart again and exhaust his dialogue to loot him."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_420" id="item_420">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="20" id="playthrough_420" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_420">Walk around the water nearby and kill the Invader Dung-Eater</label>
-                    <a class="ms-2" href="/map.html?x=4310&amp;y=3173&amp;id=playthrough_420&amp;link=/checklists/walkthrough.html%23item_420&amp;title=Walk around the water nearby and kill the Invader Dung-Eater">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4310&amp;y=3173&amp;id=playthrough_420&amp;link=/checklists/walkthrough.html%23item_420&amp;title=Walk around the water nearby and kill the Invader Dung-Eater"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_421" id="item_421">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="20" id="playthrough_421" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_421">Return to the Dung-Eater in Roundtable Hold and exhaust his dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_421&amp;link=/checklists/walkthrough.html%23item_421&amp;title=Return to the Dung-Eater in Roundtable Hold and exhaust his dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_421&amp;link=/checklists/walkthrough.html%23item_421&amp;title=Return to the Dung-Eater in Roundtable Hold and exhaust his dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_421_1" id="item_421_1">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="20" id="playthrough_421_1" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_421_1">Talk to Roderika and exhaust her dialogue</label>
-                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_421_1&amp;link=/checklists/walkthrough.html%23item_421_1&amp;title=Talk to Roderika and exhaust her dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_421_1&amp;link=/checklists/walkthrough.html%23item_421_1&amp;title=Talk to Roderika and exhaust her dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -4521,9 +3617,7 @@
         <div class="card shadow-sm mb-3" id="playthrough_section_21">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_21Col" data-bs-toggle="collapse" href="#playthrough_21Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_21Col" data-bs-toggle="collapse" href="#playthrough_21Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Sellen Part Two/Seluvis</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="playthrough_totals_21"></span>
             </h4>
@@ -4533,81 +3627,63 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="21" id="playthrough_422" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_422">From here you now have the freedom to choose between giving Seluvis' Potion to Gideon (nothing happens), Dung-Eater (you get Dung Eater Puppet and can't finish his questline) or Nepheli (You get Nepheli Loux Puppet and can't finish Nepheli's, Kenneth's or Gostoc's questlines). For the purpose of this Walkthrough, Dung Eater will be sacrificed cause he deserves it.</label>
-                    <a class="ms-2" href="/map.html?x=4302&amp;y=3441&amp;id=playthrough_422&amp;link=/checklists/walkthrough.html%23item_422&amp;title=From here you now have the freedom to choose between giving Seluvis' Potion to Gideon (nothing happens), Dung-Eater (you get Dung Eater Puppet and can't finish his questline) or Nepheli (You get Nepheli Loux Puppet and can't finish Nepheli's, Kenneth's or Gostoc's questlines). For the purpose of this Walkthrough, Dung Eater will be sacrificed cause he deserves it.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4302&amp;y=3441&amp;id=playthrough_422&amp;link=/checklists/walkthrough.html%23item_422&amp;title=From here you now have the freedom to choose between giving Seluvis' Potion to Gideon (nothing happens), Dung-Eater (you get Dung Eater Puppet and can't finish his questline) or Nepheli (You get Nepheli Loux Puppet and can't finish Nepheli's, Kenneth's or Gostoc's questlines). For the purpose of this Walkthrough, Dung Eater will be sacrificed cause he deserves it."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_423" id="item_423">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="21" id="playthrough_423" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_423">Return to Dung Eater in the Sewers and use Seluvis' Potion on him. After giving him the potion, kill him(this will let you get both the puppet and his gear)</label>
-                    <a class="ms-2" href="/map.html?x=4302&amp;y=3441&amp;id=playthrough_423&amp;link=/checklists/walkthrough.html%23item_423&amp;title=Return to Dung Eater in the Sewers and use Seluvis' Potion on him. After giving him the potion, kill him(this will let you get both the puppet and his gear)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4302&amp;y=3441&amp;id=playthrough_423&amp;link=/checklists/walkthrough.html%23item_423&amp;title=Return to Dung Eater in the Sewers and use Seluvis' Potion on him. After giving him the potion, kill him(this will let you get both the puppet and his gear)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_424" id="item_424">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="21" id="playthrough_424" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_424">Go to Ranni's Rise and go into the nearby ruins to find an Illusory Floor, hiding a staircase going down. Enter the room to find a bunch of puppets stuck in place. Break the Illusory Wall in the back to find a Sellen Puppet and interact with it to use Sellen's Primal Glintstone on it.</label>
-                    <a class="ms-2" href="/map.html?x=1664&amp;y=3666&amp;id=playthrough_424&amp;link=/checklists/walkthrough.html%23item_424&amp;title=Go to Ranni's Rise and go into the nearby ruins to find an Illusory Floor, hiding a staircase going down. Enter the room to find a bunch of puppets stuck in place. Break the Illusory Wall in the back to find a Sellen Puppet and interact with it to use Sellen's Primal Glintstone on it.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1664&amp;y=3666&amp;id=playthrough_424&amp;link=/checklists/walkthrough.html%23item_424&amp;title=Go to Ranni's Rise and go into the nearby ruins to find an Illusory Floor, hiding a staircase going down. Enter the room to find a bunch of puppets stuck in place. Break the Illusory Wall in the back to find a Sellen Puppet and interact with it to use Sellen's Primal Glintstone on it."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_425" id="item_425">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="21" id="playthrough_425" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_425">Talk to Sellen and exhaust her dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=1664&amp;y=3666&amp;id=playthrough_425&amp;link=/checklists/walkthrough.html%23item_425&amp;title=Talk to Sellen and exhaust her dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1664&amp;y=3666&amp;id=playthrough_425&amp;link=/checklists/walkthrough.html%23item_425&amp;title=Talk to Sellen and exhaust her dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_426" id="item_426">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="21" id="playthrough_426" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_426">Make sure to interact with the note next to where the Illusory Wall was.</label>
-                    <a class="ms-2" href="/map.html?x=1664&amp;y=3666&amp;id=playthrough_426&amp;link=/checklists/walkthrough.html%23item_426&amp;title=Make sure to interact with the note next to where the Illusory Wall was.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1664&amp;y=3666&amp;id=playthrough_426&amp;link=/checklists/walkthrough.html%23item_426&amp;title=Make sure to interact with the note next to where the Illusory Wall was."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_427" id="item_427">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="21" id="playthrough_427" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_427">Go talk to Seluvis and exhaust his dialogue to gain access to buying spells and a puppet from him. Buy all the spells and a puppet. Note that you will need to have at least one Starlight Shard in your inventory in order to get the puppet. Starlight Shards can be found at at little statues that look like half-filled cups all over the map.</label>
-                    <a class="ms-2" href="/map.html?x=1732&amp;y=3803&amp;id=playthrough_427&amp;link=/checklists/walkthrough.html%23item_427&amp;title=Go talk to Seluvis and exhaust his dialogue to gain access to buying spells and a puppet from him. Buy all the spells and a puppet. Note that you will need to have at least one Starlight Shard in your inventory in order to get the puppet. Starlight Shards can be found at at little statues that look like half-filled cups all over the map.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1732&amp;y=3803&amp;id=playthrough_427&amp;link=/checklists/walkthrough.html%23item_427&amp;title=Go talk to Seluvis and exhaust his dialogue to gain access to buying spells and a puppet from him. Buy all the spells and a puppet. Note that you will need to have at least one Starlight Shard in your inventory in order to get the puppet. Starlight Shards can be found at at little statues that look like half-filled cups all over the map."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_428" id="item_428">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="21" id="playthrough_428" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_428">Either grab another Starlight Shard or leave one and pick it back up. Afterwards reload and talk to Seluvis again, asking for more puppets for him to open his puppet shop.</label>
-                    <a class="ms-2" href="/map.html?x=1732&amp;y=3803&amp;id=playthrough_428&amp;link=/checklists/walkthrough.html%23item_428&amp;title=Either grab another Starlight Shard or leave one and pick it back up. Afterwards reload and talk to Seluvis again, asking for more puppets for him to open his puppet shop.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1732&amp;y=3803&amp;id=playthrough_428&amp;link=/checklists/walkthrough.html%23item_428&amp;title=Either grab another Starlight Shard or leave one and pick it back up. Afterwards reload and talk to Seluvis again, asking for more puppets for him to open his puppet shop."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_428_1" id="item_428_1">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="21" id="playthrough_428_1" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_428_1">Buy another puppet and talk to him again. He will ask you to get him the Amber Starlight. Note that if he doesn't ask for the item, you will have to buy all of his current puppets</label>
-                    <a class="ms-2" href="/map.html?x=1732&amp;y=3803&amp;id=playthrough_428_1&amp;link=/checklists/walkthrough.html%23item_428_1&amp;title=Buy another puppet and talk to him again. He will ask you to get him the Amber Starlight. Note that if he doesn't ask for the item, you will have to buy all of his current puppets">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1732&amp;y=3803&amp;id=playthrough_428_1&amp;link=/checklists/walkthrough.html%23item_428_1&amp;title=Buy another puppet and talk to him again. He will ask you to get him the Amber Starlight. Note that if he doesn't ask for the item, you will have to buy all of his current puppets"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_429" id="item_429">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="21" id="playthrough_429" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_429">Give him the Amber Starlight to finish his quest and talk to him one more time to get rewarded.(if you talk to him again, he will give you a potion to give to Ranni but I recommend not doing so. If you do you will need to seek absolution at the Church of Vows to continue Ranni's quest)</label>
-                    <a class="ms-2" href="/map.html?x=1732&amp;y=3803&amp;id=playthrough_429&amp;link=/checklists/walkthrough.html%23item_429&amp;title=Give him the Amber Starlight to finish his quest and talk to him one more time to get rewarded.(if you talk to him again, he will give you a potion to give to Ranni but I recommend not doing so. If you do you will need to seek absolution at the Church of Vows to continue Ranni's quest)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1732&amp;y=3803&amp;id=playthrough_429&amp;link=/checklists/walkthrough.html%23item_429&amp;title=Give him the Amber Starlight to finish his quest and talk to him one more time to get rewarded.(if you talk to him again, he will give you a potion to give to Ranni but I recommend not doing so. If you do you will need to seek absolution at the Church of Vows to continue Ranni's quest)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -4617,9 +3693,7 @@
         <div class="card shadow-sm mb-3" id="playthrough_section_22">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_22Col" data-bs-toggle="collapse" href="#playthrough_22Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_22Col" data-bs-toggle="collapse" href="#playthrough_22Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Liurnia Lake/Roundtable Hold</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="playthrough_totals_22"></span>
             </h4>
@@ -4629,99 +3703,77 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="22" id="playthrough_430" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_430">Talk to Ranni in Ranni's Rise and give her the Fingerslayer Blade to get the Carian Inverted Statue.</label>
-                    <a class="ms-2" href="/map.html?x=1576&amp;y=3700&amp;id=playthrough_430&amp;link=/checklists/walkthrough.html%23item_430&amp;title=Talk to Ranni in Ranni's Rise and give her the Fingerslayer Blade to get the Carian Inverted Statue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1576&amp;y=3700&amp;id=playthrough_430&amp;link=/checklists/walkthrough.html%23item_430&amp;title=Talk to Ranni in Ranni's Rise and give her the Fingerslayer Blade to get the Carian Inverted Statue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_431" id="item_431">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="22" id="playthrough_431" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_431">Go to the Church of Vows and head South-East to grab the Eastern Tableland Grace</label>
-                    <a class="ms-2" href="/map.html?x=2742&amp;y=4788&amp;id=playthrough_431&amp;link=/checklists/walkthrough.html%23item_431&amp;title=Go to the Church of Vows and head South-East to grab the Eastern Tableland Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2742&amp;y=4788&amp;id=playthrough_431&amp;link=/checklists/walkthrough.html%23item_431&amp;title=Go to the Church of Vows and head South-East to grab the Eastern Tableland Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_432" id="item_432">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="22" id="playthrough_432" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_432">Continue East then South to grab the Study Hall Entrance Grace</label>
-                    <a class="ms-2" href="/map.html?x=2904&amp;y=5140&amp;id=playthrough_432&amp;link=/checklists/walkthrough.html%23item_432&amp;title=Continue East then South to grab the Study Hall Entrance Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2904&amp;y=5140&amp;id=playthrough_432&amp;link=/checklists/walkthrough.html%23item_432&amp;title=Continue East then South to grab the Study Hall Entrance Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_433" id="item_433">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="22" id="playthrough_433" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_433">Use the Carian Inverted Statue on the altar to trigger a cutscene that change the Carian Study Hall</label>
-                    <a class="ms-2" href="/map.html?x=2904&amp;y=5140&amp;id=playthrough_433&amp;link=/checklists/walkthrough.html%23item_433&amp;title=Use the Carian Inverted Statue on the altar to trigger a cutscene that change the Carian Study Hall">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2904&amp;y=5140&amp;id=playthrough_433&amp;link=/checklists/walkthrough.html%23item_433&amp;title=Use the Carian Inverted Statue on the altar to trigger a cutscene that change the Carian Study Hall"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_434" id="item_434">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="22" id="playthrough_434" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_434">Make your way through the Carian Study Hall to the top to grab the Liurnia Tower Bridge Grace</label>
-                    <a class="ms-2" href="/map.html?x=2973&amp;y=5195&amp;id=playthrough_434&amp;link=/checklists/walkthrough.html%23item_434&amp;title=Make your way through the Carian Study Hall to the top to grab the Liurnia Tower Bridge Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2973&amp;y=5195&amp;id=playthrough_434&amp;link=/checklists/walkthrough.html%23item_434&amp;title=Make your way through the Carian Study Hall to the top to grab the Liurnia Tower Bridge Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_434_1" id="item_434_1">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="22" id="playthrough_434_1" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_434_1">Continue forward, through the door and up the lift to grab the Divine Tower of Liurnia Grace</label>
-                    <a class="ms-2" href="/map.html?x=3373&amp;y=5130&amp;id=playthrough_434_1&amp;link=/checklists/walkthrough.html%23item_434_1&amp;title=Continue forward, through the door and up the lift to grab the Divine Tower of Liurnia Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3373&amp;y=5130&amp;id=playthrough_434_1&amp;link=/checklists/walkthrough.html%23item_434_1&amp;title=Continue forward, through the door and up the lift to grab the Divine Tower of Liurnia Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_434_2" id="item_434_2">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="22" id="playthrough_434_2" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_434_2">Continue up the stairs to grab the Cursemark of Death</label>
-                    <a class="ms-2" href="/map.html?x=3345&amp;y=5135&amp;id=playthrough_434_2&amp;link=/checklists/walkthrough.html%23item_434_2&amp;title=Continue up the stairs to grab the Cursemark of Death">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3345&amp;y=5135&amp;id=playthrough_434_2&amp;link=/checklists/walkthrough.html%23item_434_2&amp;title=Continue up the stairs to grab the Cursemark of Death"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_435" id="item_435">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="22" id="playthrough_435" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_435">Go back to Roundtable Hold and loot Rogier's corpse.</label>
-                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_435&amp;link=/checklists/walkthrough.html%23item_435&amp;title=Go back to Roundtable Hold and loot Rogier's corpse.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_435&amp;link=/checklists/walkthrough.html%23item_435&amp;title=Go back to Roundtable Hold and loot Rogier's corpse."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_436" id="item_436">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="22" id="playthrough_436" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_436">Talk to Roderika and exhaust her dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_436&amp;link=/checklists/walkthrough.html%23item_436&amp;title=Talk to Roderika and exhaust her dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_436&amp;link=/checklists/walkthrough.html%23item_436&amp;title=Talk to Roderika and exhaust her dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_437" id="item_437">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="22" id="playthrough_437" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_437">If you haven't already, upgrade any Spirit Ash to at least +4, reload and talk to Roderika again.</label>
-                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_437&amp;link=/checklists/walkthrough.html%23item_437&amp;title=If you haven't already, upgrade any Spirit Ash to at least +4, reload and talk to Roderika again.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_437&amp;link=/checklists/walkthrough.html%23item_437&amp;title=If you haven't already, upgrade any Spirit Ash to at least +4, reload and talk to Roderika again."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_438" id="item_438">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="22" id="playthrough_438" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_438">Talk to Nepheli to give her the Stormhawk King and exhaust her dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_438&amp;link=/checklists/walkthrough.html%23item_438&amp;title=Talk to Nepheli to give her the Stormhawk King and exhaust her dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_438&amp;link=/checklists/walkthrough.html%23item_438&amp;title=Talk to Nepheli to give her the Stormhawk King and exhaust her dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -4731,9 +3783,7 @@
         <div class="card shadow-sm mb-3" id="playthrough_section_23">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_23Col" data-bs-toggle="collapse" href="#playthrough_23Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_23Col" data-bs-toggle="collapse" href="#playthrough_23Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Deeproot Depths</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="playthrough_totals_23"></span>
             </h4>
@@ -4743,135 +3793,105 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="23" id="playthrough_439" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_439">Go to the Great Waterfall Basin Grace in the Twin Gargoyle boss room and use the coffin nearby to grab the Great Waterfall Crest Grace.</label>
-                    <a class="ms-2" href="/map.html?x=6224&amp;y=13874&amp;id=playthrough_439&amp;link=/checklists/walkthrough.html%23item_439&amp;title=Go to the Great Waterfall Basin Grace in the Twin Gargoyle boss room and use the coffin nearby to grab the Great Waterfall Crest Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6224&amp;y=13874&amp;id=playthrough_439&amp;link=/checklists/walkthrough.html%23item_439&amp;title=Go to the Great Waterfall Basin Grace in the Twin Gargoyle boss room and use the coffin nearby to grab the Great Waterfall Crest Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_440" id="item_440">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="23" id="playthrough_440" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_440">Head West, across the roots, and grab the Deeproot Depths Grace next to the cliffs</label>
-                    <a class="ms-2" href="/map.html?x=5467&amp;y=11117&amp;id=playthrough_440&amp;link=/checklists/walkthrough.html%23item_440&amp;title=Head West, across the roots, and grab the Deeproot Depths Grace next to the cliffs">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5467&amp;y=11117&amp;id=playthrough_440&amp;link=/checklists/walkthrough.html%23item_440&amp;title=Head West, across the roots, and grab the Deeproot Depths Grace next to the cliffs"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_441" id="item_441">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="23" id="playthrough_441" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_441">Talk to Palm Reader and exhaust her dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=5467&amp;y=11117&amp;id=playthrough_441&amp;link=/checklists/walkthrough.html%23item_441&amp;title=Talk to Palm Reader and exhaust her dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5467&amp;y=11117&amp;id=playthrough_441&amp;link=/checklists/walkthrough.html%23item_441&amp;title=Talk to Palm Reader and exhaust her dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_442" id="item_442">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="23" id="playthrough_442" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_442">Make your way North/North-West and grab Map (Deeproot Depths)</label>
-                    <a class="ms-2" href="/map.html?x=5513&amp;y=10930&amp;id=playthrough_442&amp;link=/checklists/walkthrough.html%23item_442&amp;title=Make your way North/North-West and grab Map (Deeproot Depths)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5513&amp;y=10930&amp;id=playthrough_442&amp;link=/checklists/walkthrough.html%23item_442&amp;title=Make your way North/North-West and grab Map (Deeproot Depths)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_443" id="item_443">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="23" id="playthrough_443" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_443">Go up the nearby roots and head East and upwards, using the roots to grab the Across the Roots Grace</label>
-                    <a class="ms-2" href="/map.html?x=5594&amp;y=10857&amp;id=playthrough_443&amp;link=/checklists/walkthrough.html%23item_443&amp;title=Go up the nearby roots and head East and upwards, using the roots to grab the Across the Roots Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5594&amp;y=10857&amp;id=playthrough_443&amp;link=/checklists/walkthrough.html%23item_443&amp;title=Go up the nearby roots and head East and upwards, using the roots to grab the Across the Roots Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_444" id="item_444">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="23" id="playthrough_444" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_444">Head North and kill the boss, Fia's Champions</label>
-                    <a class="ms-2" href="/map.html?x=5586&amp;y=10782&amp;id=playthrough_444&amp;link=/checklists/walkthrough.html%23item_444&amp;title=Head North and kill the boss, Fia's Champions">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5586&amp;y=10782&amp;id=playthrough_444&amp;link=/checklists/walkthrough.html%23item_444&amp;title=Head North and kill the boss, Fia's Champions"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_445" id="item_445">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="23" id="playthrough_445" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_445">Talk to Fia and cuddle with her.</label>
-                    <a class="ms-2" href="/map.html?x=5704&amp;y=10698&amp;id=playthrough_445&amp;link=/checklists/walkthrough.html%23item_445&amp;title=Talk to Fia and cuddle with her.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5704&amp;y=10698&amp;id=playthrough_445&amp;link=/checklists/walkthrough.html%23item_445&amp;title=Talk to Fia and cuddle with her."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_446" id="item_446">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="23" id="playthrough_446" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_446">Grab the Prince of Death's Throne Grace</label>
-                    <a class="ms-2" href="/map.html?x=5685&amp;y=10708&amp;id=playthrough_446&amp;link=/checklists/walkthrough.html%23item_446&amp;title=Grab the Prince of Death's Throne Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5685&amp;y=10708&amp;id=playthrough_446&amp;link=/checklists/walkthrough.html%23item_446&amp;title=Grab the Prince of Death's Throne Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_447" id="item_447">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="23" id="playthrough_447" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_447">Reload and cuddle with Fia again.</label>
-                    <a class="ms-2" href="/map.html?x=5704&amp;y=10698&amp;id=playthrough_447&amp;link=/checklists/walkthrough.html%23item_447&amp;title=Reload and cuddle with Fia again.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5704&amp;y=10698&amp;id=playthrough_447&amp;link=/checklists/walkthrough.html%23item_447&amp;title=Reload and cuddle with Fia again."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_448" id="item_448">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="23" id="playthrough_448" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_448">Reload and interact with the sleeping Fia</label>
-                    <a class="ms-2" href="/map.html?x=5704&amp;y=10698&amp;id=playthrough_448&amp;link=/checklists/walkthrough.html%23item_448&amp;title=Reload and interact with the sleeping Fia">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5704&amp;y=10698&amp;id=playthrough_448&amp;link=/checklists/walkthrough.html%23item_448&amp;title=Reload and interact with the sleeping Fia"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_449" id="item_449">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="23" id="playthrough_449" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_449">Kill the boss, Lichdragon Fortissax</label>
-                    <a class="ms-2" href="/map.html?x=5656&amp;y=10740&amp;id=playthrough_449&amp;link=/checklists/walkthrough.html%23item_449&amp;title=Kill the boss, Lichdragon Fortissax">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5656&amp;y=10740&amp;id=playthrough_449&amp;link=/checklists/walkthrough.html%23item_449&amp;title=Kill the boss, Lichdragon Fortissax"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_450" id="item_450">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="23" id="playthrough_450" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_450">Loot Fia nearby</label>
-                    <a class="ms-2" href="/map.html?x=5704&amp;y=10698&amp;id=playthrough_450&amp;link=/checklists/walkthrough.html%23item_450&amp;title=Loot Fia nearby">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5704&amp;y=10698&amp;id=playthrough_450&amp;link=/checklists/walkthrough.html%23item_450&amp;title=Loot Fia nearby"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_451" id="item_451">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="23" id="playthrough_451" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_451">Reload, talk to D and exhaust his dialogue</label>
-                    <a class="ms-2" href="/map.html?x=5704&amp;y=10698&amp;id=playthrough_451&amp;link=/checklists/walkthrough.html%23item_451&amp;title=Reload, talk to D and exhaust his dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5704&amp;y=10698&amp;id=playthrough_451&amp;link=/checklists/walkthrough.html%23item_451&amp;title=Reload, talk to D and exhaust his dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_452" id="item_452">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="23" id="playthrough_452" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_452">Loot Fia for her clothes.</label>
-                    <a class="ms-2" href="/map.html?x=5704&amp;y=10698&amp;id=playthrough_452&amp;link=/checklists/walkthrough.html%23item_452&amp;title=Loot Fia for her clothes.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5704&amp;y=10698&amp;id=playthrough_452&amp;link=/checklists/walkthrough.html%23item_452&amp;title=Loot Fia for her clothes."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_453" id="item_453">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="23" id="playthrough_453" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_453">Kill D or reload then loot D's Armor and sword.</label>
-                    <a class="ms-2" href="/map.html?x=5704&amp;y=10698&amp;id=playthrough_453&amp;link=/checklists/walkthrough.html%23item_453&amp;title=Kill D or reload then loot D's Armor and sword.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5704&amp;y=10698&amp;id=playthrough_453&amp;link=/checklists/walkthrough.html%23item_453&amp;title=Kill D or reload then loot D's Armor and sword."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -4881,9 +3901,7 @@
         <div class="card shadow-sm mb-3" id="playthrough_section_24">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_24Col" data-bs-toggle="collapse" href="#playthrough_24Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_24Col" data-bs-toggle="collapse" href="#playthrough_24Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Liurnia Lake/Ainsel River Main</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="playthrough_totals_24"></span>
             </h4>
@@ -4893,108 +3911,84 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="24" id="playthrough_454" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_454">Go to the Road to the Manor Grace, talk to Iji and exhaust his dialogue</label>
-                    <a class="ms-2" href="/map.html?x=1718&amp;y=4037&amp;id=playthrough_454&amp;link=/checklists/walkthrough.html%23item_454&amp;title=Go to the Road to the Manor Grace, talk to Iji and exhaust his dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1718&amp;y=4037&amp;id=playthrough_454&amp;link=/checklists/walkthrough.html%23item_454&amp;title=Go to the Road to the Manor Grace, talk to Iji and exhaust his dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_455" id="item_455">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="24" id="playthrough_455" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_455">Go to Ranni's Rise Grace then head to Seluvis' Rise to find Seluvis' corpse(you can now use it to buy puppets)</label>
-                    <a class="ms-2" href="/map.html?x=1732&amp;y=3803&amp;id=playthrough_455&amp;link=/checklists/walkthrough.html%23item_455&amp;title=Go to Ranni's Rise Grace then head to Seluvis' Rise to find Seluvis' corpse(you can now use it to buy puppets)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1732&amp;y=3803&amp;id=playthrough_455&amp;link=/checklists/walkthrough.html%23item_455&amp;title=Go to Ranni's Rise Grace then head to Seluvis' Rise to find Seluvis' corpse(you can now use it to buy puppets)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_456" id="item_456">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="24" id="playthrough_456" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_456">Go to Pidia nearby and loot his corpse</label>
-                    <a class="ms-2" href="/map.html?x=1819&amp;y=3727&amp;id=playthrough_456&amp;link=/checklists/walkthrough.html%23item_456&amp;title=Go to Pidia nearby and loot his corpse">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1819&amp;y=3727&amp;id=playthrough_456&amp;link=/checklists/walkthrough.html%23item_456&amp;title=Go to Pidia nearby and loot his corpse"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_457" id="item_457">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="24" id="playthrough_457" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_457">Head North-East of Ranni's Rise and into Renna's Rise. Use the Waygate and grab doll from the coffin nearby</label>
-                    <a class="ms-2" href="/map.html?x=1755&amp;y=3517&amp;id=playthrough_457&amp;link=/checklists/walkthrough.html%23item_457&amp;title=Head North-East of Ranni's Rise and into Renna's Rise. Use the Waygate and grab doll from the coffin nearby">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1755&amp;y=3517&amp;id=playthrough_457&amp;link=/checklists/walkthrough.html%23item_457&amp;title=Head North-East of Ranni's Rise and into Renna's Rise. Use the Waygate and grab doll from the coffin nearby"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_458" id="item_458">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="24" id="playthrough_458" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_458">Grab the Ainsel River Main Grace.</label>
-                    <a class="ms-2" href="/map.html?x=3906&amp;y=11847&amp;id=playthrough_458&amp;link=/checklists/walkthrough.html%23item_458&amp;title=Grab the Ainsel River Main Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3906&amp;y=11847&amp;id=playthrough_458&amp;link=/checklists/walkthrough.html%23item_458&amp;title=Grab the Ainsel River Main Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_459" id="item_459">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="24" id="playthrough_459" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_459">Rest at the Grace and talk to the doll there 3 times</label>
-                    <a class="ms-2" href="/map.html?x=3906&amp;y=11847&amp;id=playthrough_459&amp;link=/checklists/walkthrough.html%23item_459&amp;title=Rest at the Grace and talk to the doll there 3 times">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3906&amp;y=11847&amp;id=playthrough_459&amp;link=/checklists/walkthrough.html%23item_459&amp;title=Rest at the Grace and talk to the doll there 3 times"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_460" id="item_460">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="24" id="playthrough_460" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_460">Head South-West and grab the Nokstella, Eternal City Grace</label>
-                    <a class="ms-2" href="/map.html?x=3605&amp;y=12044&amp;id=playthrough_460&amp;link=/checklists/walkthrough.html%23item_460&amp;title=Head South-West and grab the Nokstella, Eternal City Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3605&amp;y=12044&amp;id=playthrough_460&amp;link=/checklists/walkthrough.html%23item_460&amp;title=Head South-West and grab the Nokstella, Eternal City Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_461" id="item_461">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="24" id="playthrough_461" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_461">Follow the lower path, down the lift and grab the Nokstella Waterfall Basin Grace</label>
-                    <a class="ms-2" href="/map.html?x=3335&amp;y=11970&amp;id=playthrough_461&amp;link=/checklists/walkthrough.html%23item_461&amp;title=Follow the lower path, down the lift and grab the Nokstella Waterfall Basin Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3335&amp;y=11970&amp;id=playthrough_461&amp;link=/checklists/walkthrough.html%23item_461&amp;title=Follow the lower path, down the lift and grab the Nokstella Waterfall Basin Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_461_1" id="item_461_1">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="24" id="playthrough_461_1" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_461_1">Rest at the Grace and talk to Ranni</label>
-                    <a class="ms-2" href="/map.html?x=3335&amp;y=11970&amp;id=playthrough_461_1&amp;link=/checklists/walkthrough.html%23item_461_1&amp;title=Rest at the Grace and talk to Ranni">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3335&amp;y=11970&amp;id=playthrough_461_1&amp;link=/checklists/walkthrough.html%23item_461_1&amp;title=Rest at the Grace and talk to Ranni"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_462" id="item_462">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="24" id="playthrough_462" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_462">Continue to kill the Invader Baleful Shadow</label>
-                    <a class="ms-2" href="/map.html?x=3278&amp;y=12098&amp;id=playthrough_462&amp;link=/checklists/walkthrough.html%23item_462&amp;title=Continue to kill the Invader Baleful Shadow">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3278&amp;y=12098&amp;id=playthrough_462&amp;link=/checklists/walkthrough.html%23item_462&amp;title=Continue to kill the Invader Baleful Shadow"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_463" id="item_463">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="24" id="playthrough_463" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_463">Keep going and grab the Lake of Rot Shoreside Grace.</label>
-                    <a class="ms-2" href="/map.html?x=3267&amp;y=12188&amp;id=playthrough_463&amp;link=/checklists/walkthrough.html%23item_463&amp;title=Keep going and grab the Lake of Rot Shoreside Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3267&amp;y=12188&amp;id=playthrough_463&amp;link=/checklists/walkthrough.html%23item_463&amp;title=Keep going and grab the Lake of Rot Shoreside Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_464" id="item_464">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="24" id="playthrough_464" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_464">Make your way past the Lake of Rot(using the platforms will be easiest but you can run to the other side as long as you heal) and grab the Grand Cloister Grace.</label>
-                    <a class="ms-2" href="/map.html?x=3160&amp;y=12643&amp;id=playthrough_464&amp;link=/checklists/walkthrough.html%23item_464&amp;title=Make your way past the Lake of Rot(using the platforms will be easiest but you can run to the other side as long as you heal) and grab the Grand Cloister Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3160&amp;y=12643&amp;id=playthrough_464&amp;link=/checklists/walkthrough.html%23item_464&amp;title=Make your way past the Lake of Rot(using the platforms will be easiest but you can run to the other side as long as you heal) and grab the Grand Cloister Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -5004,9 +3998,7 @@
         <div class="card shadow-sm mb-3" id="playthrough_section_25">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_25Col" data-bs-toggle="collapse" href="#playthrough_25Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_25Col" data-bs-toggle="collapse" href="#playthrough_25Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Sellen/Ranni</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="playthrough_totals_25"></span>
             </h4>
@@ -5016,117 +4008,91 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="25" id="playthrough_465" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_465">Go to the Raya Lucaria Grand Library Grace and open the nearby chest for the Dark Moon Ring</label>
-                    <a class="ms-2" href="/map.html?x=1840&amp;y=4819&amp;id=playthrough_465&amp;link=/checklists/walkthrough.html%23item_465&amp;title=Go to the Raya Lucaria Grand Library Grace and open the nearby chest for the Dark Moon Ring">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1840&amp;y=4819&amp;id=playthrough_465&amp;link=/checklists/walkthrough.html%23item_465&amp;title=Go to the Raya Lucaria Grand Library Grace and open the nearby chest for the Dark Moon Ring"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_466" id="item_466">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="25" id="playthrough_466" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_466">Head outside the room to find 2 summon signs. Choose to either join Sellen or join Jerren</label>
-                    <a class="ms-2" href="/map.html?x=1903&amp;y=4845&amp;id=playthrough_466&amp;link=/checklists/walkthrough.html%23item_466&amp;title=Head outside the room to find 2 summon signs. Choose to either join Sellen or join Jerren">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1903&amp;y=4845&amp;id=playthrough_466&amp;link=/checklists/walkthrough.html%23item_466&amp;title=Head outside the room to find 2 summon signs. Choose to either join Sellen or join Jerren"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_467" id="item_467">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="25" id="playthrough_467" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_467">After the fight, loot the corpse/talk to the one you helped(may require reloading). If you helped Sellen, reload and talk to her again.</label>
-                    <a class="ms-2" href="/map.html?x=1840&amp;y=4819&amp;id=playthrough_467&amp;link=/checklists/walkthrough.html%23item_467&amp;title=After the fight, loot the corpse/talk to the one you helped(may require reloading). If you helped Sellen, reload and talk to her again.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1840&amp;y=4819&amp;id=playthrough_467&amp;link=/checklists/walkthrough.html%23item_467&amp;title=After the fight, loot the corpse/talk to the one you helped(may require reloading). If you helped Sellen, reload and talk to her again."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_468" id="item_468">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="25" id="playthrough_468" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_468">Return to the Grand Cloister Grace and head down then to the cliffs edge to the South and use the coffin.</label>
-                    <a class="ms-2" href="/map.html?x=3037&amp;y=12704&amp;id=playthrough_468&amp;link=/checklists/walkthrough.html%23item_468&amp;title=Return to the Grand Cloister Grace and head down then to the cliffs edge to the South and use the coffin.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3037&amp;y=12704&amp;id=playthrough_468&amp;link=/checklists/walkthrough.html%23item_468&amp;title=Return to the Grand Cloister Grace and head down then to the cliffs edge to the South and use the coffin."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_469" id="item_469">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="25" id="playthrough_469" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_469">Kill the boss, Astel, Naturalborn of the Void</label>
-                    <a class="ms-2" href="/map.html?x=2765&amp;y=13744&amp;id=playthrough_469&amp;link=/checklists/walkthrough.html%23item_469&amp;title=Kill the boss, Astel, Naturalborn of the Void">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2765&amp;y=13744&amp;id=playthrough_469&amp;link=/checklists/walkthrough.html%23item_469&amp;title=Kill the boss, Astel, Naturalborn of the Void"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_470" id="item_470">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="25" id="playthrough_470" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_470">Grab the Astel, Naturalborn of the Void Grace.</label>
-                    <a class="ms-2" href="/map.html?x=2796&amp;y=13677&amp;id=playthrough_470&amp;link=/checklists/walkthrough.html%23item_470&amp;title=Grab the Astel, Naturalborn of the Void Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2796&amp;y=13677&amp;id=playthrough_470&amp;link=/checklists/walkthrough.html%23item_470&amp;title=Grab the Astel, Naturalborn of the Void Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_471" id="item_471">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="25" id="playthrough_471" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_471">Go North and take the lift up and grab the Moonlight Altar Grace</label>
-                    <a class="ms-2" href="/map.html?x=1673&amp;y=5933&amp;id=playthrough_471&amp;link=/checklists/walkthrough.html%23item_471&amp;title=Go North and take the lift up and grab the Moonlight Altar Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1673&amp;y=5933&amp;id=playthrough_471&amp;link=/checklists/walkthrough.html%23item_471&amp;title=Go North and take the lift up and grab the Moonlight Altar Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_472" id="item_472">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="25" id="playthrough_472" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_472">Continue on the road North-East to grab the Cathedral of Manus Celes Grace</label>
-                    <a class="ms-2" href="/map.html?x=1905&amp;y=5783&amp;id=playthrough_472&amp;link=/checklists/walkthrough.html%23item_472&amp;title=Continue on the road North-East to grab the Cathedral of Manus Celes Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1905&amp;y=5783&amp;id=playthrough_472&amp;link=/checklists/walkthrough.html%23item_472&amp;title=Continue on the road North-East to grab the Cathedral of Manus Celes Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_472_1" id="item_472_1">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="25" id="playthrough_472_1" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_472_1">Go down the nearby hole to talk to Ranni and exhaust her dialogue to receive the Dark Moon Greatsword.</label>
-                    <a class="ms-2" href="/map.html?x=1905&amp;y=5783&amp;id=playthrough_472_1&amp;link=/checklists/walkthrough.html%23item_472_1&amp;title=Go down the nearby hole to talk to Ranni and exhaust her dialogue to receive the Dark Moon Greatsword.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1905&amp;y=5783&amp;id=playthrough_472_1&amp;link=/checklists/walkthrough.html%23item_472_1&amp;title=Go down the nearby hole to talk to Ranni and exhaust her dialogue to receive the Dark Moon Greatsword."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_473" id="item_473">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="25" id="playthrough_473" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_473">Return to Iji, talk to him and exhaust his dialogue</label>
-                    <a class="ms-2" href="/map.html?x=1718&amp;y=4037&amp;id=playthrough_473&amp;link=/checklists/walkthrough.html%23item_473&amp;title=Return to Iji, talk to him and exhaust his dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1718&amp;y=4037&amp;id=playthrough_473&amp;link=/checklists/walkthrough.html%23item_473&amp;title=Return to Iji, talk to him and exhaust his dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_474" id="item_474">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="25" id="playthrough_474" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_474">Return to Ranni's Rise and kill Blaidd</label>
-                    <a class="ms-2" href="/map.html?x=1576&amp;y=3700&amp;id=playthrough_474&amp;link=/checklists/walkthrough.html%23item_474&amp;title=Return to Ranni's Rise and kill Blaidd">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1576&amp;y=3700&amp;id=playthrough_474&amp;link=/checklists/walkthrough.html%23item_474&amp;title=Return to Ranni's Rise and kill Blaidd"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_475" id="item_475">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="25" id="playthrough_475" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_475">Return to Iji again and exhaust his dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=1718&amp;y=4037&amp;id=playthrough_475&amp;link=/checklists/walkthrough.html%23item_475&amp;title=Return to Iji again and exhaust his dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1718&amp;y=4037&amp;id=playthrough_475&amp;link=/checklists/walkthrough.html%23item_475&amp;title=Return to Iji again and exhaust his dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_476" id="item_476">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="25" id="playthrough_476" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_476">Reload and loot Iji's corpse.</label>
-                    <a class="ms-2" href="/map.html?x=1718&amp;y=4037&amp;id=playthrough_476&amp;link=/checklists/walkthrough.html%23item_476&amp;title=Reload and loot Iji's corpse.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=1718&amp;y=4037&amp;id=playthrough_476&amp;link=/checklists/walkthrough.html%23item_476&amp;title=Reload and loot Iji's corpse."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -5136,9 +4102,7 @@
         <div class="card shadow-sm mb-3" id="playthrough_section_26">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_26Col" data-bs-toggle="collapse" href="#playthrough_26Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_26Col" data-bs-toggle="collapse" href="#playthrough_26Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Leyndell</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="playthrough_totals_26"></span>
             </h4>
@@ -5148,198 +4112,154 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="26" id="playthrough_478" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_478">Starting from the Avenue Balcony Grace, head North-West and climb the wing of the dragon corpse to the top. Hop down and climb the ladder to to grab the West Capital Rampart Grace.</label>
-                    <a class="ms-2" href="/map.html?x=4279&amp;y=3581&amp;id=playthrough_478&amp;link=/checklists/walkthrough.html%23item_478&amp;title=Starting from the Avenue Balcony Grace, head North-West and climb the wing of the dragon corpse to the top. Hop down and climb the ladder to to grab the West Capital Rampart Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4279&amp;y=3581&amp;id=playthrough_478&amp;link=/checklists/walkthrough.html%23item_478&amp;title=Starting from the Avenue Balcony Grace, head North-West and climb the wing of the dragon corpse to the top. Hop down and climb the ladder to to grab the West Capital Rampart Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_479" id="item_479">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="26" id="playthrough_479" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_479">Go down the stairs and hop off the ledge going South-West then go to the location marked on the map to Invade and kill Errant Sorceror Wilhelm and Vargram the Raging Wolf alongside Recusant Bernahl.</label>
-                    <a class="ms-2" href="/map.html?x=4227&amp;y=3602&amp;id=playthrough_479&amp;link=/checklists/walkthrough.html%23item_479&amp;title=Go down the stairs and hop off the ledge going South-West then go to the location marked on the map to Invade and kill Errant Sorceror Wilhelm and Vargram the Raging Wolf alongside Recusant Bernahl.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4227&amp;y=3602&amp;id=playthrough_479&amp;link=/checklists/walkthrough.html%23item_479&amp;title=Go down the stairs and hop off the ledge going South-West then go to the location marked on the map to Invade and kill Errant Sorceror Wilhelm and Vargram the Raging Wolf alongside Recusant Bernahl."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_480" id="item_480">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="26" id="playthrough_480" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_480">Make your way South from the West Capital Rampart Grace to the coliseum and talk to Brother Corhyn and exhaust his dialogue</label>
-                    <a class="ms-2" href="/map.html?x=4245&amp;y=3781&amp;id=playthrough_480&amp;link=/checklists/walkthrough.html%23item_480&amp;title=Make your way South from the West Capital Rampart Grace to the coliseum and talk to Brother Corhyn and exhaust his dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4245&amp;y=3781&amp;id=playthrough_480&amp;link=/checklists/walkthrough.html%23item_480&amp;title=Make your way South from the West Capital Rampart Grace to the coliseum and talk to Brother Corhyn and exhaust his dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_481" id="item_481">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="26" id="playthrough_481" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_481">Talk to Goldmask and exhaust his dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=4245&amp;y=3781&amp;id=playthrough_481&amp;link=/checklists/walkthrough.html%23item_481&amp;title=Talk to Goldmask and exhaust his dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4245&amp;y=3781&amp;id=playthrough_481&amp;link=/checklists/walkthrough.html%23item_481&amp;title=Talk to Goldmask and exhaust his dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_482" id="item_482">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="26" id="playthrough_482" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_482">Follow the roots up to the East and kill the boss, Godfrey, First Elden Lord.</label>
-                    <a class="ms-2" href="/map.html?x=4354&amp;y=3709&amp;id=playthrough_482&amp;link=/checklists/walkthrough.html%23item_482&amp;title=Follow the roots up to the East and kill the boss, Godfrey, First Elden Lord.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4354&amp;y=3709&amp;id=playthrough_482&amp;link=/checklists/walkthrough.html%23item_482&amp;title=Follow the roots up to the East and kill the boss, Godfrey, First Elden Lord."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_483" id="item_483">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="26" id="playthrough_483" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_483">Grab the Erdtree Sanctuary Grace.</label>
-                    <a class="ms-2" href="/map.html?x=4365&amp;y=3708&amp;id=playthrough_483&amp;link=/checklists/walkthrough.html%23item_483&amp;title=Grab the Erdtree Sanctuary Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4365&amp;y=3708&amp;id=playthrough_483&amp;link=/checklists/walkthrough.html%23item_483&amp;title=Grab the Erdtree Sanctuary Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_484" id="item_484">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="26" id="playthrough_484" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_484">Go up the roots to the East, up to the next floor. Go outside, and go left onto the roof to enter the window. Go up the roots then grab the Golden Order Principia from above the Erdtree Sanctuary Grace.</label>
-                    <a class="ms-2" href="/map.html?x=4365&amp;y=3708&amp;id=playthrough_484&amp;link=/checklists/walkthrough.html%23item_484&amp;title=Go up the roots to the East, up to the next floor. Go outside, and go left onto the roof to enter the window. Go up the roots then grab the Golden Order Principia from above the Erdtree Sanctuary Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4365&amp;y=3708&amp;id=playthrough_484&amp;link=/checklists/walkthrough.html%23item_484&amp;title=Go up the roots to the East, up to the next floor. Go outside, and go left onto the roof to enter the window. Go up the roots then grab the Golden Order Principia from above the Erdtree Sanctuary Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_485" id="item_485">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="26" id="playthrough_485" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_485">Go to Miriel, Pastor of Vows and exhaust his dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=2422&amp;y=4709&amp;id=playthrough_485&amp;link=/checklists/walkthrough.html%23item_485&amp;title=Go to Miriel, Pastor of Vows and exhaust his dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2422&amp;y=4709&amp;id=playthrough_485&amp;link=/checklists/walkthrough.html%23item_485&amp;title=Go to Miriel, Pastor of Vows and exhaust his dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_486" id="item_486">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="26" id="playthrough_486" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_486">Give him the Golden Order Principia then buy the Law of Regression</label>
-                    <a class="ms-2" href="/map.html?x=2422&amp;y=4709&amp;id=playthrough_486&amp;link=/checklists/walkthrough.html%23item_486&amp;title=Give him the Golden Order Principia then buy the Law of Regression">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2422&amp;y=4709&amp;id=playthrough_486&amp;link=/checklists/walkthrough.html%23item_486&amp;title=Give him the Golden Order Principia then buy the Law of Regression"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_487" id="item_487">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="26" id="playthrough_487" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_487">Return to Erdtree Sanctuary Grace, go down the lift nearby and read the message at the bottom</label>
-                    <a class="ms-2" href="/map.html?x=4321&amp;y=3658&amp;id=playthrough_487&amp;link=/checklists/walkthrough.html%23item_487&amp;title=Return to Erdtree Sanctuary Grace, go down the lift nearby and read the message at the bottom">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4321&amp;y=3658&amp;id=playthrough_487&amp;link=/checklists/walkthrough.html%23item_487&amp;title=Return to Erdtree Sanctuary Grace, go down the lift nearby and read the message at the bottom"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_488" id="item_488">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="26" id="playthrough_488" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_488">Use Law of Regression at the message and read the new message</label>
-                    <a class="ms-2" href="/map.html?x=4321&amp;y=3658&amp;id=playthrough_488&amp;link=/checklists/walkthrough.html%23item_488&amp;title=Use Law of Regression at the message and read the new message">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4321&amp;y=3658&amp;id=playthrough_488&amp;link=/checklists/walkthrough.html%23item_488&amp;title=Use Law of Regression at the message and read the new message"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_489" id="item_489">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="26" id="playthrough_489" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_489">Return to Goldmask and exhaust his dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=4245&amp;y=3781&amp;id=playthrough_489&amp;link=/checklists/walkthrough.html%23item_489&amp;title=Return to Goldmask and exhaust his dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4245&amp;y=3781&amp;id=playthrough_489&amp;link=/checklists/walkthrough.html%23item_489&amp;title=Return to Goldmask and exhaust his dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_490" id="item_490">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="26" id="playthrough_490" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_490">Talk to Brother Corhyn and exhaust his dialogue</label>
-                    <a class="ms-2" href="/map.html?x=4245&amp;y=3781&amp;id=playthrough_490&amp;link=/checklists/walkthrough.html%23item_490&amp;title=Talk to Brother Corhyn and exhaust his dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4245&amp;y=3781&amp;id=playthrough_490&amp;link=/checklists/walkthrough.html%23item_490&amp;title=Talk to Brother Corhyn and exhaust his dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_491" id="item_491">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="26" id="playthrough_491" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_491">Go back to the Erdtree Sanctuary Grace and go up the roots to grab the Queen's Bedchamber Grace</label>
-                    <a class="ms-2" href="/map.html?x=4441&amp;y=3629&amp;id=playthrough_491&amp;link=/checklists/walkthrough.html%23item_491&amp;title=Go back to the Erdtree Sanctuary Grace and go up the roots to grab the Queen's Bedchamber Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4441&amp;y=3629&amp;id=playthrough_491&amp;link=/checklists/walkthrough.html%23item_491&amp;title=Go back to the Erdtree Sanctuary Grace and go up the roots to grab the Queen's Bedchamber Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_492" id="item_492">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="26" id="playthrough_492" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_492">Continue up the path to the boss room to summon Melina and kill the boss Morgott, the Omen King.</label>
-                    <a class="ms-2" href="/map.html?x=4521&amp;y=3727&amp;id=playthrough_492&amp;link=/checklists/walkthrough.html%23item_492&amp;title=Continue up the path to the boss room to summon Melina and kill the boss Morgott, the Omen King.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4521&amp;y=3727&amp;id=playthrough_492&amp;link=/checklists/walkthrough.html%23item_492&amp;title=Continue up the path to the boss room to summon Melina and kill the boss Morgott, the Omen King."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_493" id="item_493">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="26" id="playthrough_493" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_493">Attempt to open enter the Erdtree to be denied then grab the Elden Throne Grace</label>
-                    <a class="ms-2" href="/map.html?x=4534&amp;y=3737&amp;id=playthrough_493&amp;link=/checklists/walkthrough.html%23item_493&amp;title=Attempt to open enter the Erdtree to be denied then grab the Elden Throne Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4534&amp;y=3737&amp;id=playthrough_493&amp;link=/checklists/walkthrough.html%23item_493&amp;title=Attempt to open enter the Erdtree to be denied then grab the Elden Throne Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_494" id="item_494">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="26" id="playthrough_494" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_494">Rest at the Grace to talk to Melina and exhaust her dialogue</label>
-                    <a class="ms-2" href="/map.html?x=4534&amp;y=3737&amp;id=playthrough_494&amp;link=/checklists/walkthrough.html%23item_494&amp;title=Rest at the Grace to talk to Melina and exhaust her dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4534&amp;y=3737&amp;id=playthrough_494&amp;link=/checklists/walkthrough.html%23item_494&amp;title=Rest at the Grace to talk to Melina and exhaust her dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_495" id="item_495">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="26" id="playthrough_495" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_495">Rest at the Queen's Bedchamber Grace to talk to Melina and exhaust her dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=4441&amp;y=3629&amp;id=playthrough_495&amp;link=/checklists/walkthrough.html%23item_495&amp;title=Rest at the Queen's Bedchamber Grace to talk to Melina and exhaust her dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4441&amp;y=3629&amp;id=playthrough_495&amp;link=/checklists/walkthrough.html%23item_495&amp;title=Rest at the Queen's Bedchamber Grace to talk to Melina and exhaust her dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_496" id="item_496">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="26" id="playthrough_496" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_496">Go to the Avenue Balcony Grace and head North-East along the road, through the giant gates, up the slope, up the lift, across the bridge and down the next lift to grab the Forbidden Lands Grace.</label>
-                    <a class="ms-2" href="/map.html?x=4989&amp;y=3485&amp;id=playthrough_496&amp;link=/checklists/walkthrough.html%23item_496&amp;title=Go to the Avenue Balcony Grace and head North-East along the road, through the giant gates, up the slope, up the lift, across the bridge and down the next lift to grab the Forbidden Lands Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4989&amp;y=3485&amp;id=playthrough_496&amp;link=/checklists/walkthrough.html%23item_496&amp;title=Go to the Avenue Balcony Grace and head North-East along the road, through the giant gates, up the slope, up the lift, across the bridge and down the next lift to grab the Forbidden Lands Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_497" id="item_497">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="26" id="playthrough_497" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_497">Head North-East on the path through the area to summon Millicent and kill the boss, Black Blade Kindred.</label>
-                    <a class="ms-2" href="/map.html?x=5478&amp;y=3187&amp;id=playthrough_497&amp;link=/checklists/walkthrough.html%23item_497&amp;title=Head North-East on the path through the area to summon Millicent and kill the boss, Black Blade Kindred.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5478&amp;y=3187&amp;id=playthrough_497&amp;link=/checklists/walkthrough.html%23item_497&amp;title=Head North-East on the path through the area to summon Millicent and kill the boss, Black Blade Kindred."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_498" id="item_498">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="26" id="playthrough_498" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_498">Go past the boss and grab the Grand Lift of Rold Grace.</label>
-                    <a class="ms-2" href="/map.html?x=5493&amp;y=3042&amp;id=playthrough_498&amp;link=/checklists/walkthrough.html%23item_498&amp;title=Go past the boss and grab the Grand Lift of Rold Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5493&amp;y=3042&amp;id=playthrough_498&amp;link=/checklists/walkthrough.html%23item_498&amp;title=Go past the boss and grab the Grand Lift of Rold Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_499" id="item_499">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="26" id="playthrough_499" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_499">Talk to the Finger Reader nearby and exhaust her dialogue</label>
-                    <a class="ms-2" href="/map.html?x=5493&amp;y=3042&amp;id=playthrough_499&amp;link=/checklists/walkthrough.html%23item_499&amp;title=Talk to the Finger Reader nearby and exhaust her dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5493&amp;y=3042&amp;id=playthrough_499&amp;link=/checklists/walkthrough.html%23item_499&amp;title=Talk to the Finger Reader nearby and exhaust her dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -5349,9 +4269,7 @@
         <div class="card shadow-sm mb-3" id="playthrough_section_27">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_27Col" data-bs-toggle="collapse" href="#playthrough_27Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_27Col" data-bs-toggle="collapse" href="#playthrough_27Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Roundtable Hold/Nepheli/Dragonbarrow</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="playthrough_totals_27"></span>
             </h4>
@@ -5361,117 +4279,91 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="27" id="playthrough_500" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_500">Return to Roundtable Hold, talk to Enia and exhaust her dialogue</label>
-                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_500&amp;link=/checklists/walkthrough.html%23item_500&amp;title=Return to Roundtable Hold, talk to Enia and exhaust her dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_500&amp;link=/checklists/walkthrough.html%23item_500&amp;title=Return to Roundtable Hold, talk to Enia and exhaust her dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_501" id="item_501">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="27" id="playthrough_501" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_501">Talk to Gideon and exhaust his dialogue</label>
-                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_501&amp;link=/checklists/walkthrough.html%23item_501&amp;title=Talk to Gideon and exhaust his dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_501&amp;link=/checklists/walkthrough.html%23item_501&amp;title=Talk to Gideon and exhaust his dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_502" id="item_502">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="27" id="playthrough_502" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_502">Talk to Hewg and exhaust his dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_502&amp;link=/checklists/walkthrough.html%23item_502&amp;title=Talk to Hewg and exhaust his dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_502&amp;link=/checklists/walkthrough.html%23item_502&amp;title=Talk to Hewg and exhaust his dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_503" id="item_503">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="27" id="playthrough_503" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_503">Go to the Godrick the Grafted Grace in Stormveil Castle, talk to Nepheli in the throne room and exhaust her dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=3052&amp;y=6409&amp;id=playthrough_503&amp;link=/checklists/walkthrough.html%23item_503&amp;title=Go to the Godrick the Grafted Grace in Stormveil Castle, talk to Nepheli in the throne room and exhaust her dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3052&amp;y=6409&amp;id=playthrough_503&amp;link=/checklists/walkthrough.html%23item_503&amp;title=Go to the Godrick the Grafted Grace in Stormveil Castle, talk to Nepheli in the throne room and exhaust her dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_504" id="item_504">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="27" id="playthrough_504" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_504">Talk to Kenneth and exhaust his dialogue</label>
-                    <a class="ms-2" href="/map.html?x=3052&amp;y=6409&amp;id=playthrough_504&amp;link=/checklists/walkthrough.html%23item_504&amp;title=Talk to Kenneth and exhaust his dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3052&amp;y=6409&amp;id=playthrough_504&amp;link=/checklists/walkthrough.html%23item_504&amp;title=Talk to Kenneth and exhaust his dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_505" id="item_505">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="27" id="playthrough_505" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_505">Talk to Gostoc and exhaust his dialogue to add new items to his shop.</label>
-                    <a class="ms-2" href="/map.html?x=3052&amp;y=6409&amp;id=playthrough_505&amp;link=/checklists/walkthrough.html%23item_505&amp;title=Talk to Gostoc and exhaust his dialogue to add new items to his shop.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=3052&amp;y=6409&amp;id=playthrough_505&amp;link=/checklists/walkthrough.html%23item_505&amp;title=Talk to Gostoc and exhaust his dialogue to add new items to his shop."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_506" id="item_506">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="27" id="playthrough_506" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_506">Go to Bestial Sanctum Grace, feed Deathroot to Gurranq and exhaust his dialogue</label>
-                    <a class="ms-2" href="/map.html?x=5968&amp;y=5488&amp;id=playthrough_506&amp;link=/checklists/walkthrough.html%23item_506&amp;title=Go to Bestial Sanctum Grace, feed Deathroot to Gurranq and exhaust his dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5968&amp;y=5488&amp;id=playthrough_506&amp;link=/checklists/walkthrough.html%23item_506&amp;title=Go to Bestial Sanctum Grace, feed Deathroot to Gurranq and exhaust his dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_507" id="item_507">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="27" id="playthrough_507" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_507">Rest at the Grace and Gurranq will attack you. Beat him up but don't kill him then talk to him again</label>
-                    <a class="ms-2" href="/map.html?x=5968&amp;y=5488&amp;id=playthrough_507&amp;link=/checklists/walkthrough.html%23item_507&amp;title=Rest at the Grace and Gurranq will attack you. Beat him up but don't kill him then talk to him again">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5968&amp;y=5488&amp;id=playthrough_507&amp;link=/checklists/walkthrough.html%23item_507&amp;title=Rest at the Grace and Gurranq will attack you. Beat him up but don't kill him then talk to him again"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_508" id="item_508">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="27" id="playthrough_508" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_508">In the Siofra River Well, go to the Siofra River Bank Grace. Go North-East and use the Waygate then head to the North-East corner of the area to grab the Below the Well Grace.</label>
-                    <a class="ms-2" href="/map.html?x=6214&amp;y=14467&amp;id=playthrough_508&amp;link=/checklists/walkthrough.html%23item_508&amp;title=In the Siofra River Well, go to the Siofra River Bank Grace. Go North-East and use the Waygate then head to the North-East corner of the area to grab the Below the Well Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6214&amp;y=14467&amp;id=playthrough_508&amp;link=/checklists/walkthrough.html%23item_508&amp;title=In the Siofra River Well, go to the Siofra River Bank Grace. Go North-East and use the Waygate then head to the North-East corner of the area to grab the Below the Well Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_509" id="item_509">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="27" id="playthrough_509" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_509">Use the Imp Statue and go up the lift to grab the Deep Siofra Well Grace.</label>
-                    <a class="ms-2" href="/map.html?x=5356&amp;y=6271&amp;id=playthrough_509&amp;link=/checklists/walkthrough.html%23item_509&amp;title=Use the Imp Statue and go up the lift to grab the Deep Siofra Well Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5356&amp;y=6271&amp;id=playthrough_509&amp;link=/checklists/walkthrough.html%23item_509&amp;title=Use the Imp Statue and go up the lift to grab the Deep Siofra Well Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_510" id="item_510">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="27" id="playthrough_510" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_510">Head North-West to the Coliseum and talk to the Great Jar.</label>
-                    <a class="ms-2" href="/map.html?x=4985&amp;y=5898&amp;id=playthrough_510&amp;link=/checklists/walkthrough.html%23item_510&amp;title=Head North-West to the Coliseum and talk to the Great Jar.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4985&amp;y=5898&amp;id=playthrough_510&amp;link=/checklists/walkthrough.html%23item_510&amp;title=Head North-West to the Coliseum and talk to the Great Jar."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_511" id="item_511">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="27" id="playthrough_511" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_511">Use the Red Summon Signs in front of the Great Jar to summon and kill all three of the Knight of the Great Jar.</label>
-                    <a class="ms-2" href="/map.html?x=4985&amp;y=5898&amp;id=playthrough_511&amp;link=/checklists/walkthrough.html%23item_511&amp;title=Use the Red Summon Signs in front of the Great Jar to summon and kill all three of the Knight of the Great Jar.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4985&amp;y=5898&amp;id=playthrough_511&amp;link=/checklists/walkthrough.html%23item_511&amp;title=Use the Red Summon Signs in front of the Great Jar to summon and kill all three of the Knight of the Great Jar."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_512" id="item_512">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="27" id="playthrough_512" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_512">Talk to the Great Jar again and be rewarded.</label>
-                    <a class="ms-2" href="/map.html?x=4985&amp;y=5898&amp;id=playthrough_512&amp;link=/checklists/walkthrough.html%23item_512&amp;title=Talk to the Great Jar again and be rewarded.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4985&amp;y=5898&amp;id=playthrough_512&amp;link=/checklists/walkthrough.html%23item_512&amp;title=Talk to the Great Jar again and be rewarded."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -5481,9 +4373,7 @@
         <div class="card shadow-sm mb-3" id="playthrough_section_28">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_28Col" data-bs-toggle="collapse" href="#playthrough_28Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_28Col" data-bs-toggle="collapse" href="#playthrough_28Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Mountaintops of the Giants Part 1</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="playthrough_totals_28"></span>
             </h4>
@@ -5493,126 +4383,98 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="28" id="playthrough_513" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_513">Return to the Grand Lift of Rold Grace and go up the lift to grab Map (Mountaintops of the Giants, West)</label>
-                    <a class="ms-2" href="/map.html?x=5526&amp;y=2881&amp;id=playthrough_513&amp;link=/checklists/walkthrough.html%23item_513&amp;title=Return to the Grand Lift of Rold Grace and go up the lift to grab Map (Mountaintops of the Giants, West)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5526&amp;y=2881&amp;id=playthrough_513&amp;link=/checklists/walkthrough.html%23item_513&amp;title=Return to the Grand Lift of Rold Grace and go up the lift to grab Map (Mountaintops of the Giants, West)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_514" id="item_514">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="28" id="playthrough_514" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_514">Grab the Zamor Ruins Grace nearby.</label>
-                    <a class="ms-2" href="/map.html?x=5583&amp;y=2844&amp;id=playthrough_514&amp;link=/checklists/walkthrough.html%23item_514&amp;title=Grab the Zamor Ruins Grace nearby.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5583&amp;y=2844&amp;id=playthrough_514&amp;link=/checklists/walkthrough.html%23item_514&amp;title=Grab the Zamor Ruins Grace nearby."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_515" id="item_515">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="28" id="playthrough_515" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_515">Rest and talk to Melina at Zamor Ruins Grace</label>
-                    <a class="ms-2" href="/map.html?x=5583&amp;y=2844&amp;id=playthrough_515&amp;link=/checklists/walkthrough.html%23item_515&amp;title=Rest and talk to Melina at Zamor Ruins Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5583&amp;y=2844&amp;id=playthrough_515&amp;link=/checklists/walkthrough.html%23item_515&amp;title=Rest and talk to Melina at Zamor Ruins Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_516" id="item_516">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="28" id="playthrough_516" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_516">Talk to Shabriri nearby and exhaust his dialogue</label>
-                    <a class="ms-2" href="/map.html?x=5583&amp;y=2844&amp;id=playthrough_516&amp;link=/checklists/walkthrough.html%23item_516&amp;title=Talk to Shabriri nearby and exhaust his dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5583&amp;y=2844&amp;id=playthrough_516&amp;link=/checklists/walkthrough.html%23item_516&amp;title=Talk to Shabriri nearby and exhaust his dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_517" id="item_517">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="28" id="playthrough_517" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_517">Rest at the Grace to talk to Melina and exhaust her dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=5583&amp;y=2844&amp;id=playthrough_517&amp;link=/checklists/walkthrough.html%23item_517&amp;title=Rest at the Grace to talk to Melina and exhaust her dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5583&amp;y=2844&amp;id=playthrough_517&amp;link=/checklists/walkthrough.html%23item_517&amp;title=Rest at the Grace to talk to Melina and exhaust her dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_518" id="item_518">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="28" id="playthrough_518" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_518">Head North-East and when you see the fire guys, enter the nearby door to grab the Giants' Mountaintop Catacombs Grace.</label>
-                    <a class="ms-2" href="/map.html?x=5787&amp;y=2830&amp;id=playthrough_518&amp;link=/checklists/walkthrough.html%23item_518&amp;title=Head North-East and when you see the fire guys, enter the nearby door to grab the Giants' Mountaintop Catacombs Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5787&amp;y=2830&amp;id=playthrough_518&amp;link=/checklists/walkthrough.html%23item_518&amp;title=Head North-East and when you see the fire guys, enter the nearby door to grab the Giants' Mountaintop Catacombs Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_519" id="item_519">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="28" id="playthrough_519" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_519">Go through the area then down the lift, keep going to go down another lift. Follow this path to it's end then fall down side path hole near the Giant Warrior Pot. This area will look like the same area as before but if you go back to the lift, activate it and step off, there will be a secret path under the lift with a Giant Warrior Pot. Hop down and use the lever to unlock the boss room</label>
-                    <a class="ms-2" href="/map.html?x=5787&amp;y=2830&amp;id=playthrough_519&amp;link=/checklists/walkthrough.html%23item_519&amp;title=Go through the area then down the lift, keep going to go down another lift. Follow this path to it's end then fall down side path hole near the Giant Warrior Pot. This area will look like the same area as before but if you go back to the lift, activate it and step off, there will be a secret path under the lift with a Giant Warrior Pot. Hop down and use the lever to unlock the boss room">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5787&amp;y=2830&amp;id=playthrough_519&amp;link=/checklists/walkthrough.html%23item_519&amp;title=Go through the area then down the lift, keep going to go down another lift. Follow this path to it's end then fall down side path hole near the Giant Warrior Pot. This area will look like the same area as before but if you go back to the lift, activate it and step off, there will be a secret path under the lift with a Giant Warrior Pot. Hop down and use the lever to unlock the boss room"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_519_1" id="item_519_1">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="28" id="playthrough_519_1" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_519_1">With the boss door opened now just kill the boss, Ulcerated Tree Spirit, for the Seventh Deathroot</label>
-                    <a class="ms-2" href="/map.html?x=5769&amp;y=2818&amp;id=playthrough_519_1&amp;link=/checklists/walkthrough.html%23item_519_1&amp;title=With the boss door opened now just kill the boss, Ulcerated Tree Spirit, for the Seventh Deathroot">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5769&amp;y=2818&amp;id=playthrough_519_1&amp;link=/checklists/walkthrough.html%23item_519_1&amp;title=With the boss door opened now just kill the boss, Ulcerated Tree Spirit, for the Seventh Deathroot"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_520" id="item_520">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="28" id="playthrough_520" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_520">Exit the catacombs and head North-East to grab the Ancient Snow Valley Grace</label>
-                    <a class="ms-2" href="/map.html?x=6010&amp;y=2220&amp;id=playthrough_520&amp;link=/checklists/walkthrough.html%23item_520&amp;title=Exit the catacombs and head North-East to grab the Ancient Snow Valley Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6010&amp;y=2220&amp;id=playthrough_520&amp;link=/checklists/walkthrough.html%23item_520&amp;title=Exit the catacombs and head North-East to grab the Ancient Snow Valley Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_521" id="item_521">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="28" id="playthrough_521" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_521">Talk to Millicent nearby and exhaust her dialogue</label>
-                    <a class="ms-2" href="/map.html?x=6010&amp;y=2220&amp;id=playthrough_521&amp;link=/checklists/walkthrough.html%23item_521&amp;title=Talk to Millicent nearby and exhaust her dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6010&amp;y=2220&amp;id=playthrough_521&amp;link=/checklists/walkthrough.html%23item_521&amp;title=Talk to Millicent nearby and exhaust her dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_522" id="item_522">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="28" id="playthrough_522" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_522">Continue North to the frozen river then head West to the Shack of the Lofty to invade and kill Juno Hoslow</label>
-                    <a class="ms-2" href="/map.html?x=5842&amp;y=2103&amp;id=playthrough_522&amp;link=/checklists/walkthrough.html%23item_522&amp;title=Continue North to the frozen river then head West to the Shack of the Lofty to invade and kill Juno Hoslow">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5842&amp;y=2103&amp;id=playthrough_522&amp;link=/checklists/walkthrough.html%23item_522&amp;title=Continue North to the frozen river then head West to the Shack of the Lofty to invade and kill Juno Hoslow"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_523" id="item_523">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="28" id="playthrough_523" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_523">Use the Spiritjump point South of the Shack of the Lofty to reach the Stargazer's Ruins. Enter the ruins and summon your Spirit Jellyfish Ashes then talk to the Spirit Jellyfish nearby to solve the puzzle.</label>
-                    <a class="ms-2" href="/map.html?x=5967&amp;y=2141&amp;id=playthrough_523&amp;link=/checklists/walkthrough.html%23item_523&amp;title=Use the Spiritjump point South of the Shack of the Lofty to reach the Stargazer's Ruins. Enter the ruins and summon your Spirit Jellyfish Ashes then talk to the Spirit Jellyfish nearby to solve the puzzle.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5967&amp;y=2141&amp;id=playthrough_523&amp;link=/checklists/walkthrough.html%23item_523&amp;title=Use the Spiritjump point South of the Shack of the Lofty to reach the Stargazer's Ruins. Enter the ruins and summon your Spirit Jellyfish Ashes then talk to the Spirit Jellyfish nearby to solve the puzzle."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_524" id="item_524">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="28" id="playthrough_524" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_524">Head to the bridge South-East of the ruins to talk to Corhyn and exhaust his dialogue (if you give him the Potion of Forgetfulness, he will be here at the end of his questline instead of the Capital of Ash)</label>
-                    <a class="ms-2" href="/map.html?x=6031&amp;y=2218&amp;id=playthrough_524&amp;link=/checklists/walkthrough.html%23item_524&amp;title=Head to the bridge South-East of the ruins to talk to Corhyn and exhaust his dialogue (if you give him the Potion of Forgetfulness, he will be here at the end of his questline instead of the Capital of Ash)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6031&amp;y=2218&amp;id=playthrough_524&amp;link=/checklists/walkthrough.html%23item_524&amp;title=Head to the bridge South-East of the ruins to talk to Corhyn and exhaust his dialogue (if you give him the Potion of Forgetfulness, he will be here at the end of his questline instead of the Capital of Ash)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_525" id="item_525">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="28" id="playthrough_525" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_525">Talk to Goldmask and exhaust his dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=6031&amp;y=2218&amp;id=playthrough_525&amp;link=/checklists/walkthrough.html%23item_525&amp;title=Talk to Goldmask and exhaust his dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6031&amp;y=2218&amp;id=playthrough_525&amp;link=/checklists/walkthrough.html%23item_525&amp;title=Talk to Goldmask and exhaust his dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -5622,9 +4484,7 @@
         <div class="card shadow-sm mb-3" id="playthrough_section_29">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_29Col" data-bs-toggle="collapse" href="#playthrough_29Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_29Col" data-bs-toggle="collapse" href="#playthrough_29Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Volcano Manor</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="playthrough_totals_29"></span>
             </h4>
@@ -5634,126 +4494,98 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="29" id="playthrough_526" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_526">Go to Volcano Manor and talk to Bernahl for reward</label>
-                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_526&amp;link=/checklists/walkthrough.html%23item_526&amp;title=Go to Volcano Manor and talk to Bernahl for reward">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_526&amp;link=/checklists/walkthrough.html%23item_526&amp;title=Go to Volcano Manor and talk to Bernahl for reward"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_526_1" id="item_526_1">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="29" id="playthrough_526_1" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_526_1">Talk to Diallos nearby and exhaust his dialogue</label>
-                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_526_1&amp;link=/checklists/walkthrough.html%23item_526_1&amp;title=Talk to Diallos nearby and exhaust his dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_526_1&amp;link=/checklists/walkthrough.html%23item_526_1&amp;title=Talk to Diallos nearby and exhaust his dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_527" id="item_527">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="29" id="playthrough_527" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_527">Talk to Tanith and exhaust her dialogue to grab the Audience Pathway Grace</label>
-                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_527&amp;link=/checklists/walkthrough.html%23item_527&amp;title=Talk to Tanith and exhaust her dialogue to grab the Audience Pathway Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_527&amp;link=/checklists/walkthrough.html%23item_527&amp;title=Talk to Tanith and exhaust her dialogue to grab the Audience Pathway Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_528" id="item_528">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="29" id="playthrough_528" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_528">Enter the boss room and kill the boss Rykard, Lord of Blasphemy (There is a spear nearby with a special attack that deals big damage against Rykard)</label>
-                    <a class="ms-2" href="/map.html?x=2292&amp;y=2960&amp;id=playthrough_528&amp;link=/checklists/walkthrough.html%23item_528&amp;title=Enter the boss room and kill the boss Rykard, Lord of Blasphemy (There is a spear nearby with a special attack that deals big damage against Rykard)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2292&amp;y=2960&amp;id=playthrough_528&amp;link=/checklists/walkthrough.html%23item_528&amp;title=Enter the boss room and kill the boss Rykard, Lord of Blasphemy (There is a spear nearby with a special attack that deals big damage against Rykard)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_529" id="item_529">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="29" id="playthrough_529" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_529">Grab the Rykard, Lord of Blasphemy Grace</label>
-                    <a class="ms-2" href="/map.html?x=2282&amp;y=2949&amp;id=playthrough_529&amp;link=/checklists/walkthrough.html%23item_529&amp;title=Grab the Rykard, Lord of Blasphemy Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2282&amp;y=2949&amp;id=playthrough_529&amp;link=/checklists/walkthrough.html%23item_529&amp;title=Grab the Rykard, Lord of Blasphemy Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_530" id="item_530">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="29" id="playthrough_530" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_530">Talk to Tanith and exhaust her dialogue</label>
-                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_530&amp;link=/checklists/walkthrough.html%23item_530&amp;title=Talk to Tanith and exhaust her dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_530&amp;link=/checklists/walkthrough.html%23item_530&amp;title=Talk to Tanith and exhaust her dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_531" id="item_531">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="29" id="playthrough_531" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_531">Talk to Patches and exhaust his dialogue</label>
-                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_531&amp;link=/checklists/walkthrough.html%23item_531&amp;title=Talk to Patches and exhaust his dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_531&amp;link=/checklists/walkthrough.html%23item_531&amp;title=Talk to Patches and exhaust his dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_532" id="item_532">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="29" id="playthrough_532" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_532">Talk to Bernahl and exhaust his dialogue</label>
-                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_532&amp;link=/checklists/walkthrough.html%23item_532&amp;title=Talk to Bernahl and exhaust his dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2229&amp;y=2895&amp;id=playthrough_532&amp;link=/checklists/walkthrough.html%23item_532&amp;title=Talk to Bernahl and exhaust his dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_534" id="item_534">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="29" id="playthrough_534" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_534">Talk to Rya at her location past the Temple of Eiglay Grace(don't give her the potion)</label>
-                    <a class="ms-2" href="/map.html?x=2204&amp;y=2974&amp;id=playthrough_534&amp;link=/checklists/walkthrough.html%23item_534&amp;title=Talk to Rya at her location past the Temple of Eiglay Grace(don't give her the potion)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2204&amp;y=2974&amp;id=playthrough_534&amp;link=/checklists/walkthrough.html%23item_534&amp;title=Talk to Rya at her location past the Temple of Eiglay Grace(don't give her the potion)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_535" id="item_535">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="29" id="playthrough_535" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_535">Reload and read the note she left at her location.</label>
-                    <a class="ms-2" href="/map.html?x=2204&amp;y=2974&amp;id=playthrough_535&amp;link=/checklists/walkthrough.html%23item_535&amp;title=Reload and read the note she left at her location.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2204&amp;y=2974&amp;id=playthrough_535&amp;link=/checklists/walkthrough.html%23item_535&amp;title=Reload and read the note she left at her location."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_536" id="item_536">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="29" id="playthrough_536" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_536">Go to the Shaded Castle Inner Gate Grace in Shaded Castle and continue through, up the lift to the bossroom to talk to Patches on the bridge full of statues and receive the Dancer's Castanettes from him.</label>
-                    <a class="ms-2" href="/map.html?x=2893&amp;y=2639&amp;id=playthrough_536&amp;link=/checklists/walkthrough.html%23item_536&amp;title=Go to the Shaded Castle Inner Gate Grace in Shaded Castle and continue through, up the lift to the bossroom to talk to Patches on the bridge full of statues and receive the Dancer's Castanettes from him.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2893&amp;y=2639&amp;id=playthrough_536&amp;link=/checklists/walkthrough.html%23item_536&amp;title=Go to the Shaded Castle Inner Gate Grace in Shaded Castle and continue through, up the lift to the bossroom to talk to Patches on the bridge full of statues and receive the Dancer's Castanettes from him."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_537" id="item_537">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="29" id="playthrough_537" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_537">Go back to the Rykard, Lord of Blasphemy Grace, talk Tanith nearby and exhaust her dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=2282&amp;y=2949&amp;id=playthrough_537&amp;link=/checklists/walkthrough.html%23item_537&amp;title=Go back to the Rykard, Lord of Blasphemy Grace, talk Tanith nearby and exhaust her dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2282&amp;y=2949&amp;id=playthrough_537&amp;link=/checklists/walkthrough.html%23item_537&amp;title=Go back to the Rykard, Lord of Blasphemy Grace, talk Tanith nearby and exhaust her dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_538" id="item_538">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="29" id="playthrough_538" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_538">Kill Tanith and her Crucible Knight</label>
-                    <a class="ms-2" href="/map.html?x=2282&amp;y=2949&amp;id=playthrough_538&amp;link=/checklists/walkthrough.html%23item_538&amp;title=Kill Tanith and her Crucible Knight">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=2282&amp;y=2949&amp;id=playthrough_538&amp;link=/checklists/walkthrough.html%23item_538&amp;title=Kill Tanith and her Crucible Knight"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_539" id="item_539">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="29" id="playthrough_539" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_539">Go to Murkwater Cave in Limgrave and meet Patches again in his old bossroom(this is his current permanent location)</label>
-                    <a class="ms-2" href="/map.html?x=4042&amp;y=6975&amp;id=playthrough_539&amp;link=/checklists/walkthrough.html%23item_539&amp;title=Go to Murkwater Cave in Limgrave and meet Patches again in his old bossroom(this is his current permanent location)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4042&amp;y=6975&amp;id=playthrough_539&amp;link=/checklists/walkthrough.html%23item_539&amp;title=Go to Murkwater Cave in Limgrave and meet Patches again in his old bossroom(this is his current permanent location)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -5763,9 +4595,7 @@
         <div class="card shadow-sm mb-3" id="playthrough_section_30">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_30Col" data-bs-toggle="collapse" href="#playthrough_30Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_30Col" data-bs-toggle="collapse" href="#playthrough_30Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Mountaintops of the Giants Part 2</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="playthrough_totals_30"></span>
             </h4>
@@ -5775,144 +4605,112 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="30" id="playthrough_540" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_540">Start at the Ancient Snow Valley Grace and head North-East to the frozen river. Continue North-East to Freezing Lake Grace</label>
-                    <a class="ms-2" href="/map.html?x=6348&amp;y=1841&amp;id=playthrough_540&amp;link=/checklists/walkthrough.html%23item_540&amp;title=Start at the Ancient Snow Valley Grace and head North-East to the frozen river. Continue North-East to Freezing Lake Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6348&amp;y=1841&amp;id=playthrough_540&amp;link=/checklists/walkthrough.html%23item_540&amp;title=Start at the Ancient Snow Valley Grace and head North-East to the frozen river. Continue North-East to Freezing Lake Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_541" id="item_541">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="30" id="playthrough_541" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_541">Go up the slope to the North and head South-West up the slope to grab the Snow Valley Ruins Overlook Grace.</label>
-                    <a class="ms-2" href="/map.html?x=6136&amp;y=1961&amp;id=playthrough_541&amp;link=/checklists/walkthrough.html%23item_541&amp;title=Go up the slope to the North and head South-West up the slope to grab the Snow Valley Ruins Overlook Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6136&amp;y=1961&amp;id=playthrough_541&amp;link=/checklists/walkthrough.html%23item_541&amp;title=Go up the slope to the North and head South-West up the slope to grab the Snow Valley Ruins Overlook Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_542" id="item_542">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="30" id="playthrough_542" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_542">Head North-West from the Grace, behind the gravestones, and kill the boss, Tibia Mariner for the Eighth Deathroot</label>
-                    <a class="ms-2" href="/map.html?x=6016&amp;y=1922&amp;id=playthrough_542&amp;link=/checklists/walkthrough.html%23item_542&amp;title=Head North-West from the Grace, behind the gravestones, and kill the boss, Tibia Mariner for the Eighth Deathroot">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6016&amp;y=1922&amp;id=playthrough_542&amp;link=/checklists/walkthrough.html%23item_542&amp;title=Head North-West from the Grace, behind the gravestones, and kill the boss, Tibia Mariner for the Eighth Deathroot"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_543" id="item_543">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="30" id="playthrough_543" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_543">Continue West and down the slop going North-East to grab the Castle Sol Main Gate Grace</label>
-                    <a class="ms-2" href="/map.html?x=6004&amp;y=1854&amp;id=playthrough_543&amp;link=/checklists/walkthrough.html%23item_543&amp;title=Continue West and down the slop going North-East to grab the Castle Sol Main Gate Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6004&amp;y=1854&amp;id=playthrough_543&amp;link=/checklists/walkthrough.html%23item_543&amp;title=Continue West and down the slop going North-East to grab the Castle Sol Main Gate Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_544" id="item_544">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="30" id="playthrough_544" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_544">Go into Castle Sol and up the stairs to the church to grab the Church of the Eclipse Grace</label>
-                    <a class="ms-2" href="/map.html?x=6087&amp;y=1806&amp;id=playthrough_544&amp;link=/checklists/walkthrough.html%23item_544&amp;title=Go into Castle Sol and up the stairs to the church to grab the Church of the Eclipse Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6087&amp;y=1806&amp;id=playthrough_544&amp;link=/checklists/walkthrough.html%23item_544&amp;title=Go into Castle Sol and up the stairs to the church to grab the Church of the Eclipse Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_545" id="item_545">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="30" id="playthrough_545" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_545">Go deeper into the church and through the back door to grab the shortcut to the boss room, then go inside and kill the boss, Commander Niall</label>
-                    <a class="ms-2" href="/map.html?x=6100&amp;y=1725&amp;id=playthrough_545&amp;link=/checklists/walkthrough.html%23item_545&amp;title=Go deeper into the church and through the back door to grab the shortcut to the boss room, then go inside and kill the boss, Commander Niall">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6100&amp;y=1725&amp;id=playthrough_545&amp;link=/checklists/walkthrough.html%23item_545&amp;title=Go deeper into the church and through the back door to grab the shortcut to the boss room, then go inside and kill the boss, Commander Niall"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_546" id="item_546">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="30" id="playthrough_546" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_546">Grab the Castle Sol Rooftop Grace</label>
-                    <a class="ms-2" href="/map.html?x=6100&amp;y=1725&amp;id=playthrough_546&amp;link=/checklists/walkthrough.html%23item_546&amp;title=Grab the Castle Sol Rooftop Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6100&amp;y=1725&amp;id=playthrough_546&amp;link=/checklists/walkthrough.html%23item_546&amp;title=Grab the Castle Sol Rooftop Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_547" id="item_547">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="30" id="playthrough_547" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_547">Go up the lift in the boss room to grab the Haligtree Secret Medallion (Left)</label>
-                    <a class="ms-2" href="/map.html?x=6106&amp;y=1640&amp;id=playthrough_547&amp;link=/checklists/walkthrough.html%23item_547&amp;title=Go up the lift in the boss room to grab the Haligtree Secret Medallion (Left)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6106&amp;y=1640&amp;id=playthrough_547&amp;link=/checklists/walkthrough.html%23item_547&amp;title=Go up the lift in the boss room to grab the Haligtree Secret Medallion (Left)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_548" id="item_548">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="30" id="playthrough_548" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_548">Go back to the Freezing Lake Grace and head across the lake going South-East until you reach the South-East corner to grab the First Church of Marika Grace</label>
-                    <a class="ms-2" href="/map.html?x=6754&amp;y=2370&amp;id=playthrough_548&amp;link=/checklists/walkthrough.html%23item_548&amp;title=Go back to the Freezing Lake Grace and head across the lake going South-East until you reach the South-East corner to grab the First Church of Marika Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6754&amp;y=2370&amp;id=playthrough_548&amp;link=/checklists/walkthrough.html%23item_548&amp;title=Go back to the Freezing Lake Grace and head across the lake going South-East until you reach the South-East corner to grab the First Church of Marika Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_549" id="item_549">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="30" id="playthrough_549" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_549">Rest at the Grace to talk to Melina and exhaust her dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=6754&amp;y=2370&amp;id=playthrough_549&amp;link=/checklists/walkthrough.html%23item_549&amp;title=Rest at the Grace to talk to Melina and exhaust her dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6754&amp;y=2370&amp;id=playthrough_549&amp;link=/checklists/walkthrough.html%23item_549&amp;title=Rest at the Grace to talk to Melina and exhaust her dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_550" id="item_550">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="30" id="playthrough_550" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_550">Head West to grab the Whiteridge Road Grace</label>
-                    <a class="ms-2" href="/map.html?x=6311&amp;y=2302&amp;id=playthrough_550&amp;link=/checklists/walkthrough.html%23item_550&amp;title=Head West to grab the Whiteridge Road Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6311&amp;y=2302&amp;id=playthrough_550&amp;link=/checklists/walkthrough.html%23item_550&amp;title=Head West to grab the Whiteridge Road Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_551" id="item_551">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="30" id="playthrough_551" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_551">Head South and go across the bridge to grab the Giants' Gravepost Grace</label>
-                    <a class="ms-2" href="/map.html?x=6215&amp;y=2620&amp;id=playthrough_551&amp;link=/checklists/walkthrough.html%23item_551&amp;title=Head South and go across the bridge to grab the Giants' Gravepost Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6215&amp;y=2620&amp;id=playthrough_551&amp;link=/checklists/walkthrough.html%23item_551&amp;title=Head South and go across the bridge to grab the Giants' Gravepost Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_553" id="item_553">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="30" id="playthrough_553" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_553">Go South/South-West to the Church of Repose to kill the Invader, Bloody Finger Okina</label>
-                    <a class="ms-2" href="/map.html?x=6000&amp;y=2995&amp;id=playthrough_553&amp;link=/checklists/walkthrough.html%23item_553&amp;title=Go South/South-West to the Church of Repose to kill the Invader, Bloody Finger Okina">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6000&amp;y=2995&amp;id=playthrough_553&amp;link=/checklists/walkthrough.html%23item_553&amp;title=Go South/South-West to the Church of Repose to kill the Invader, Bloody Finger Okina"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_554" id="item_554">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="30" id="playthrough_554" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_554">Head East to grab the Foot of the Forge Grace</label>
-                    <a class="ms-2" href="/map.html?x=6189&amp;y=2994&amp;id=playthrough_554&amp;link=/checklists/walkthrough.html%23item_554&amp;title=Head East to grab the Foot of the Forge Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6189&amp;y=2994&amp;id=playthrough_554&amp;link=/checklists/walkthrough.html%23item_554&amp;title=Head East to grab the Foot of the Forge Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_555" id="item_555">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="30" id="playthrough_555" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_555">Use the boss door just North-East of the Grace to enter the boss room, summon Alexander and ill the Fire Giant</label>
-                    <a class="ms-2" href="/map.html?x=6355&amp;y=3160&amp;id=playthrough_555&amp;link=/checklists/walkthrough.html%23item_555&amp;title=Use the boss door just North-East of the Grace to enter the boss room, summon Alexander and ill the Fire Giant">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6355&amp;y=3160&amp;id=playthrough_555&amp;link=/checklists/walkthrough.html%23item_555&amp;title=Use the boss door just North-East of the Grace to enter the boss room, summon Alexander and ill the Fire Giant"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_556" id="item_556">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="30" id="playthrough_556" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_556">Grab the Fire Giant Grace nearby but DO NOT PROCEED TO THE FORGE YET</label>
-                    <a class="ms-2" href="/map.html?x=6445&amp;y=3177&amp;id=playthrough_556&amp;link=/checklists/walkthrough.html%23item_556&amp;title=Grab the Fire Giant Grace nearby but DO NOT PROCEED TO THE FORGE YET">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6445&amp;y=3177&amp;id=playthrough_556&amp;link=/checklists/walkthrough.html%23item_556&amp;title=Grab the Fire Giant Grace nearby but DO NOT PROCEED TO THE FORGE YET"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -5922,9 +4720,7 @@
         <div class="card shadow-sm mb-3" id="playthrough_section_31">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_31Col" data-bs-toggle="collapse" href="#playthrough_31Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_31Col" data-bs-toggle="collapse" href="#playthrough_31Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Leyndell Sewers and the Frenzied Flame</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="playthrough_totals_31"></span>
             </h4>
@@ -5934,144 +4730,112 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="31" id="playthrough_557" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_557">Go back to the Underground Roadside Grace in the sewers beneath Leyndell and follow the directions below to unlock all the shortcuts and reach the Forsaken Depths Grace(The sewers are confusing so the instructions will be a little difficult to follow unfortunately)</label>
-                    <a class="ms-2" href="/map.html?x=4350&amp;y=3486&amp;id=playthrough_557&amp;link=/checklists/walkthrough.html%23item_557&amp;title=Go back to the Underground Roadside Grace in the sewers beneath Leyndell and follow the directions below to unlock all the shortcuts and reach the Forsaken Depths Grace(The sewers are confusing so the instructions will be a little difficult to follow unfortunately)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4350&amp;y=3486&amp;id=playthrough_557&amp;link=/checklists/walkthrough.html%23item_557&amp;title=Go back to the Underground Roadside Grace in the sewers beneath Leyndell and follow the directions below to unlock all the shortcuts and reach the Forsaken Depths Grace(The sewers are confusing so the instructions will be a little difficult to follow unfortunately)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_558" id="item_558">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="31" id="playthrough_558" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_558">Take a left and jump down the large open grate. Follow the path and look to your right for the large pipe opening and go inside of it. Follow the path, being careful to jump over the hole, and take the path that slopes upwards. Jump over the hole at the top of the slope and take a right at the fork. Climb the ladder and go through the to find a lever and a closed door. Pull the lever to open up the first shortcut.</label>
-                    <a class="ms-2" href="/map.html?x=4350&amp;y=3486&amp;id=playthrough_558&amp;link=/checklists/walkthrough.html%23item_558&amp;title=Take a left and jump down the large open grate. Follow the path and look to your right for the large pipe opening and go inside of it. Follow the path, being careful to jump over the hole, and take the path that slopes upwards. Jump over the hole at the top of the slope and take a right at the fork. Climb the ladder and go through the to find a lever and a closed door. Pull the lever to open up the first shortcut.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4350&amp;y=3486&amp;id=playthrough_558&amp;link=/checklists/walkthrough.html%23item_558&amp;title=Take a left and jump down the large open grate. Follow the path and look to your right for the large pipe opening and go inside of it. Follow the path, being careful to jump over the hole, and take the path that slopes upwards. Jump over the hole at the top of the slope and take a right at the fork. Climb the ladder and go through the to find a lever and a closed door. Pull the lever to open up the first shortcut."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_559" id="item_559">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="31" id="playthrough_559" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_559">Open the closed door and go through it. Turn left and hop down to the path below. Turn around and go down the stairs. Keep making lefts as you follow the path until you reach the flowers. Hop down to the flowers then turn around and enter the path behind you. Continue straight to the end of the path then make a right and go up the slope to enter an open room with an Omen and two ladders. Climb the ladder on the right side and go through the doorway. Open the door in front of you to unloack the shortcut right in front of the Underground Roadside Grace.</label>
-                    <a class="ms-2" href="/map.html?x=4426&amp;y=3451&amp;id=playthrough_559&amp;link=/checklists/walkthrough.html%23item_559&amp;title=Open the closed door and go through it. Turn left and hop down to the path below. Turn around and go down the stairs. Keep making lefts as you follow the path until you reach the flowers. Hop down to the flowers then turn around and enter the path behind you. Continue straight to the end of the path then make a right and go up the slope to enter an open room with an Omen and two ladders. Climb the ladder on the right side and go through the doorway. Open the door in front of you to unloack the shortcut right in front of the Underground Roadside Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4426&amp;y=3451&amp;id=playthrough_559&amp;link=/checklists/walkthrough.html%23item_559&amp;title=Open the closed door and go through it. Turn left and hop down to the path below. Turn around and go down the stairs. Keep making lefts as you follow the path until you reach the flowers. Hop down to the flowers then turn around and enter the path behind you. Continue straight to the end of the path then make a right and go up the slope to enter an open room with an Omen and two ladders. Climb the ladder on the right side and go through the doorway. Open the door in front of you to unloack the shortcut right in front of the Underground Roadside Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_560" id="item_560">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="31" id="playthrough_560" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_560">After opening the door, turn around and take the pipe sloping upwards on your right. Follow it all the way to the top then hop down to the left. Hop up onto the wooden path just above and go through the doorway. Jump down onto the open-top pipe just in front of you and enter it. Take the path going East, then turn left and immediately turn left again to go down the slope. Follow the path going right to a hole and jump INTO the hole this time. Follow the path to find a ladder then go down the ladder to see a giant pot. To the right of the pot is a lift, take the lift down and grab the Forsaken Depths Grace.</label>
-                    <a class="ms-2" href="/map.html?x=4350&amp;y=3486&amp;id=playthrough_560&amp;link=/checklists/walkthrough.html%23item_560&amp;title=After opening the door, turn around and take the pipe sloping upwards on your right. Follow it all the way to the top then hop down to the left. Hop up onto the wooden path just above and go through the doorway. Jump down onto the open-top pipe just in front of you and enter it. Take the path going East, then turn left and immediately turn left again to go down the slope. Follow the path going right to a hole and jump INTO the hole this time. Follow the path to find a ladder then go down the ladder to see a giant pot. To the right of the pot is a lift, take the lift down and grab the Forsaken Depths Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4350&amp;y=3486&amp;id=playthrough_560&amp;link=/checklists/walkthrough.html%23item_560&amp;title=After opening the door, turn around and take the pipe sloping upwards on your right. Follow it all the way to the top then hop down to the left. Hop up onto the wooden path just above and go through the doorway. Jump down onto the open-top pipe just in front of you and enter it. Take the path going East, then turn left and immediately turn left again to go down the slope. Follow the path going right to a hole and jump INTO the hole this time. Follow the path to find a ladder then go down the ladder to see a giant pot. To the right of the pot is a lift, take the lift down and grab the Forsaken Depths Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_561" id="item_561">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="31" id="playthrough_561" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_561">Enter the boss room to kill the boss, Mohg, The Omen</label>
-                    <a class="ms-2" href="/map.html?x=4448&amp;y=3471&amp;id=playthrough_561&amp;link=/checklists/walkthrough.html%23item_561&amp;title=Enter the boss room to kill the boss, Mohg, The Omen">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4448&amp;y=3471&amp;id=playthrough_561&amp;link=/checklists/walkthrough.html%23item_561&amp;title=Enter the boss room to kill the boss, Mohg, The Omen"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_562" id="item_562">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="31" id="playthrough_562" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_562">Grab the Cathedral of the Forsaken Grace.</label>
-                    <a class="ms-2" href="/map.html?x=4570&amp;y=3402&amp;id=playthrough_562&amp;link=/checklists/walkthrough.html%23item_562&amp;title=Grab the Cathedral of the Forsaken Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4570&amp;y=3402&amp;id=playthrough_562&amp;link=/checklists/walkthrough.html%23item_562&amp;title=Grab the Cathedral of the Forsaken Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_563" id="item_563">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="31" id="playthrough_563" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_563">Rest at the Grace to talk to Melina and exhaust her dialogue</label>
-                    <a class="ms-2" href="/map.html?x=4570&amp;y=3402&amp;id=playthrough_563&amp;link=/checklists/walkthrough.html%23item_563&amp;title=Rest at the Grace to talk to Melina and exhaust her dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4570&amp;y=3402&amp;id=playthrough_563&amp;link=/checklists/walkthrough.html%23item_563&amp;title=Rest at the Grace to talk to Melina and exhaust her dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_564" id="item_564">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="31" id="playthrough_564" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_564">Hit the altar to break the illusion and reveal the path forward. Make your way down the passage until you reach the bottom to grab the Frenzied Flame Proscription Grace.</label>
-                    <a class="ms-2" href="/map.html?x=4622&amp;y=3385&amp;id=playthrough_564&amp;link=/checklists/walkthrough.html%23item_564&amp;title=Hit the altar to break the illusion and reveal the path forward. Make your way down the passage until you reach the bottom to grab the Frenzied Flame Proscription Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4622&amp;y=3385&amp;id=playthrough_564&amp;link=/checklists/walkthrough.html%23item_564&amp;title=Hit the altar to break the illusion and reveal the path forward. Make your way down the passage until you reach the bottom to grab the Frenzied Flame Proscription Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_565" id="item_565">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="31" id="playthrough_565" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_565">Talk to Hyetta nearby and exhaust her dialogue</label>
-                    <a class="ms-2" href="/map.html?x=4622&amp;y=3385&amp;id=playthrough_565&amp;link=/checklists/walkthrough.html%23item_565&amp;title=Talk to Hyetta nearby and exhaust her dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4622&amp;y=3385&amp;id=playthrough_565&amp;link=/checklists/walkthrough.html%23item_565&amp;title=Talk to Hyetta nearby and exhaust her dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_566" id="item_566">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="31" id="playthrough_566" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_566">Rest at the Grace to talk to Melina and exhaust her dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=4622&amp;y=3385&amp;id=playthrough_566&amp;link=/checklists/walkthrough.html%23item_566&amp;title=Rest at the Grace to talk to Melina and exhaust her dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4622&amp;y=3385&amp;id=playthrough_566&amp;link=/checklists/walkthrough.html%23item_566&amp;title=Rest at the Grace to talk to Melina and exhaust her dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_567" id="item_567">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="31" id="playthrough_567" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_567">YOU NOW HAVE A CHOICE!!! This choice only affects cutscenes/dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=4622&amp;y=3385&amp;id=playthrough_567&amp;link=/checklists/walkthrough.html%23item_567&amp;title=YOU NOW HAVE A CHOICE!!! This choice only affects cutscenes/dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4622&amp;y=3385&amp;id=playthrough_567&amp;link=/checklists/walkthrough.html%23item_567&amp;title=YOU NOW HAVE A CHOICE!!! This choice only affects cutscenes/dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_568" id="item_568">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="31" id="playthrough_568" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_568">Choice A is to take the Frenzied Flame NOW. This leads to a dialogue with Melina, an alternate cutscene at the Forge of Giants, and a cutscene with Melina if you choose the Frenzied Flame Ending.</label>
-                    <a class="ms-2" href="/map.html?x=4622&amp;y=3385&amp;id=playthrough_568&amp;link=/checklists/walkthrough.html%23item_568&amp;title=Choice A is to take the Frenzied Flame NOW. This leads to a dialogue with Melina, an alternate cutscene at the Forge of Giants, and a cutscene with Melina if you choose the Frenzied Flame Ending.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4622&amp;y=3385&amp;id=playthrough_568&amp;link=/checklists/walkthrough.html%23item_568&amp;title=Choice A is to take the Frenzied Flame NOW. This leads to a dialogue with Melina, an alternate cutscene at the Forge of Giants, and a cutscene with Melina if you choose the Frenzied Flame Ending."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_569" id="item_569">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="31" id="playthrough_569" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_569">Choice B is to wait until after Melina sacrifices herself to grab the Frenzied Flame. This will result in the normal cutscene at the Forge of Giants all the things from Choice A will not occur. For this Walkthrough, we will follow choice A.</label>
-                    <a class="ms-2" href="/map.html?x=4622&amp;y=3385&amp;id=playthrough_569&amp;link=/checklists/walkthrough.html%23item_569&amp;title=Choice B is to wait until after Melina sacrifices herself to grab the Frenzied Flame. This will result in the normal cutscene at the Forge of Giants all the things from Choice A will not occur. For this Walkthrough, we will follow choice A.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4622&amp;y=3385&amp;id=playthrough_569&amp;link=/checklists/walkthrough.html%23item_569&amp;title=Choice B is to wait until after Melina sacrifices herself to grab the Frenzied Flame. This will result in the normal cutscene at the Forge of Giants all the things from Choice A will not occur. For this Walkthrough, we will follow choice A."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_570" id="item_570">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="31" id="playthrough_570" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_570">Take off all of your equipment and open the doors to the Frenzied Flame. A cutscene will play.</label>
-                    <a class="ms-2" href="/map.html?x=4622&amp;y=3385&amp;id=playthrough_570&amp;link=/checklists/walkthrough.html%23item_570&amp;title=Take off all of your equipment and open the doors to the Frenzied Flame. A cutscene will play.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4622&amp;y=3385&amp;id=playthrough_570&amp;link=/checklists/walkthrough.html%23item_570&amp;title=Take off all of your equipment and open the doors to the Frenzied Flame. A cutscene will play."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_571" id="item_571">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="31" id="playthrough_571" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_571">Talk to Hyetta and exhaust her dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=4622&amp;y=3385&amp;id=playthrough_571&amp;link=/checklists/walkthrough.html%23item_571&amp;title=Talk to Hyetta and exhaust her dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4622&amp;y=3385&amp;id=playthrough_571&amp;link=/checklists/walkthrough.html%23item_571&amp;title=Talk to Hyetta and exhaust her dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_572" id="item_572">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="31" id="playthrough_572" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_572">Rest at the Grace to talk to Melina and exhaust her dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=4622&amp;y=3385&amp;id=playthrough_572&amp;link=/checklists/walkthrough.html%23item_572&amp;title=Rest at the Grace to talk to Melina and exhaust her dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4622&amp;y=3385&amp;id=playthrough_572&amp;link=/checklists/walkthrough.html%23item_572&amp;title=Rest at the Grace to talk to Melina and exhaust her dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -6081,9 +4845,7 @@
         <div class="card shadow-sm mb-3" id="playthrough_section_32">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_32Col" data-bs-toggle="collapse" href="#playthrough_32Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_32Col" data-bs-toggle="collapse" href="#playthrough_32Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Hidden Path to the Haligtree</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="playthrough_totals_32"></span>
             </h4>
@@ -6093,36 +4855,28 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="32" id="playthrough_573" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_573">Go back to the Grand Lift of Rold Grace and use the lift. However, switch the medallion option to Use the Secret Medallion. Once you've finished riding the lift, follow the path forward to grab the Hidden Path to the Haligtree Grace</label>
-                    <a class="ms-2" href="/map.html?x=5401&amp;y=2805&amp;id=playthrough_573&amp;link=/checklists/walkthrough.html%23item_573&amp;title=Go back to the Grand Lift of Rold Grace and use the lift. However, switch the medallion option to Use the Secret Medallion. Once you've finished riding the lift, follow the path forward to grab the Hidden Path to the Haligtree Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5401&amp;y=2805&amp;id=playthrough_573&amp;link=/checklists/walkthrough.html%23item_573&amp;title=Go back to the Grand Lift of Rold Grace and use the lift. However, switch the medallion option to Use the Secret Medallion. Once you've finished riding the lift, follow the path forward to grab the Hidden Path to the Haligtree Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_574" id="item_574">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="32" id="playthrough_574" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_574">Once you have grabbed the Grace, turn around and go back to the platform with the railings and find where the railing is broken. Fall off the edge where that railing is to reveal the invisible path below.</label>
-                    <a class="ms-2" href="/map.html?x=5468&amp;y=2834&amp;id=playthrough_574&amp;link=/checklists/walkthrough.html%23item_574&amp;title=Once you have grabbed the Grace, turn around and go back to the platform with the railings and find where the railing is broken. Fall off the edge where that railing is to reveal the invisible path below.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5468&amp;y=2834&amp;id=playthrough_574&amp;link=/checklists/walkthrough.html%23item_574&amp;title=Once you have grabbed the Grace, turn around and go back to the platform with the railings and find where the railing is broken. Fall off the edge where that railing is to reveal the invisible path below."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_575" id="item_575">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="32" id="playthrough_575" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_575">Follow the invible path using messages, bloodstains, rainbow stones, or the Hoarfrost Stomp Ash of War to it different locations but the specific path we want to follow is the one going West to the doorway. At the doorway, before entering, look to your left to see a corpse on a platform below. Jump down to the platform and jump through either windowsill and pull the lever on the North side behind the giant kraken. Turn South and head through the pathway to find the boss room.</label>
-                    <a class="ms-2" href="/map.html?x=5419&amp;y=2884&amp;id=playthrough_575&amp;link=/checklists/walkthrough.html%23item_575&amp;title=Follow the invible path using messages, bloodstains, rainbow stones, or the Hoarfrost Stomp Ash of War to it different locations but the specific path we want to follow is the one going West to the doorway. At the doorway, before entering, look to your left to see a corpse on a platform below. Jump down to the platform and jump through either windowsill and pull the lever on the North side behind the giant kraken. Turn South and head through the pathway to find the boss room.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5419&amp;y=2884&amp;id=playthrough_575&amp;link=/checklists/walkthrough.html%23item_575&amp;title=Follow the invible path using messages, bloodstains, rainbow stones, or the Hoarfrost Stomp Ash of War to it different locations but the specific path we want to follow is the one going West to the doorway. At the doorway, before entering, look to your left to see a corpse on a platform below. Jump down to the platform and jump through either windowsill and pull the lever on the North side behind the giant kraken. Turn South and head through the pathway to find the boss room."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_576" id="item_576">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="32" id="playthrough_576" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_576">Enter the boss room and kill the boss, Stray Mimic Tear and open the nearby chest for the Ninth and final Deathroot.</label>
-                    <a class="ms-2" href="/map.html?x=5419&amp;y=2884&amp;id=playthrough_576&amp;link=/checklists/walkthrough.html%23item_576&amp;title=Enter the boss room and kill the boss, Stray Mimic Tear and open the nearby chest for the Ninth and final Deathroot.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5419&amp;y=2884&amp;id=playthrough_576&amp;link=/checklists/walkthrough.html%23item_576&amp;title=Enter the boss room and kill the boss, Stray Mimic Tear and open the nearby chest for the Ninth and final Deathroot."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -6132,9 +4886,7 @@
         <div class="card shadow-sm mb-3" id="playthrough_section_33">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_33Col" data-bs-toggle="collapse" href="#playthrough_33Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_33Col" data-bs-toggle="collapse" href="#playthrough_33Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Gurranq/Gowry/Gideon/Consecrated Snowfield</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="playthrough_totals_33"></span>
             </h4>
@@ -6144,117 +4896,91 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="33" id="playthrough_577" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_577">Return to the Bestial Sanctum to talk to Gurranq, give him the remaining Deathroot and exhaust his dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=5968&amp;y=5488&amp;id=playthrough_577&amp;link=/checklists/walkthrough.html%23item_577&amp;title=Return to the Bestial Sanctum to talk to Gurranq, give him the remaining Deathroot and exhaust his dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5968&amp;y=5488&amp;id=playthrough_577&amp;link=/checklists/walkthrough.html%23item_577&amp;title=Return to the Bestial Sanctum to talk to Gurranq, give him the remaining Deathroot and exhaust his dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_578" id="item_578">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="33" id="playthrough_578" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_578">Return to Gowry at Gowry's Shack to talk to him and exhaust his dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=5672&amp;y=6738&amp;id=playthrough_578&amp;link=/checklists/walkthrough.html%23item_578&amp;title=Return to Gowry at Gowry's Shack to talk to him and exhaust his dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5672&amp;y=6738&amp;id=playthrough_578&amp;link=/checklists/walkthrough.html%23item_578&amp;title=Return to Gowry at Gowry's Shack to talk to him and exhaust his dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_579" id="item_579">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="33" id="playthrough_579" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_579">Buy the spell, Pest Threads, from Gowry.</label>
-                    <a class="ms-2" href="/map.html?x=5672&amp;y=6738&amp;id=playthrough_579&amp;link=/checklists/walkthrough.html%23item_579&amp;title=Buy the spell, Pest Threads, from Gowry.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5672&amp;y=6738&amp;id=playthrough_579&amp;link=/checklists/walkthrough.html%23item_579&amp;title=Buy the spell, Pest Threads, from Gowry."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_580" id="item_580">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="33" id="playthrough_580" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_580">Talk to Gowry again and exhaust his dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=5672&amp;y=6738&amp;id=playthrough_580&amp;link=/checklists/walkthrough.html%23item_580&amp;title=Talk to Gowry again and exhaust his dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5672&amp;y=6738&amp;id=playthrough_580&amp;link=/checklists/walkthrough.html%23item_580&amp;title=Talk to Gowry again and exhaust his dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_581" id="item_581">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="33" id="playthrough_581" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_581">Return to the Roundtable to talk to Gideon and exhaust all his dialogue options.</label>
-                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_581&amp;link=/checklists/walkthrough.html%23item_581&amp;title=Return to the Roundtable to talk to Gideon and exhaust all his dialogue options.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_581&amp;link=/checklists/walkthrough.html%23item_581&amp;title=Return to the Roundtable to talk to Gideon and exhaust all his dialogue options."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_582" id="item_582">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="33" id="playthrough_582" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_582">From the Hidden Path to the Haligtree Grace, head outside and grab the Consecrated Snowfield Grace.</label>
-                    <a class="ms-2" href="/map.html?x=5405&amp;y=2691&amp;id=playthrough_582&amp;link=/checklists/walkthrough.html%23item_582&amp;title=From the Hidden Path to the Haligtree Grace, head outside and grab the Consecrated Snowfield Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5405&amp;y=2691&amp;id=playthrough_582&amp;link=/checklists/walkthrough.html%23item_582&amp;title=From the Hidden Path to the Haligtree Grace, head outside and grab the Consecrated Snowfield Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_583" id="item_583">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="33" id="playthrough_583" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_583">Head North from the Grace to grab the Inner Consecrated Snowfield Grace</label>
-                    <a class="ms-2" href="/map.html?x=5401&amp;y=2332&amp;id=playthrough_583&amp;link=/checklists/walkthrough.html%23item_583&amp;title=Head North from the Grace to grab the Inner Consecrated Snowfield Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5401&amp;y=2332&amp;id=playthrough_583&amp;link=/checklists/walkthrough.html%23item_583&amp;title=Head North from the Grace to grab the Inner Consecrated Snowfield Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_584" id="item_584">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="33" id="playthrough_584" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_584">Go North to grab Map (Mountaintops of the Giants, West)</label>
-                    <a class="ms-2" href="/map.html?x=5352&amp;y=2152&amp;id=playthrough_584&amp;link=/checklists/walkthrough.html%23item_584&amp;title=Go North to grab Map (Mountaintops of the Giants, West)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5352&amp;y=2152&amp;id=playthrough_584&amp;link=/checklists/walkthrough.html%23item_584&amp;title=Go North to grab Map (Mountaintops of the Giants, West)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_585" id="item_585">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="33" id="playthrough_585" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_585">Head North-West to grab the Ordina, Liturgical Town Grace</label>
-                    <a class="ms-2" href="/map.html?x=5271&amp;y=1956&amp;id=playthrough_585&amp;link=/checklists/walkthrough.html%23item_585&amp;title=Head North-West to grab the Ordina, Liturgical Town Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5271&amp;y=1956&amp;id=playthrough_585&amp;link=/checklists/walkthrough.html%23item_585&amp;title=Head North-West to grab the Ordina, Liturgical Town Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_586" id="item_586">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="33" id="playthrough_586" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_586">Interact with the Imp Statue on the North side of town to enter the Evergaol.</label>
-                    <a class="ms-2" href="/map.html?x=5293&amp;y=1887&amp;id=playthrough_586&amp;link=/checklists/walkthrough.html%23item_586&amp;title=Interact with the Imp Statue on the North side of town to enter the Evergaol.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5293&amp;y=1887&amp;id=playthrough_586&amp;link=/checklists/walkthrough.html%23item_586&amp;title=Interact with the Imp Statue on the North side of town to enter the Evergaol."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_587" id="item_587">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="33" id="playthrough_587" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_587">Go around the town and light the four statues to break the seal and unlock the entrance to the Haligtree.</label>
-                    <a class="ms-2" href="/map.html?x=5293&amp;y=1887&amp;id=playthrough_587&amp;link=/checklists/walkthrough.html%23item_587&amp;title=Go around the town and light the four statues to break the seal and unlock the entrance to the Haligtree.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5293&amp;y=1887&amp;id=playthrough_587&amp;link=/checklists/walkthrough.html%23item_587&amp;title=Go around the town and light the four statues to break the seal and unlock the entrance to the Haligtree."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_588" id="item_588">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="33" id="playthrough_588" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_588">Head West of the town, across the river, then North-West to grab the Apostate Derelict Grace.</label>
-                    <a class="ms-2" href="/map.html?x=5044&amp;y=1695&amp;id=playthrough_588&amp;link=/checklists/walkthrough.html%23item_588&amp;title=Head West of the town, across the river, then North-West to grab the Apostate Derelict Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5044&amp;y=1695&amp;id=playthrough_588&amp;link=/checklists/walkthrough.html%23item_588&amp;title=Head West of the town, across the river, then North-West to grab the Apostate Derelict Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_589" id="item_589">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="33" id="playthrough_589" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_589">Summon Latenna nearby to talk to her and exhaust her dialogue.</label>
-                    <a class="ms-2" href="/map.html?x=5044&amp;y=1695&amp;id=playthrough_589&amp;link=/checklists/walkthrough.html%23item_589&amp;title=Summon Latenna nearby to talk to her and exhaust her dialogue.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5044&amp;y=1695&amp;id=playthrough_589&amp;link=/checklists/walkthrough.html%23item_589&amp;title=Summon Latenna nearby to talk to her and exhaust her dialogue."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -6264,9 +4990,7 @@
         <div class="card shadow-sm mb-3" id="playthrough_section_34">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_34Col" data-bs-toggle="collapse" href="#playthrough_34Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_34Col" data-bs-toggle="collapse" href="#playthrough_34Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Mohgwyn's Palace</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="playthrough_totals_34"></span>
             </h4>
@@ -6276,90 +5000,70 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="34" id="playthrough_590" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_590">You may have already entered Mohgwyn's Palace by using the Pureblood Knight's Talisman, however we will now enter another way. First, go to the Western edge of the Consecrated Snowfield to kill the Invader, Sanguine Noble.</label>
-                    <a class="ms-2" href="/map.html?x=4982&amp;y=2241&amp;id=playthrough_590&amp;link=/checklists/walkthrough.html%23item_590&amp;title=You may have already entered Mohgwyn's Palace by using the Pureblood Knight's Talisman, however we will now enter another way. First, go to the Western edge of the Consecrated Snowfield to kill the Invader, Sanguine Noble.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4982&amp;y=2241&amp;id=playthrough_590&amp;link=/checklists/walkthrough.html%23item_590&amp;title=You may have already entered Mohgwyn's Palace by using the Pureblood Knight's Talisman, however we will now enter another way. First, go to the Western edge of the Consecrated Snowfield to kill the Invader, Sanguine Noble."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_590_1" id="item_590_1">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="34" id="playthrough_590_1" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_590_1">Head West of the Sanguine Noble, into the corner of the forest and use the Waygate to grab the Palace Approach Ledge-Road Grace</label>
-                    <a class="ms-2" href="/map.html?x=4880&amp;y=2234&amp;id=playthrough_590_1&amp;link=/checklists/walkthrough.html%23item_590_1&amp;title=Head West of the Sanguine Noble, into the corner of the forest and use the Waygate to grab the Palace Approach Ledge-Road Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4880&amp;y=2234&amp;id=playthrough_590_1&amp;link=/checklists/walkthrough.html%23item_590_1&amp;title=Head West of the Sanguine Noble, into the corner of the forest and use the Waygate to grab the Palace Approach Ledge-Road Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_591" id="item_591">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="34" id="playthrough_591" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_591">Explore the blood area in the South until you are Invaded three separate times by the Invaders, Nameless White Masks. Kill all three of the invaders(if you do not, their rewards will be missed)</label>
-                    <a class="ms-2" href="/map.html?x=7016&amp;y=14442&amp;id=playthrough_591&amp;link=/checklists/walkthrough.html%23item_591&amp;title=Explore the blood area in the South until you are Invaded three separate times by the Invaders, Nameless White Masks. Kill all three of the invaders(if you do not, their rewards will be missed)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=7016&amp;y=14442&amp;id=playthrough_591&amp;link=/checklists/walkthrough.html%23item_591&amp;title=Explore the blood area in the South until you are Invaded three separate times by the Invaders, Nameless White Masks. Kill all three of the invaders(if you do not, their rewards will be missed)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_592" id="item_592">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="34" id="playthrough_592" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_592">Make your way to the North-West part of the area to grab the Dynasty Mausoleum Entrance Grace</label>
-                    <a class="ms-2" href="/map.html?x=4880&amp;y=2234&amp;id=playthrough_592&amp;link=/checklists/walkthrough.html%23item_592&amp;title=Make your way to the North-West part of the area to grab the Dynasty Mausoleum Entrance Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=4880&amp;y=2234&amp;id=playthrough_592&amp;link=/checklists/walkthrough.html%23item_592&amp;title=Make your way to the North-West part of the area to grab the Dynasty Mausoleum Entrance Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_593" id="item_593">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="34" id="playthrough_593" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_593">Go through the tunnel to it's end to grab the Dynasty Mausoleum Midpoint Grace</label>
-                    <a class="ms-2" href="/map.html?x=6850&amp;y=14371&amp;id=playthrough_593&amp;link=/checklists/walkthrough.html%23item_593&amp;title=Go through the tunnel to it's end to grab the Dynasty Mausoleum Midpoint Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6850&amp;y=14371&amp;id=playthrough_593&amp;link=/checklists/walkthrough.html%23item_593&amp;title=Go through the tunnel to it's end to grab the Dynasty Mausoleum Midpoint Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_594" id="item_594">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="34" id="playthrough_594" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_594">Turn around and re-enter the tunnel, use the Red Summon Sign to invade White Mask Varre and then kill him.</label>
-                    <a class="ms-2" href="/map.html?x=6850&amp;y=14371&amp;id=playthrough_594&amp;link=/checklists/walkthrough.html%23item_594&amp;title=Turn around and re-enter the tunnel, use the Red Summon Sign to invade White Mask Varre and then kill him.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6850&amp;y=14371&amp;id=playthrough_594&amp;link=/checklists/walkthrough.html%23item_594&amp;title=Turn around and re-enter the tunnel, use the Red Summon Sign to invade White Mask Varre and then kill him."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_595" id="item_595">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="34" id="playthrough_595" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_595">Talk to White Mask Varre near where the Summon Sign was and exhaust his dialogue</label>
-                    <a class="ms-2" href="/map.html?x=6850&amp;y=14371&amp;id=playthrough_595&amp;link=/checklists/walkthrough.html%23item_595&amp;title=Talk to White Mask Varre near where the Summon Sign was and exhaust his dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6850&amp;y=14371&amp;id=playthrough_595&amp;link=/checklists/walkthrough.html%23item_595&amp;title=Talk to White Mask Varre near where the Summon Sign was and exhaust his dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_596" id="item_596">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="34" id="playthrough_596" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_596">Rest at the Grace and make sure to put the Purifying Crystal Tear in your Flask, otherwise this next fight will be very difficult.</label>
-                    <a class="ms-2" href="/map.html?x=6850&amp;y=14371&amp;id=playthrough_596&amp;link=/checklists/walkthrough.html%23item_596&amp;title=Rest at the Grace and make sure to put the Purifying Crystal Tear in your Flask, otherwise this next fight will be very difficult.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6850&amp;y=14371&amp;id=playthrough_596&amp;link=/checklists/walkthrough.html%23item_596&amp;title=Rest at the Grace and make sure to put the Purifying Crystal Tear in your Flask, otherwise this next fight will be very difficult."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_597" id="item_597">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="34" id="playthrough_597" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_597">Continue up the path from the Grace and use the lift to kill the boss, Mohg, Lord of Blood</label>
-                    <a class="ms-2" href="/map.html?x=6796&amp;y=14396&amp;id=playthrough_597&amp;link=/checklists/walkthrough.html%23item_597&amp;title=Continue up the path from the Grace and use the lift to kill the boss, Mohg, Lord of Blood">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6796&amp;y=14396&amp;id=playthrough_597&amp;link=/checklists/walkthrough.html%23item_597&amp;title=Continue up the path from the Grace and use the lift to kill the boss, Mohg, Lord of Blood"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_598" id="item_598">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="34" id="playthrough_598" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_598">Grab the Cocoon of the Empyrean Grace</label>
-                    <a class="ms-2" href="/map.html?x=6756&amp;y=14378&amp;id=playthrough_598&amp;link=/checklists/walkthrough.html%23item_598&amp;title=Grab the Cocoon of the Empyrean Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=6756&amp;y=14378&amp;id=playthrough_598&amp;link=/checklists/walkthrough.html%23item_598&amp;title=Grab the Cocoon of the Empyrean Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -6369,9 +5073,7 @@
         <div class="card shadow-sm mb-3" id="playthrough_section_35">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_35Col" data-bs-toggle="collapse" href="#playthrough_35Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_35Col" data-bs-toggle="collapse" href="#playthrough_35Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Miquella's Haligtree</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="playthrough_totals_35"></span>
             </h4>
@@ -6381,180 +5083,140 @@
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="35" id="playthrough_599" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_599">Go back to the Ordina, Liturgical Town Grace then head North-East to use the Waygate to Miquella's Haligtree and grab the Haligtree Canopy Grace nearby</label>
-                    <a class="ms-2" href="/map.html?x=5610&amp;y=1330&amp;id=playthrough_599&amp;link=/checklists/walkthrough.html%23item_599&amp;title=Go back to the Ordina, Liturgical Town Grace then head North-East to use the Waygate to Miquella's Haligtree and grab the Haligtree Canopy Grace nearby">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5610&amp;y=1330&amp;id=playthrough_599&amp;link=/checklists/walkthrough.html%23item_599&amp;title=Go back to the Ordina, Liturgical Town Grace then head North-East to use the Waygate to Miquella's Haligtree and grab the Haligtree Canopy Grace nearby"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_600" id="item_600">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="35" id="playthrough_600" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_600">Follow the roots past the enemies and grab the Haligtree Town Grace</label>
-                    <a class="ms-2" href="/map.html?x=5673&amp;y=1139&amp;id=playthrough_600&amp;link=/checklists/walkthrough.html%23item_600&amp;title=Follow the roots past the enemies and grab the Haligtree Town Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5673&amp;y=1139&amp;id=playthrough_600&amp;link=/checklists/walkthrough.html%23item_600&amp;title=Follow the roots past the enemies and grab the Haligtree Town Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_601" id="item_601">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="35" id="playthrough_601" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_601">Make your way through the town to grab the Haligtree Town Plaza Grace</label>
-                    <a class="ms-2" href="/map.html?x=5615&amp;y=1075&amp;id=playthrough_601&amp;link=/checklists/walkthrough.html%23item_601&amp;title=Make your way through the town to grab the Haligtree Town Plaza Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5615&amp;y=1075&amp;id=playthrough_601&amp;link=/checklists/walkthrough.html%23item_601&amp;title=Make your way through the town to grab the Haligtree Town Plaza Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_602" id="item_602">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="35" id="playthrough_602" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_602">Continue forward to kill the boss Loretta, Knight of the Haligtree</label>
-                    <a class="ms-2" href="/map.html?x=5785&amp;y=1134&amp;id=playthrough_602&amp;link=/checklists/walkthrough.html%23item_602&amp;title=Continue forward to kill the boss Loretta, Knight of the Haligtree">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5785&amp;y=1134&amp;id=playthrough_602&amp;link=/checklists/walkthrough.html%23item_602&amp;title=Continue forward to kill the boss Loretta, Knight of the Haligtree"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_603" id="item_603">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="35" id="playthrough_603" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_603">Grab the Haligtree Promenade Grace</label>
-                    <a class="ms-2" href="/map.html?x=5786&amp;y=1071&amp;id=playthrough_603&amp;link=/checklists/walkthrough.html%23item_603&amp;title=Grab the Haligtree Promenade Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5786&amp;y=1071&amp;id=playthrough_603&amp;link=/checklists/walkthrough.html%23item_603&amp;title=Grab the Haligtree Promenade Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_604" id="item_604">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="35" id="playthrough_604" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_604">Take the nearby lift down then continue forward to grab the Prayer Room Grace.</label>
-                    <a class="ms-2" href="/map.html?x=5690&amp;y=936&amp;id=playthrough_604&amp;link=/checklists/walkthrough.html%23item_604&amp;title=Take the nearby lift down then continue forward to grab the Prayer Room Grace.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5690&amp;y=936&amp;id=playthrough_604&amp;link=/checklists/walkthrough.html%23item_604&amp;title=Take the nearby lift down then continue forward to grab the Prayer Room Grace."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_605" id="item_605">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="35" id="playthrough_605" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_605">Talk to Millicent and exhaust her dialogue</label>
-                    <a class="ms-2" href="/map.html?x=5690&amp;y=936&amp;id=playthrough_605&amp;link=/checklists/walkthrough.html%23item_605&amp;title=Talk to Millicent and exhaust her dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5690&amp;y=936&amp;id=playthrough_605&amp;link=/checklists/walkthrough.html%23item_605&amp;title=Talk to Millicent and exhaust her dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_606" id="item_606">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="35" id="playthrough_606" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_606">Continue forward, past the enemies and grab the Elphael Inner Wall Grace behind the Erdtree Avatar</label>
-                    <a class="ms-2" href="/map.html?x=5584&amp;y=778&amp;id=playthrough_606&amp;link=/checklists/walkthrough.html%23item_606&amp;title=Continue forward, past the enemies and grab the Elphael Inner Wall Grace behind the Erdtree Avatar">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5584&amp;y=778&amp;id=playthrough_606&amp;link=/checklists/walkthrough.html%23item_606&amp;title=Continue forward, past the enemies and grab the Elphael Inner Wall Grace behind the Erdtree Avatar"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_607" id="item_607">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="35" id="playthrough_607" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_607">Keep following this path to the rot swamp and run through it to the other side then down the ladder to grab the Drainage Channel Grace</label>
-                    <a class="ms-2" href="/map.html?x=5735&amp;y=881&amp;id=playthrough_607&amp;link=/checklists/walkthrough.html%23item_607&amp;title=Keep following this path to the rot swamp and run through it to the other side then down the ladder to grab the Drainage Channel Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5735&amp;y=881&amp;id=playthrough_607&amp;link=/checklists/walkthrough.html%23item_607&amp;title=Keep following this path to the rot swamp and run through it to the other side then down the ladder to grab the Drainage Channel Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_608" id="item_608">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="35" id="playthrough_608" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_608">Turn around and go back up the ladder and look to your left to see an island. Kill the pest nearby then use the root to jump to the island. Enter the center of the rot swamp to kill the Ulcerated Tree Spirit</label>
-                    <a class="ms-2" href="/map.html?x=5662&amp;y=896&amp;id=playthrough_608&amp;link=/checklists/walkthrough.html%23item_608&amp;title=Turn around and go back up the ladder and look to your left to see an island. Kill the pest nearby then use the root to jump to the island. Enter the center of the rot swamp to kill the Ulcerated Tree Spirit">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5662&amp;y=896&amp;id=playthrough_608&amp;link=/checklists/walkthrough.html%23item_608&amp;title=Turn around and go back up the ladder and look to your left to see an island. Kill the pest nearby then use the root to jump to the island. Enter the center of the rot swamp to kill the Ulcerated Tree Spirit"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_609" id="item_609">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="35" id="playthrough_609" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_609">Reload and on the cliff above the swamp where the Ulcerated Tree Spirit spawned will be 2 Summon Signs. One will have you invade and kill Millicent while the other has you save her from her fate. For the purposes of the guide, save her.</label>
-                    <a class="ms-2" href="/map.html?x=5621&amp;y=917&amp;id=playthrough_609&amp;link=/checklists/walkthrough.html%23item_609&amp;title=Reload and on the cliff above the swamp where the Ulcerated Tree Spirit spawned will be 2 Summon Signs. One will have you invade and kill Millicent while the other has you save her from her fate. For the purposes of the guide, save her.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5621&amp;y=917&amp;id=playthrough_609&amp;link=/checklists/walkthrough.html%23item_609&amp;title=Reload and on the cliff above the swamp where the Ulcerated Tree Spirit spawned will be 2 Summon Signs. One will have you invade and kill Millicent while the other has you save her from her fate. For the purposes of the guide, save her."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_610" id="item_610">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="35" id="playthrough_610" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_610">After saving Millicent, speak to her nearby and exhaust her dialogue</label>
-                    <a class="ms-2" href="/map.html?x=5615&amp;y=927&amp;id=playthrough_610&amp;link=/checklists/walkthrough.html%23item_610&amp;title=After saving Millicent, speak to her nearby and exhaust her dialogue">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5615&amp;y=927&amp;id=playthrough_610&amp;link=/checklists/walkthrough.html%23item_610&amp;title=After saving Millicent, speak to her nearby and exhaust her dialogue"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_610_1" id="item_610_1">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="35" id="playthrough_610_1" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_610_1">Reload the area to receive the Unalloyed Gold Needle</label>
-                    <a class="ms-2" href="/map.html?x=5615&amp;y=927&amp;id=playthrough_610_1&amp;link=/checklists/walkthrough.html%23item_610_1&amp;title=Reload the area to receive the Unalloyed Gold Needle">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5615&amp;y=927&amp;id=playthrough_610_1&amp;link=/checklists/walkthrough.html%23item_610_1&amp;title=Reload the area to receive the Unalloyed Gold Needle"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_611" id="item_611">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="35" id="playthrough_611" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_611">Go back to the Drainage Channel Grace and continue forward across the pathways and past the enemies to use the lift inside the building. Take the lift down and grab the Haligtree Roots Grace</label>
-                    <a class="ms-2" href="/map.html?x=5701&amp;y=818&amp;id=playthrough_611&amp;link=/checklists/walkthrough.html%23item_611&amp;title=Go back to the Drainage Channel Grace and continue forward across the pathways and past the enemies to use the lift inside the building. Take the lift down and grab the Haligtree Roots Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5701&amp;y=818&amp;id=playthrough_611&amp;link=/checklists/walkthrough.html%23item_611&amp;title=Go back to the Drainage Channel Grace and continue forward across the pathways and past the enemies to use the lift inside the building. Take the lift down and grab the Haligtree Roots Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_612" id="item_612">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="35" id="playthrough_612" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_612">Keep going to kill the boss Malenia, Blade of Miquella</label>
-                    <a class="ms-2" href="/map.html?x=5574&amp;y=885&amp;id=playthrough_612&amp;link=/checklists/walkthrough.html%23item_612&amp;title=Keep going to kill the boss Malenia, Blade of Miquella">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5574&amp;y=885&amp;id=playthrough_612&amp;link=/checklists/walkthrough.html%23item_612&amp;title=Keep going to kill the boss Malenia, Blade of Miquella"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_613" id="item_613">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="35" id="playthrough_613" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_613">Grab the Malenia, Goddess of Rot Grace</label>
-                    <a class="ms-2" href="/map.html?x=5590&amp;y=889&amp;id=playthrough_613&amp;link=/checklists/walkthrough.html%23item_613&amp;title=Grab the Malenia, Goddess of Rot Grace">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5590&amp;y=889&amp;id=playthrough_613&amp;link=/checklists/walkthrough.html%23item_613&amp;title=Grab the Malenia, Goddess of Rot Grace"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_614" id="item_614">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="35" id="playthrough_614" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_614">Reload and interract with the Scarlet Aeonia flower nearby to turn the Unalloyed Gold Needle into Miquella's Needle</label>
-                    <a class="ms-2" href="/map.html?x=5590&amp;y=889&amp;id=playthrough_614&amp;link=/checklists/walkthrough.html%23item_614&amp;title=Reload and interract with the Scarlet Aeonia flower nearby to turn the Unalloyed Gold Needle into Miquella's Needle">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5590&amp;y=889&amp;id=playthrough_614&amp;link=/checklists/walkthrough.html%23item_614&amp;title=Reload and interract with the Scarlet Aeonia flower nearby to turn the Unalloyed Gold Needle into Miquella's Needle"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_615" id="item_615">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="35" id="playthrough_615" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_615">Return to Gowry at his shack to talk to him and reload(if he isn't dead, kill him)</label>
-                    <a class="ms-2" href="/map.html?x=5672&amp;y=6738&amp;id=playthrough_615&amp;link=/checklists/walkthrough.html%23item_615&amp;title=Return to Gowry at his shack to talk to him and reload(if he isn't dead, kill him)">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=5672&amp;y=6738&amp;id=playthrough_615&amp;link=/checklists/walkthrough.html%23item_615&amp;title=Return to Gowry at his shack to talk to him and reload(if he isn't dead, kill him)"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_616" id="item_616">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="35" id="playthrough_616" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_616">Go to Gideon and talk to him about the Medallion, the Tree, the Palace, and the Lord of Blood to be rewarded.</label>
-                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_616&amp;link=/checklists/walkthrough.html%23item_616&amp;title=Go to Gideon and talk to him about the Medallion, the Tree, the Palace, and the Lord of Blood to be rewarded.">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_616&amp;link=/checklists/walkthrough.html%23item_616&amp;title=Go to Gideon and talk to him about the Medallion, the Tree, the Palace, and the Lord of Blood to be rewarded."><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
                 <li class="list-group-item searchable ps-0" data-id="playthrough_617" id="item_617">
                   <div class="form-check checkbox d-flex align-items-center">
                     <input class="form-check-input" data-section-idx="35" id="playthrough_617" type="checkbox" value="">
                     <label class="form-check-label item_content" for="playthrough_617">Talk to Hewg after upgrading any weapon to max if you haven't already</label>
-                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_617&amp;link=/checklists/walkthrough.html%23item_617&amp;title=Talk to Hewg after upgrading any weapon to max if you haven't already">
-                      <i class="bi bi-geo-alt"></i>
-                    </a>
+                    <a class="ms-2" href="/map.html?x=584&amp;y=8454&amp;id=playthrough_617&amp;link=/checklists/walkthrough.html%23item_617&amp;title=Talk to Hewg after upgrading any weapon to max if you haven't already"><i class="bi bi-geo-alt"></i></a>
                   </div>
                 </li>
               </ul>
@@ -6564,9 +5226,7 @@
         <div class="card shadow-sm mb-3" id="playthrough_section_36">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_36Col" data-bs-toggle="collapse" href="#playthrough_36Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_36Col" data-bs-toggle="collapse" href="#playthrough_36Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Crumbling Farum Azula/Wrapping Up</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="playthrough_totals_36"></span>
             </h4>
@@ -6741,9 +5401,7 @@
         <div class="card shadow-sm mb-3" id="playthrough_section_37">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_37Col" data-bs-toggle="collapse" href="#playthrough_37Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#playthrough_37Col" data-bs-toggle="collapse" href="#playthrough_37Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Capital of Ash</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="playthrough_totals_37"></span>
             </h4>

--- a/docs/checklists/weapons.html
+++ b/docs/checklists/weapons.html
@@ -27,14 +27,10 @@
         <a class="navbar-brand me-auto ms-2" href="/index.html">Roundtable Guides</a>
         <form class="d-none d-sm-flex order-2 order-xl-3">
           <input aria-label="search" class="form-control me-2" name="search" placeholder="Search" type="search">
-          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit">
-            <i class="bi bi-search"></i>
-          </button>
+          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit"><i class="bi bi-search"></i></button>
         </form>
         <div class="d-sm-none order-2">
-          <a class="nav-link me-0" href="/search.html">
-            <i class="bi bi-search sb-icon-search"></i>
-          </a>
+          <a class="nav-link me-0" href="/search.html"><i class="bi bi-search sb-icon-search"></i></a>
         </div>
         <div class="collapse navbar-collapse order-3 order-xl-2 ms-xl-2" id="nav-collapse">
           <ul class="nav navbar-nav navbar-nav-scroll mr-auto">
@@ -179,14 +175,10 @@
               </ul>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/map.html">
-                <i class="bi bi-map"></i> Map
-              </a>
+              <a class="nav-link hide-buttons" href="/map.html"><i class="bi bi-map"></i> Map</a>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/options.html">
-                <i class="bi bi-gear-fill"></i> Options
-              </a>
+              <a class="nav-link hide-buttons" href="/options.html"><i class="bi bi-gear-fill"></i> Options</a>
             </li>
           </ul>
         </div>
@@ -206,9 +198,7 @@
       </div>
       <nav class="text-muted toc d-print-none">
         <strong class="d-block h5">
-          <a class="toc-button" data-bs-toggle="collapse" href="#toc_weapons" role="button">
-            <i class="bi bi-plus-lg"></i>Table Of Contents
-          </a>
+          <a class="toc-button" data-bs-toggle="collapse" href="#toc_weapons" role="button"><i class="bi bi-plus-lg"></i>Table Of Contents</a>
         </strong>
         <ul class="toc_page collapse" id="toc_weapons">
           <li>
@@ -398,9 +388,7 @@
         <div class="card shadow-sm mb-3" id="weapons_section_0">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_0Col" data-bs-toggle="collapse" href="#weapons_0Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_0Col" data-bs-toggle="collapse" href="#weapons_0Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Hand-to-Hand+Arts">Hand-to-Hand Arts</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="weapons_totals_0"></span>
             </h4>
@@ -412,9 +400,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -443,9 +429,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="weapons_50_63" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_63&amp;id=weapons_50_63&amp;link=/checklists/weapons.html%23item_50_63&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dryleaf+Arts&quot;&gt;Dryleaf Arts&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_63&amp;id=weapons_50_63&amp;link=/checklists/weapons.html%23item_50_63&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dryleaf+Arts&quot;&gt;Dryleaf Arts&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -478,9 +462,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="weapons_50_64" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_64&amp;id=weapons_50_64&amp;link=/checklists/weapons.html%23item_50_64&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dane's+Footwork&quot;&gt;Dane's Footwork&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_64&amp;id=weapons_50_64&amp;link=/checklists/weapons.html%23item_50_64&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dane's+Footwork&quot;&gt;Dane's Footwork&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -514,9 +496,7 @@
         <div class="card shadow-sm mb-3" id="weapons_section_1">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_1Col" data-bs-toggle="collapse" href="#weapons_1Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_1Col" data-bs-toggle="collapse" href="#weapons_1Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Throwing+Blades">Throwing Blades</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="weapons_totals_1"></span>
             </h4>
@@ -528,9 +508,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -559,9 +537,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="1" id="weapons_50_72" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_72&amp;id=weapons_50_72&amp;link=/checklists/weapons.html%23item_50_72&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Smithscript+Dagger&quot;&gt;Smithscript Dagger&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_72&amp;id=weapons_50_72&amp;link=/checklists/weapons.html%23item_50_72&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Smithscript+Dagger&quot;&gt;Smithscript Dagger&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -595,9 +571,7 @@
         <div class="card shadow-sm mb-3" id="weapons_section_2">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_2Col" data-bs-toggle="collapse" href="#weapons_2Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_2Col" data-bs-toggle="collapse" href="#weapons_2Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Backhand+Blades">Backhand Blades</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="weapons_totals_2"></span>
             </h4>
@@ -609,9 +583,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -640,9 +612,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="weapons_50_73" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_73&amp;id=weapons_50_73&amp;link=/checklists/weapons.html%23item_50_73&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Backhand+Blade&quot;&gt;Backhand Blade&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_73&amp;id=weapons_50_73&amp;link=/checklists/weapons.html%23item_50_73&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Backhand+Blade&quot;&gt;Backhand Blade&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -675,9 +645,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="weapons_50_74" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_74&amp;id=weapons_50_74&amp;link=/checklists/weapons.html%23item_50_74&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Smithscript+Cirque&quot;&gt;Smithscript Cirque&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_74&amp;id=weapons_50_74&amp;link=/checklists/weapons.html%23item_50_74&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Smithscript+Cirque&quot;&gt;Smithscript Cirque&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -710,9 +678,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="2" id="weapons_50_75" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_75&amp;id=weapons_50_75&amp;link=/checklists/weapons.html%23item_50_75&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Curseblade's+Cirque&quot;&gt;Curseblade's Cirque&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_75&amp;id=weapons_50_75&amp;link=/checklists/weapons.html%23item_50_75&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Curseblade's+Cirque&quot;&gt;Curseblade's Cirque&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -746,9 +712,7 @@
         <div class="card shadow-sm mb-3" id="weapons_section_3">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_3Col" data-bs-toggle="collapse" href="#weapons_3Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_3Col" data-bs-toggle="collapse" href="#weapons_3Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Perfume+Bottles">Perfume Bottles</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="weapons_totals_3"></span>
             </h4>
@@ -760,9 +724,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -791,9 +753,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="weapons_50_65" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_65&amp;id=weapons_50_65&amp;link=/checklists/weapons.html%23item_50_65&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Firespark+Perfume+Bottle&quot;&gt;Firespark Perfume Bottle&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_65&amp;id=weapons_50_65&amp;link=/checklists/weapons.html%23item_50_65&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Firespark+Perfume+Bottle&quot;&gt;Firespark Perfume Bottle&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -826,9 +786,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="weapons_50_66" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_66&amp;id=weapons_50_66&amp;link=/checklists/weapons.html%23item_50_66&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Chilling+Perfume+Bottle&quot;&gt;Chilling Perfume Bottle&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_66&amp;id=weapons_50_66&amp;link=/checklists/weapons.html%23item_50_66&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Chilling+Perfume+Bottle&quot;&gt;Chilling Perfume Bottle&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -861,9 +819,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="weapons_50_67" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_67&amp;id=weapons_50_67&amp;link=/checklists/weapons.html%23item_50_67&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Frenzyflame+Perfume+Bottle&quot;&gt;Frenzyflame Perfume Bottle&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_67&amp;id=weapons_50_67&amp;link=/checklists/weapons.html%23item_50_67&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Frenzyflame+Perfume+Bottle&quot;&gt;Frenzyflame Perfume Bottle&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -896,9 +852,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="weapons_50_68" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_68&amp;id=weapons_50_68&amp;link=/checklists/weapons.html%23item_50_68&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Lightning+Perfume+Bottle&quot;&gt;Lightning Perfume Bottle&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_68&amp;id=weapons_50_68&amp;link=/checklists/weapons.html%23item_50_68&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Lightning+Perfume+Bottle&quot;&gt;Lightning Perfume Bottle&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -931,9 +885,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="3" id="weapons_50_69" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_69&amp;id=weapons_50_69&amp;link=/checklists/weapons.html%23item_50_69&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Deadly+Poison+Perfume+Bottle&quot;&gt;Deadly Poison Perfume Bottle&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_69&amp;id=weapons_50_69&amp;link=/checklists/weapons.html%23item_50_69&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Deadly+Poison+Perfume+Bottle&quot;&gt;Deadly Poison Perfume Bottle&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -967,9 +919,7 @@
         <div class="card shadow-sm mb-3" id="weapons_section_4">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_4Col" data-bs-toggle="collapse" href="#weapons_4Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_4Col" data-bs-toggle="collapse" href="#weapons_4Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Beast+Claws">Beast Claws</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="weapons_totals_4"></span>
             </h4>
@@ -981,9 +931,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -1012,9 +960,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="weapons_50_82" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_82&amp;id=weapons_50_82&amp;link=/checklists/weapons.html%23item_50_82&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Beast+Claw+(Weapon)&quot;&gt;Beast Claw&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_82&amp;id=weapons_50_82&amp;link=/checklists/weapons.html%23item_50_82&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Beast+Claw+(Weapon)&quot;&gt;Beast Claw&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1047,9 +993,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="4" id="weapons_50_83" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_83&amp;id=weapons_50_83&amp;link=/checklists/weapons.html%23item_50_83&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Red+Bear's+Claw&quot;&gt;Red Bear's Claw&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_83&amp;id=weapons_50_83&amp;link=/checklists/weapons.html%23item_50_83&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Red+Bear's+Claw&quot;&gt;Red Bear's Claw&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1083,9 +1027,7 @@
         <div class="card shadow-sm mb-3" id="weapons_section_5">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_5Col" data-bs-toggle="collapse" href="#weapons_5Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_5Col" data-bs-toggle="collapse" href="#weapons_5Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Light+Greatswords">Light Greatswords</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="weapons_totals_5"></span>
             </h4>
@@ -1097,9 +1039,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -1128,9 +1068,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="weapons_50_79" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_79&amp;id=weapons_50_79&amp;link=/checklists/weapons.html%23item_50_79&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Milady&quot;&gt;Milady&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_79&amp;id=weapons_50_79&amp;link=/checklists/weapons.html%23item_50_79&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Milady&quot;&gt;Milady&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1163,9 +1101,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="weapons_50_80" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_80&amp;id=weapons_50_80&amp;link=/checklists/weapons.html%23item_50_80&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Leda's+Sword&quot;&gt;Leda's Sword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_80&amp;id=weapons_50_80&amp;link=/checklists/weapons.html%23item_50_80&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Leda's+Sword&quot;&gt;Leda's Sword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1198,9 +1134,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="5" id="weapons_50_81" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_81&amp;id=weapons_50_81&amp;link=/checklists/weapons.html%23item_50_81&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Rellana's+Twin+Blades&quot;&gt;Rellana's Twin Blades&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_81&amp;id=weapons_50_81&amp;link=/checklists/weapons.html%23item_50_81&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Rellana's+Twin+Blades&quot;&gt;Rellana's Twin Blades&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1234,9 +1168,7 @@
         <div class="card shadow-sm mb-3" id="weapons_section_6">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_6Col" data-bs-toggle="collapse" href="#weapons_6Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_6Col" data-bs-toggle="collapse" href="#weapons_6Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Great+Katanas">Great Katanas</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="weapons_totals_6"></span>
             </h4>
@@ -1248,9 +1180,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -1279,9 +1209,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="weapons_50_76" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_76&amp;id=weapons_50_76&amp;link=/checklists/weapons.html%23item_50_76&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Great+Katana&quot;&gt;Great Katana&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_76&amp;id=weapons_50_76&amp;link=/checklists/weapons.html%23item_50_76&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Great+Katana&quot;&gt;Great Katana&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1314,9 +1242,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="weapons_50_77" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_77&amp;id=weapons_50_77&amp;link=/checklists/weapons.html%23item_50_77&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dragon-Hunter's+Great+Katana&quot;&gt;Dragon-Hunter's Great Katana&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_77&amp;id=weapons_50_77&amp;link=/checklists/weapons.html%23item_50_77&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dragon-Hunter's+Great+Katana&quot;&gt;Dragon-Hunter's Great Katana&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1349,9 +1275,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="6" id="weapons_50_78" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_78&amp;id=weapons_50_78&amp;link=/checklists/weapons.html%23item_50_78&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Rakshasa's+Great+Katana&quot;&gt;Rakshasa's Great Katana&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_78&amp;id=weapons_50_78&amp;link=/checklists/weapons.html%23item_50_78&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Rakshasa's+Great+Katana&quot;&gt;Rakshasa's Great Katana&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1385,9 +1309,7 @@
         <div class="card shadow-sm mb-3" id="weapons_section_7">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_7Col" data-bs-toggle="collapse" href="#weapons_7Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_7Col" data-bs-toggle="collapse" href="#weapons_7Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Daggers">Daggers</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="weapons_totals_7"></span>
             </h4>
@@ -1399,9 +1321,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -1430,9 +1350,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="weapons_3_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_3_1&amp;id=weapons_3_1&amp;link=/checklists/weapons.html%23item_3_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dagger&quot;&gt;Dagger&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_3_1&amp;id=weapons_3_1&amp;link=/checklists/weapons.html%23item_3_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dagger&quot;&gt;Dagger&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1465,9 +1383,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="weapons_3_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_3_3&amp;id=weapons_3_3&amp;link=/checklists/weapons.html%23item_3_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Parrying+Dagger&quot;&gt;Parrying Dagger&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_3_3&amp;id=weapons_3_3&amp;link=/checklists/weapons.html%23item_3_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Parrying+Dagger&quot;&gt;Parrying Dagger&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1500,9 +1416,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="weapons_3_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_3_4&amp;id=weapons_3_4&amp;link=/checklists/weapons.html%23item_3_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Misericorde&quot;&gt;Misericorde&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_3_4&amp;id=weapons_3_4&amp;link=/checklists/weapons.html%23item_3_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Misericorde&quot;&gt;Misericorde&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1535,9 +1449,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="weapons_3_10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_3_10&amp;id=weapons_3_10&amp;link=/checklists/weapons.html%23item_3_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Great+Knife&quot;&gt;Great Knife&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_3_10&amp;id=weapons_3_10&amp;link=/checklists/weapons.html%23item_3_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Great+Knife&quot;&gt;Great Knife&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1570,9 +1482,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="weapons_3_14" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_3_14&amp;id=weapons_3_14&amp;link=/checklists/weapons.html%23item_3_14&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Bloodstained+Dagger&quot;&gt;Bloodstained Dagger&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_3_14&amp;id=weapons_3_14&amp;link=/checklists/weapons.html%23item_3_14&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Bloodstained+Dagger&quot;&gt;Bloodstained Dagger&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1605,9 +1515,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="weapons_3_15" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_3_15&amp;id=weapons_3_15&amp;link=/checklists/weapons.html%23item_3_15&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Erdsteel+Dagger&quot;&gt;Erdsteel Dagger&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_3_15&amp;id=weapons_3_15&amp;link=/checklists/weapons.html%23item_3_15&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Erdsteel+Dagger&quot;&gt;Erdsteel Dagger&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1640,9 +1548,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="weapons_3_11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_3_11&amp;id=weapons_3_11&amp;link=/checklists/weapons.html%23item_3_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Wakizashi&quot;&gt;Wakizashi&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_3_11&amp;id=weapons_3_11&amp;link=/checklists/weapons.html%23item_3_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Wakizashi&quot;&gt;Wakizashi&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1675,9 +1581,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="weapons_3_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_3_7&amp;id=weapons_3_7&amp;link=/checklists/weapons.html%23item_3_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Celebrant's+Sickle&quot;&gt;Celebrant's Sickle&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_3_7&amp;id=weapons_3_7&amp;link=/checklists/weapons.html%23item_3_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Celebrant's+Sickle&quot;&gt;Celebrant's Sickle&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1710,9 +1614,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="weapons_3_13" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_3_13&amp;id=weapons_3_13&amp;link=/checklists/weapons.html%23item_3_13&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ivory+Sickle&quot;&gt;Ivory Sickle&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_3_13&amp;id=weapons_3_13&amp;link=/checklists/weapons.html%23item_3_13&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ivory+Sickle&quot;&gt;Ivory Sickle&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1745,9 +1647,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="weapons_3_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_3_6&amp;id=weapons_3_6&amp;link=/checklists/weapons.html%23item_3_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Crystal+Knife&quot;&gt;Crystal Knife&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_3_6&amp;id=weapons_3_6&amp;link=/checklists/weapons.html%23item_3_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Crystal+Knife&quot;&gt;Crystal Knife&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1780,9 +1680,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="weapons_3_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_3_9&amp;id=weapons_3_9&amp;link=/checklists/weapons.html%23item_3_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Scorpion's+Stinger&quot;&gt;Scorpion's Stinger&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_3_9&amp;id=weapons_3_9&amp;link=/checklists/weapons.html%23item_3_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Scorpion's+Stinger&quot;&gt;Scorpion's Stinger&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1815,9 +1713,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="weapons_3_12" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_3_12&amp;id=weapons_3_12&amp;link=/checklists/weapons.html%23item_3_12&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Cinquedea&quot;&gt;Cinquedea&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_3_12&amp;id=weapons_3_12&amp;link=/checklists/weapons.html%23item_3_12&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Cinquedea&quot;&gt;Cinquedea&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1850,9 +1746,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="weapons_3_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_3_8&amp;id=weapons_3_8&amp;link=/checklists/weapons.html%23item_3_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Glintstone+Kris&quot;&gt;Glintstone Kris&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_3_8&amp;id=weapons_3_8&amp;link=/checklists/weapons.html%23item_3_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Glintstone+Kris&quot;&gt;Glintstone Kris&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1885,9 +1779,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="weapons_3_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_3_5&amp;id=weapons_3_5&amp;link=/checklists/weapons.html%23item_3_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Reduvia&quot;&gt;Reduvia&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_3_5&amp;id=weapons_3_5&amp;link=/checklists/weapons.html%23item_3_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Reduvia&quot;&gt;Reduvia&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1920,9 +1812,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="weapons_3_16" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_3_16&amp;id=weapons_3_16&amp;link=/checklists/weapons.html%23item_3_16&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Blade+of+Calling&quot;&gt;Blade of Calling&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_3_16&amp;id=weapons_3_16&amp;link=/checklists/weapons.html%23item_3_16&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Blade+of+Calling&quot;&gt;Blade of Calling&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1955,9 +1845,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="weapons_3_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_3_2&amp;id=weapons_3_2&amp;link=/checklists/weapons.html%23item_3_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Black+Knife&quot;&gt;Black Knife&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_3_2&amp;id=weapons_3_2&amp;link=/checklists/weapons.html%23item_3_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Black+Knife&quot;&gt;Black Knife&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -1990,9 +1878,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="weapons_50_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_1&amp;id=weapons_50_1&amp;link=/checklists/weapons.html%23item_50_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Main-gauche&quot;&gt;Main-gauche&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_1&amp;id=weapons_50_1&amp;link=/checklists/weapons.html%23item_50_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Main-gauche&quot;&gt;Main-gauche&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2025,9 +1911,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="7" id="weapons_50_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_2&amp;id=weapons_50_2&amp;link=/checklists/weapons.html%23item_50_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Fire+Knight's+Shortsword&quot;&gt;Fire Knight's Shortsword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_2&amp;id=weapons_50_2&amp;link=/checklists/weapons.html%23item_50_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Fire+Knight's+Shortsword&quot;&gt;Fire Knight's Shortsword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2061,9 +1945,7 @@
         <div class="card shadow-sm mb-3" id="weapons_section_8">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_8Col" data-bs-toggle="collapse" href="#weapons_8Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_8Col" data-bs-toggle="collapse" href="#weapons_8Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Straight+Swords">Straight Swords</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="weapons_totals_8"></span>
             </h4>
@@ -2075,9 +1957,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -2106,9 +1986,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="weapons_13_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_13_1&amp;id=weapons_13_1&amp;link=/checklists/weapons.html%23item_13_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Short+Sword&quot;&gt;Short Sword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_13_1&amp;id=weapons_13_1&amp;link=/checklists/weapons.html%23item_13_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Short+Sword&quot;&gt;Short Sword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2141,9 +2019,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="weapons_13_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_13_2&amp;id=weapons_13_2&amp;link=/checklists/weapons.html%23item_13_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Longsword&quot;&gt;Longsword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_13_2&amp;id=weapons_13_2&amp;link=/checklists/weapons.html%23item_13_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Longsword&quot;&gt;Longsword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2176,9 +2052,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="weapons_13_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_13_3&amp;id=weapons_13_3&amp;link=/checklists/weapons.html%23item_13_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Broadsword&quot;&gt;Broadsword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_13_3&amp;id=weapons_13_3&amp;link=/checklists/weapons.html%23item_13_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Broadsword&quot;&gt;Broadsword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2211,9 +2085,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="weapons_13_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_13_4&amp;id=weapons_13_4&amp;link=/checklists/weapons.html%23item_13_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Weathered+Straight+Sword&quot;&gt;Weathered Straight Sword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_13_4&amp;id=weapons_13_4&amp;link=/checklists/weapons.html%23item_13_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Weathered+Straight+Sword&quot;&gt;Weathered Straight Sword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2246,9 +2118,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="weapons_13_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_13_5&amp;id=weapons_13_5&amp;link=/checklists/weapons.html%23item_13_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Lordsworn's+Straight+Sword&quot;&gt;Lordsworn's Straight Sword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_13_5&amp;id=weapons_13_5&amp;link=/checklists/weapons.html%23item_13_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Lordsworn's+Straight+Sword&quot;&gt;Lordsworn's Straight Sword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2281,9 +2151,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="weapons_13_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_13_6&amp;id=weapons_13_6&amp;link=/checklists/weapons.html%23item_13_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Noble's+Slender+Sword&quot;&gt;Noble's Slender Sword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_13_6&amp;id=weapons_13_6&amp;link=/checklists/weapons.html%23item_13_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Noble's+Slender+Sword&quot;&gt;Noble's Slender Sword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2316,9 +2184,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="weapons_13_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_13_7&amp;id=weapons_13_7&amp;link=/checklists/weapons.html%23item_13_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Cane+Sword&quot;&gt;Cane Sword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_13_7&amp;id=weapons_13_7&amp;link=/checklists/weapons.html%23item_13_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Cane+Sword&quot;&gt;Cane Sword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2351,9 +2217,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="weapons_13_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_13_8&amp;id=weapons_13_8&amp;link=/checklists/weapons.html%23item_13_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Warhawk's+Talon&quot;&gt;Warhawk's Talon&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_13_8&amp;id=weapons_13_8&amp;link=/checklists/weapons.html%23item_13_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Warhawk's+Talon&quot;&gt;Warhawk's Talon&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2386,9 +2250,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="weapons_13_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_13_9&amp;id=weapons_13_9&amp;link=/checklists/weapons.html%23item_13_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Lazuli+Glintstone+Sword&quot;&gt;Lazuli Glintsone Sword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_13_9&amp;id=weapons_13_9&amp;link=/checklists/weapons.html%23item_13_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Lazuli+Glintstone+Sword&quot;&gt;Lazuli Glintsone Sword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2421,9 +2283,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="weapons_13_10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_13_10&amp;id=weapons_13_10&amp;link=/checklists/weapons.html%23item_13_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Carian+Knight's+Sword&quot;&gt;Carian Knight's Sword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_13_10&amp;id=weapons_13_10&amp;link=/checklists/weapons.html%23item_13_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Carian+Knight's+Sword&quot;&gt;Carian Knight's Sword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2456,9 +2316,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="weapons_13_11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_13_11&amp;id=weapons_13_11&amp;link=/checklists/weapons.html%23item_13_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Crystal+Sword&quot;&gt;Crystal Sword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_13_11&amp;id=weapons_13_11&amp;link=/checklists/weapons.html%23item_13_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Crystal+Sword&quot;&gt;Crystal Sword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2491,9 +2349,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="weapons_13_12" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_13_12&amp;id=weapons_13_12&amp;link=/checklists/weapons.html%23item_13_12&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Rotten+Crystal+Sword&quot;&gt;Rotten Crystal Sword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_13_12&amp;id=weapons_13_12&amp;link=/checklists/weapons.html%23item_13_12&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Rotten+Crystal+Sword&quot;&gt;Rotten Crystal Sword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2526,9 +2382,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="weapons_13_13" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_13_13&amp;id=weapons_13_13&amp;link=/checklists/weapons.html%23item_13_13&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Miquellan+Knight's+Sword&quot;&gt;Miquellan Knight's Sword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_13_13&amp;id=weapons_13_13&amp;link=/checklists/weapons.html%23item_13_13&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Miquellan+Knight's+Sword&quot;&gt;Miquellan Knight's Sword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2561,9 +2415,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="weapons_13_14" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_13_14&amp;id=weapons_13_14&amp;link=/checklists/weapons.html%23item_13_14&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ornamental+Straight+Sword&quot;&gt;Ornamental Straight Sword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_13_14&amp;id=weapons_13_14&amp;link=/checklists/weapons.html%23item_13_14&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ornamental+Straight+Sword&quot;&gt;Ornamental Straight Sword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2596,9 +2448,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="weapons_13_15" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_13_15&amp;id=weapons_13_15&amp;link=/checklists/weapons.html%23item_13_15&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Golden+Epitaph&quot;&gt;Golden Epitaph&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_13_15&amp;id=weapons_13_15&amp;link=/checklists/weapons.html%23item_13_15&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Golden+Epitaph&quot;&gt;Golden Epitaph&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2631,9 +2481,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="weapons_13_16" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_13_16&amp;id=weapons_13_16&amp;link=/checklists/weapons.html%23item_13_16&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Sword+of+St+Trina&quot;&gt;Sword of St Trina&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_13_16&amp;id=weapons_13_16&amp;link=/checklists/weapons.html%23item_13_16&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Sword+of+St+Trina&quot;&gt;Sword of St Trina&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2666,9 +2514,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="weapons_13_17" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_13_17&amp;id=weapons_13_17&amp;link=/checklists/weapons.html%23item_13_17&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Regalia+of+Eochaid&quot;&gt;Regalia of Eochaid&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_13_17&amp;id=weapons_13_17&amp;link=/checklists/weapons.html%23item_13_17&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Regalia+of+Eochaid&quot;&gt;Regalia of Eochaid&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2701,9 +2547,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="weapons_13_18" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_13_18&amp;id=weapons_13_18&amp;link=/checklists/weapons.html%23item_13_18&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Coded+Sword&quot;&gt;Coded Sword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_13_18&amp;id=weapons_13_18&amp;link=/checklists/weapons.html%23item_13_18&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Coded+Sword&quot;&gt;Coded Sword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2736,9 +2580,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="weapons_13_19" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_13_19&amp;id=weapons_13_19&amp;link=/checklists/weapons.html%23item_13_19&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Sword+of+Night+and+Flame&quot;&gt;Sword of Night and Flame&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_13_19&amp;id=weapons_13_19&amp;link=/checklists/weapons.html%23item_13_19&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Sword+of+Night+and+Flame&quot;&gt;Sword of Night and Flame&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2771,9 +2613,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="weapons_50_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_3&amp;id=weapons_50_3&amp;link=/checklists/weapons.html%23item_50_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Velvet+Sword+of+St.+Trina&quot;&gt;Velvet Sword of St. Trina&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_3&amp;id=weapons_50_3&amp;link=/checklists/weapons.html%23item_50_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Velvet+Sword+of+St.+Trina&quot;&gt;Velvet Sword of St. Trina&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2806,9 +2646,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="weapons_50_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_5&amp;id=weapons_50_5&amp;link=/checklists/weapons.html%23item_50_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Stone-Sheathed+Sword&quot;&gt;Stone-Sheathed Sword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_5&amp;id=weapons_50_5&amp;link=/checklists/weapons.html%23item_50_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Stone-Sheathed+Sword&quot;&gt;Stone-Sheathed Sword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2841,9 +2679,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="weapons_50_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_6&amp;id=weapons_50_6&amp;link=/checklists/weapons.html%23item_50_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Sword+of+Light&quot;&gt;Sword of Light&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_6&amp;id=weapons_50_6&amp;link=/checklists/weapons.html%23item_50_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Sword+of+Light&quot;&gt;Sword of Light&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2876,9 +2712,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="8" id="weapons_50_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_7&amp;id=weapons_50_7&amp;link=/checklists/weapons.html%23item_50_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Sword+of+Darkness&quot;&gt;Sword of Darkness&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_7&amp;id=weapons_50_7&amp;link=/checklists/weapons.html%23item_50_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Sword+of+Darkness&quot;&gt;Sword of Darkness&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2912,9 +2746,7 @@
         <div class="card shadow-sm mb-3" id="weapons_section_9">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_9Col" data-bs-toggle="collapse" href="#weapons_9Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_9Col" data-bs-toggle="collapse" href="#weapons_9Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Greatswords">Greatswords</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="weapons_totals_9"></span>
             </h4>
@@ -2926,9 +2758,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -2957,9 +2787,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="weapons_14_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_14_1&amp;id=weapons_14_1&amp;link=/checklists/weapons.html%23item_14_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Bastard+Sword&quot;&gt;Bastard Sword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_14_1&amp;id=weapons_14_1&amp;link=/checklists/weapons.html%23item_14_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Bastard+Sword&quot;&gt;Bastard Sword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -2992,9 +2820,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="weapons_14_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_14_2&amp;id=weapons_14_2&amp;link=/checklists/weapons.html%23item_14_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Claymore&quot;&gt;Claymore&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_14_2&amp;id=weapons_14_2&amp;link=/checklists/weapons.html%23item_14_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Claymore&quot;&gt;Claymore&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3027,9 +2853,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="weapons_14_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_14_3&amp;id=weapons_14_3&amp;link=/checklists/weapons.html%23item_14_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Iron+Greatsword&quot;&gt;Iron Greatsword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_14_3&amp;id=weapons_14_3&amp;link=/checklists/weapons.html%23item_14_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Iron+Greatsword&quot;&gt;Iron Greatsword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3062,9 +2886,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="weapons_14_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_14_4&amp;id=weapons_14_4&amp;link=/checklists/weapons.html%23item_14_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Lordsworn's+Greatsword&quot;&gt;Lordsworn's Greatsword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_14_4&amp;id=weapons_14_4&amp;link=/checklists/weapons.html%23item_14_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Lordsworn's+Greatsword&quot;&gt;Lordsworn's Greatsword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3097,9 +2919,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="weapons_14_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_14_5&amp;id=weapons_14_5&amp;link=/checklists/weapons.html%23item_14_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Knight's+Greatsword&quot;&gt;Knight's Greatsword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_14_5&amp;id=weapons_14_5&amp;link=/checklists/weapons.html%23item_14_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Knight's+Greatsword&quot;&gt;Knight's Greatsword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3132,9 +2952,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="weapons_14_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_14_6&amp;id=weapons_14_6&amp;link=/checklists/weapons.html%23item_14_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Banished+Knight's+Greatsword&quot;&gt;Banished Knight's Greatsword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_14_6&amp;id=weapons_14_6&amp;link=/checklists/weapons.html%23item_14_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Banished+Knight's+Greatsword&quot;&gt;Banished Knight's Greatsword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3167,9 +2985,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="weapons_14_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_14_7&amp;id=weapons_14_7&amp;link=/checklists/weapons.html%23item_14_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Forked+Greatsword&quot;&gt;Forked Greatsword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_14_7&amp;id=weapons_14_7&amp;link=/checklists/weapons.html%23item_14_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Forked+Greatsword&quot;&gt;Forked Greatsword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3202,9 +3018,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="weapons_14_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_14_8&amp;id=weapons_14_8&amp;link=/checklists/weapons.html%23item_14_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Flamberge&quot;&gt;Flamberge&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_14_8&amp;id=weapons_14_8&amp;link=/checklists/weapons.html%23item_14_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Flamberge&quot;&gt;Flamberge&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3237,9 +3051,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="weapons_14_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_14_9&amp;id=weapons_14_9&amp;link=/checklists/weapons.html%23item_14_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gargoyle's+Greatsword&quot;&gt;Gargoyle's Greatsword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_14_9&amp;id=weapons_14_9&amp;link=/checklists/weapons.html%23item_14_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gargoyle's+Greatsword&quot;&gt;Gargoyle's Greatsword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3272,9 +3084,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="weapons_14_10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_14_10&amp;id=weapons_14_10&amp;link=/checklists/weapons.html%23item_14_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gargoyle's+Blackblade&quot;&gt;Gargoyle's Blackblade&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_14_10&amp;id=weapons_14_10&amp;link=/checklists/weapons.html%23item_14_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gargoyle's+Blackblade&quot;&gt;Gargoyle's Blackblade&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3307,9 +3117,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="weapons_14_11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_14_11&amp;id=weapons_14_11&amp;link=/checklists/weapons.html%23item_14_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Inseparable+Sword&quot;&gt;Inseparable Sword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_14_11&amp;id=weapons_14_11&amp;link=/checklists/weapons.html%23item_14_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Inseparable+Sword&quot;&gt;Inseparable Sword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3342,9 +3150,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="weapons_14_12" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_14_12&amp;id=weapons_14_12&amp;link=/checklists/weapons.html%23item_14_12&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Sword+of+Milos&quot;&gt;Sword of Milos&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_14_12&amp;id=weapons_14_12&amp;link=/checklists/weapons.html%23item_14_12&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Sword+of+Milos&quot;&gt;Sword of Milos&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3377,9 +3183,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="weapons_14_13" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_14_13&amp;id=weapons_14_13&amp;link=/checklists/weapons.html%23item_14_13&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Marais+Executioner's+Sword&quot;&gt;Marais Executioner's Sword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_14_13&amp;id=weapons_14_13&amp;link=/checklists/weapons.html%23item_14_13&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Marais+Executioner's+Sword&quot;&gt;Marais Executioner's Sword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3412,9 +3216,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="weapons_14_14" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_14_14&amp;id=weapons_14_14&amp;link=/checklists/weapons.html%23item_14_14&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ordovis's+Greatsword&quot;&gt;Ordovis's Greatsword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_14_14&amp;id=weapons_14_14&amp;link=/checklists/weapons.html%23item_14_14&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ordovis's+Greatsword&quot;&gt;Ordovis's Greatsword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3447,9 +3249,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="weapons_14_15" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_14_15&amp;id=weapons_14_15&amp;link=/checklists/weapons.html%23item_14_15&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Alabaster+Lord's+Sword&quot;&gt;Alabaster Lord's Sword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_14_15&amp;id=weapons_14_15&amp;link=/checklists/weapons.html%23item_14_15&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Alabaster+Lord's+Sword&quot;&gt;Alabaster Lord's Sword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3482,9 +3282,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="weapons_14_16" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_14_16&amp;id=weapons_14_16&amp;link=/checklists/weapons.html%23item_14_16&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Death's+Poker&quot;&gt;Death's Poker&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_14_16&amp;id=weapons_14_16&amp;link=/checklists/weapons.html%23item_14_16&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Death's+Poker&quot;&gt;Death's Poker&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3517,9 +3315,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="weapons_14_17" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_14_17&amp;id=weapons_14_17&amp;link=/checklists/weapons.html%23item_14_17&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Helphen's+Steeple&quot;&gt;Helphen's Steeple&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_14_17&amp;id=weapons_14_17&amp;link=/checklists/weapons.html%23item_14_17&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Helphen's+Steeple&quot;&gt;Helphen's Steeple&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3552,9 +3348,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="weapons_14_18" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_14_18&amp;id=weapons_14_18&amp;link=/checklists/weapons.html%23item_14_18&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Blasphemous+Blade&quot;&gt;Blasphemous Blade&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_14_18&amp;id=weapons_14_18&amp;link=/checklists/weapons.html%23item_14_18&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Blasphemous+Blade&quot;&gt;Blasphemous Blade&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3587,9 +3381,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="weapons_14_19" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_14_19&amp;id=weapons_14_19&amp;link=/checklists/weapons.html%23item_14_19&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Golden+Order+Greatsword&quot;&gt;Golden Order Greatsword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_14_19&amp;id=weapons_14_19&amp;link=/checklists/weapons.html%23item_14_19&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Golden+Order+Greatsword&quot;&gt;Golden Order Greatsword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3622,9 +3414,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="weapons_14_20" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_14_20&amp;id=weapons_14_20&amp;link=/checklists/weapons.html%23item_14_20&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dark+Moon+Greatsword&quot;&gt;Dark Moon Greatsword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_14_20&amp;id=weapons_14_20&amp;link=/checklists/weapons.html%23item_14_20&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dark+Moon+Greatsword&quot;&gt;Dark Moon Greatsword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3657,9 +3447,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="weapons_14_21" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_14_21&amp;id=weapons_14_21&amp;link=/checklists/weapons.html%23item_14_21&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Sacred+Relic+Sword&quot;&gt;Sacred Relic Sword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_14_21&amp;id=weapons_14_21&amp;link=/checklists/weapons.html%23item_14_21&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Sacred+Relic+Sword&quot;&gt;Sacred Relic Sword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3692,9 +3480,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="weapons_50_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_8&amp;id=weapons_50_8&amp;link=/checklists/weapons.html%23item_50_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Greatsword+of+Damnation&quot;&gt;Greatsword of Damnation&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_8&amp;id=weapons_50_8&amp;link=/checklists/weapons.html%23item_50_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Greatsword+of+Damnation&quot;&gt;Greatsword of Damnation&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3727,9 +3513,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="weapons_50_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_9&amp;id=weapons_50_9&amp;link=/checklists/weapons.html%23item_50_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Lizard+Greatsword&quot;&gt;Lizard Greatsword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_9&amp;id=weapons_50_9&amp;link=/checklists/weapons.html%23item_50_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Lizard+Greatsword&quot;&gt;Lizard Greatsword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3762,9 +3546,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="9" id="weapons_50_10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_10&amp;id=weapons_50_10&amp;link=/checklists/weapons.html%23item_50_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Greatsword+of+Solitude&quot;&gt;Greatsword of Solitude&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_10&amp;id=weapons_50_10&amp;link=/checklists/weapons.html%23item_50_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Greatsword+of+Solitude&quot;&gt;Greatsword of Solitude&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3798,9 +3580,7 @@
         <div class="card shadow-sm mb-3" id="weapons_section_10">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_10Col" data-bs-toggle="collapse" href="#weapons_10Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_10Col" data-bs-toggle="collapse" href="#weapons_10Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Colossal+Swords">Colossal Swords</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="weapons_totals_10"></span>
             </h4>
@@ -3812,9 +3592,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -3843,9 +3621,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="10" id="weapons_5_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_5_5&amp;id=weapons_5_5&amp;link=/checklists/weapons.html%23item_5_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Zweihander&quot;&gt;Zweihander&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_5_5&amp;id=weapons_5_5&amp;link=/checklists/weapons.html%23item_5_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Zweihander&quot;&gt;Zweihander&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3878,9 +3654,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="10" id="weapons_5_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_5_1&amp;id=weapons_5_1&amp;link=/checklists/weapons.html%23item_5_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Greatsword&quot;&gt;Greatsword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_5_1&amp;id=weapons_5_1&amp;link=/checklists/weapons.html%23item_5_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Greatsword&quot;&gt;Greatsword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3913,9 +3687,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="10" id="weapons_5_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_5_2&amp;id=weapons_5_2&amp;link=/checklists/weapons.html%23item_5_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Watchdog's+Greatsword&quot;&gt;Watchdog's Greatsword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_5_2&amp;id=weapons_5_2&amp;link=/checklists/weapons.html%23item_5_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Watchdog's+Greatsword&quot;&gt;Watchdog's Greatsword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3948,9 +3720,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="10" id="weapons_5_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_5_4&amp;id=weapons_5_4&amp;link=/checklists/weapons.html%23item_5_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Troll's+Golden+Sword&quot;&gt;Troll's Golden Sword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_5_4&amp;id=weapons_5_4&amp;link=/checklists/weapons.html%23item_5_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Troll's+Golden+Sword&quot;&gt;Troll's Golden Sword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -3983,9 +3753,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="10" id="weapons_5_11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_5_11&amp;id=weapons_5_11&amp;link=/checklists/weapons.html%23item_5_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Troll+Knight's+Sword&quot;&gt;Troll Knight's Sword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_5_11&amp;id=weapons_5_11&amp;link=/checklists/weapons.html%23item_5_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Troll+Knight's+Sword&quot;&gt;Troll Knight's Sword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4018,9 +3786,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="10" id="weapons_5_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_5_7&amp;id=weapons_5_7&amp;link=/checklists/weapons.html%23item_5_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Royal+Greatsword&quot;&gt;Royal Greatsword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_5_7&amp;id=weapons_5_7&amp;link=/checklists/weapons.html%23item_5_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Royal+Greatsword&quot;&gt;Royal Greatsword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4053,9 +3819,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="10" id="weapons_5_10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_5_10&amp;id=weapons_5_10&amp;link=/checklists/weapons.html%23item_5_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Grafted+Blade+Greatsword&quot;&gt;Grafted Blade Greatsword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_5_10&amp;id=weapons_5_10&amp;link=/checklists/weapons.html%23item_5_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Grafted+Blade+Greatsword&quot;&gt;Grafted Blade Greatsword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4088,9 +3852,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="10" id="weapons_5_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_5_9&amp;id=weapons_5_9&amp;link=/checklists/weapons.html%23item_5_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ruins+Greatsword&quot;&gt;Ruins Greatsword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_5_9&amp;id=weapons_5_9&amp;link=/checklists/weapons.html%23item_5_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ruins+Greatsword&quot;&gt;Ruins Greatsword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4123,9 +3885,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="10" id="weapons_5_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_5_6&amp;id=weapons_5_6&amp;link=/checklists/weapons.html%23item_5_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Starscourge+Greatsword&quot;&gt;Starscourge Greatsword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_5_6&amp;id=weapons_5_6&amp;link=/checklists/weapons.html%23item_5_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Starscourge+Greatsword&quot;&gt;Starscourge Greatsword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4158,9 +3918,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="10" id="weapons_5_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_5_8&amp;id=weapons_5_8&amp;link=/checklists/weapons.html%23item_5_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Godslayer's+Greatsword&quot;&gt;Godslayer's Greatsword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_5_8&amp;id=weapons_5_8&amp;link=/checklists/weapons.html%23item_5_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Godslayer's+Greatsword&quot;&gt;Godslayer's Greatsword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4193,9 +3951,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="10" id="weapons_5_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_5_3&amp;id=weapons_5_3&amp;link=/checklists/weapons.html%23item_5_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Maliketh's+Black+Blade&quot;&gt;Maliketh's Black Blade&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_5_3&amp;id=weapons_5_3&amp;link=/checklists/weapons.html%23item_5_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Maliketh's+Black+Blade&quot;&gt;Maliketh's Black Blade&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4228,9 +3984,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="10" id="weapons_50_11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_11&amp;id=weapons_50_11&amp;link=/checklists/weapons.html%23item_50_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ancient+Meteoric+Ore+Greatsword&quot;&gt;Ancient Meteoric Ore Greatsword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_11&amp;id=weapons_50_11&amp;link=/checklists/weapons.html%23item_50_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ancient+Meteoric+Ore+Greatsword&quot;&gt;Ancient Meteoric Ore Greatsword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4263,9 +4017,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="10" id="weapons_50_12" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_12&amp;id=weapons_50_12&amp;link=/checklists/weapons.html%23item_50_12&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Fire+Knight's+Greatsword&quot;&gt;Fire Knight's Greatsword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_12&amp;id=weapons_50_12&amp;link=/checklists/weapons.html%23item_50_12&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Fire+Knight's+Greatsword&quot;&gt;Fire Knight's Greatsword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4298,9 +4050,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="10" id="weapons_50_13" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_13&amp;id=weapons_50_13&amp;link=/checklists/weapons.html%23item_50_13&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Greatsword+of+Radahn+(Light)&quot;&gt;Greatsword of Radahn (Light)&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_13&amp;id=weapons_50_13&amp;link=/checklists/weapons.html%23item_50_13&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Greatsword+of+Radahn+(Light)&quot;&gt;Greatsword of Radahn (Light)&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4333,9 +4083,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="10" id="weapons_50_14" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_14&amp;id=weapons_50_14&amp;link=/checklists/weapons.html%23item_50_14&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Greatsword+of+Radahn+(Lord)&quot;&gt;Greatsword of Radahn (Lord)&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_14&amp;id=weapons_50_14&amp;link=/checklists/weapons.html%23item_50_14&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Greatsword+of+Radahn+(Lord)&quot;&gt;Greatsword of Radahn (Lord)&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4368,9 +4116,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="10" id="weapons_50_15" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_15&amp;id=weapons_50_15&amp;link=/checklists/weapons.html%23item_50_15&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Moonrithyll's+Knight+Sword&quot;&gt;Moonrithyll's Knight Sword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_15&amp;id=weapons_50_15&amp;link=/checklists/weapons.html%23item_50_15&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Moonrithyll's+Knight+Sword&quot;&gt;Moonrithyll's Knight Sword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4404,9 +4150,7 @@
         <div class="card shadow-sm mb-3" id="weapons_section_11">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_11Col" data-bs-toggle="collapse" href="#weapons_11Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_11Col" data-bs-toggle="collapse" href="#weapons_11Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Thrusting+Swords">Thrusting Swords</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="weapons_totals_11"></span>
             </h4>
@@ -4418,9 +4162,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -4449,9 +4191,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="11" id="weapons_15_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_15_1&amp;id=weapons_15_1&amp;link=/checklists/weapons.html%23item_15_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Rapier&quot;&gt;Rapier&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_15_1&amp;id=weapons_15_1&amp;link=/checklists/weapons.html%23item_15_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Rapier&quot;&gt;Rapier&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4484,9 +4224,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="11" id="weapons_15_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_15_2&amp;id=weapons_15_2&amp;link=/checklists/weapons.html%23item_15_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Estoc&quot;&gt;Estoc&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_15_2&amp;id=weapons_15_2&amp;link=/checklists/weapons.html%23item_15_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Estoc&quot;&gt;Estoc&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4519,9 +4257,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="11" id="weapons_15_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_15_3&amp;id=weapons_15_3&amp;link=/checklists/weapons.html%23item_15_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Noble's+Estoc&quot;&gt;Noble's Estoc&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_15_3&amp;id=weapons_15_3&amp;link=/checklists/weapons.html%23item_15_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Noble's+Estoc&quot;&gt;Noble's Estoc&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4554,9 +4290,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="11" id="weapons_15_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_15_4&amp;id=weapons_15_4&amp;link=/checklists/weapons.html%23item_15_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Cleanrot+Knight's+Sword&quot;&gt;Cleanrot Knight's Sword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_15_4&amp;id=weapons_15_4&amp;link=/checklists/weapons.html%23item_15_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Cleanrot+Knight's+Sword&quot;&gt;Cleanrot Knight's Sword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4589,9 +4323,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="11" id="weapons_15_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_15_5&amp;id=weapons_15_5&amp;link=/checklists/weapons.html%23item_15_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Rogier's+Rapier&quot;&gt;Rogier's Rapier+8&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_15_5&amp;id=weapons_15_5&amp;link=/checklists/weapons.html%23item_15_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Rogier's+Rapier&quot;&gt;Rogier's Rapier+8&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4624,9 +4356,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="11" id="weapons_15_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_15_6&amp;id=weapons_15_6&amp;link=/checklists/weapons.html%23item_15_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Antspur+Rapier&quot;&gt;Antspur Rapier&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_15_6&amp;id=weapons_15_6&amp;link=/checklists/weapons.html%23item_15_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Antspur+Rapier&quot;&gt;Antspur Rapier&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4659,9 +4389,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="11" id="weapons_15_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_15_7&amp;id=weapons_15_7&amp;link=/checklists/weapons.html%23item_15_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Frozen+Needle&quot;&gt;Frozen Needle&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_15_7&amp;id=weapons_15_7&amp;link=/checklists/weapons.html%23item_15_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Frozen+Needle&quot;&gt;Frozen Needle&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4694,9 +4422,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="11" id="weapons_50_16" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_16&amp;id=weapons_50_16&amp;link=/checklists/weapons.html%23item_50_16&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Carian+Sorcery+Sword&quot;&gt;Carian Sorcery Sword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_16&amp;id=weapons_50_16&amp;link=/checklists/weapons.html%23item_50_16&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Carian+Sorcery+Sword&quot;&gt;Carian Sorcery Sword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4730,9 +4456,7 @@
         <div class="card shadow-sm mb-3" id="weapons_section_12">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_12Col" data-bs-toggle="collapse" href="#weapons_12Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_12Col" data-bs-toggle="collapse" href="#weapons_12Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Heavy+Thrusting+Swords">Heavy Thrusting Swords</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="weapons_totals_12"></span>
             </h4>
@@ -4744,9 +4468,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -4775,9 +4497,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="weapons_16_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_16_1&amp;id=weapons_16_1&amp;link=/checklists/weapons.html%23item_16_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Great+Epee&quot;&gt;Great Épée&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_16_1&amp;id=weapons_16_1&amp;link=/checklists/weapons.html%23item_16_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Great+Epee&quot;&gt;Great Épée&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4810,9 +4530,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="weapons_16_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_16_2&amp;id=weapons_16_2&amp;link=/checklists/weapons.html%23item_16_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Godskin+Stitcher&quot;&gt;Godskin Stitcher&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_16_2&amp;id=weapons_16_2&amp;link=/checklists/weapons.html%23item_16_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Godskin+Stitcher&quot;&gt;Godskin Stitcher&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4845,9 +4563,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="weapons_16_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_16_3&amp;id=weapons_16_3&amp;link=/checklists/weapons.html%23item_16_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Bloody+Helice&quot;&gt;Bloody Helice&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_16_3&amp;id=weapons_16_3&amp;link=/checklists/weapons.html%23item_16_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Bloody+Helice&quot;&gt;Bloody Helice&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4880,9 +4596,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="weapons_16_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_16_4&amp;id=weapons_16_4&amp;link=/checklists/weapons.html%23item_16_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dragon+King's+Cragblade&quot;&gt;Dragon King's Cragblade&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_16_4&amp;id=weapons_16_4&amp;link=/checklists/weapons.html%23item_16_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dragon+King's+Cragblade&quot;&gt;Dragon King's Cragblade&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4915,9 +4629,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="weapons_50_17" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_17&amp;id=weapons_50_17&amp;link=/checklists/weapons.html%23item_50_17&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Sword+Lance&quot;&gt;Sword Lance&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_17&amp;id=weapons_50_17&amp;link=/checklists/weapons.html%23item_50_17&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Sword+Lance&quot;&gt;Sword Lance&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4950,9 +4662,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="12" id="weapons_50_18" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_18&amp;id=weapons_50_18&amp;link=/checklists/weapons.html%23item_50_18&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Queelign's+Greatsword&quot;&gt;Queelign's Greatsword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_18&amp;id=weapons_50_18&amp;link=/checklists/weapons.html%23item_50_18&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Queelign's+Greatsword&quot;&gt;Queelign's Greatsword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -4986,9 +4696,7 @@
         <div class="card shadow-sm mb-3" id="weapons_section_13">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_13Col" data-bs-toggle="collapse" href="#weapons_13Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_13Col" data-bs-toggle="collapse" href="#weapons_13Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Curved+Swords">Curved Swords</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="weapons_totals_13"></span>
             </h4>
@@ -5000,9 +4708,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -5031,9 +4737,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="13" id="weapons_9_13" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_9_13&amp;id=weapons_9_13&amp;link=/checklists/weapons.html%23item_9_13&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Scimitar&quot;&gt;Scimitar&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_9_13&amp;id=weapons_9_13&amp;link=/checklists/weapons.html%23item_9_13&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Scimitar&quot;&gt;Scimitar&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5066,9 +4770,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="13" id="weapons_9_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_9_1&amp;id=weapons_9_1&amp;link=/checklists/weapons.html%23item_9_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Falchion&quot;&gt;Falchion&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_9_1&amp;id=weapons_9_1&amp;link=/checklists/weapons.html%23item_9_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Falchion&quot;&gt;Falchion&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5101,9 +4803,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="13" id="weapons_9_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_9_4&amp;id=weapons_9_4&amp;link=/checklists/weapons.html%23item_9_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Shamshir&quot;&gt;Shamshir&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_9_4&amp;id=weapons_9_4&amp;link=/checklists/weapons.html%23item_9_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Shamshir&quot;&gt;Shamshir&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5136,9 +4836,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="13" id="weapons_9_14" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_9_14&amp;id=weapons_9_14&amp;link=/checklists/weapons.html%23item_9_14&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Grossmesser&quot;&gt;Grossmesser&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_9_14&amp;id=weapons_9_14&amp;link=/checklists/weapons.html%23item_9_14&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Grossmesser&quot;&gt;Grossmesser&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5171,9 +4869,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="13" id="weapons_9_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_9_5&amp;id=weapons_9_5&amp;link=/checklists/weapons.html%23item_9_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Bandit's+Curved+Sword&quot;&gt;Bandit's Curved Sword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_9_5&amp;id=weapons_9_5&amp;link=/checklists/weapons.html%23item_9_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Bandit's+Curved+Sword&quot;&gt;Bandit's Curved Sword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5206,9 +4902,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="13" id="weapons_9_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_9_3&amp;id=weapons_9_3&amp;link=/checklists/weapons.html%23item_9_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Shotel&quot;&gt;Shotel&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_9_3&amp;id=weapons_9_3&amp;link=/checklists/weapons.html%23item_9_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Shotel&quot;&gt;Shotel&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5241,9 +4935,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="13" id="weapons_9_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_9_9&amp;id=weapons_9_9&amp;link=/checklists/weapons.html%23item_9_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Scavenger's+Curved+Sword&quot;&gt;Scavenger's Curved Sword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_9_9&amp;id=weapons_9_9&amp;link=/checklists/weapons.html%23item_9_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Scavenger's+Curved+Sword&quot;&gt;Scavenger's Curved Sword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5276,9 +4968,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="13" id="weapons_9_12" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_9_12&amp;id=weapons_9_12&amp;link=/checklists/weapons.html%23item_9_12&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Mantis+Blade&quot;&gt;Mantis Blade&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_9_12&amp;id=weapons_9_12&amp;link=/checklists/weapons.html%23item_9_12&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Mantis+Blade&quot;&gt;Mantis Blade&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5311,9 +5001,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="13" id="weapons_9_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_9_2&amp;id=weapons_9_2&amp;link=/checklists/weapons.html%23item_9_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Beastman's+Curved+Sword&quot;&gt;Beastman's Curved Sword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_9_2&amp;id=weapons_9_2&amp;link=/checklists/weapons.html%23item_9_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Beastman's+Curved+Sword&quot;&gt;Beastman's Curved Sword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5346,9 +5034,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="13" id="weapons_9_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_9_7&amp;id=weapons_9_7&amp;link=/checklists/weapons.html%23item_9_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Flowing+Curved+Sword&quot;&gt;Flowing Curved Sword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_9_7&amp;id=weapons_9_7&amp;link=/checklists/weapons.html%23item_9_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Flowing+Curved+Sword&quot;&gt;Flowing Curved Sword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5381,9 +5067,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="13" id="weapons_9_11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_9_11&amp;id=weapons_9_11&amp;link=/checklists/weapons.html%23item_9_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Serpent-God's+Curved+Sword&quot;&gt;Serpent-God's Curved Sword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_9_11&amp;id=weapons_9_11&amp;link=/checklists/weapons.html%23item_9_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Serpent-God's+Curved+Sword&quot;&gt;Serpent-God's Curved Sword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5416,9 +5100,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="13" id="weapons_9_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_9_6&amp;id=weapons_9_6&amp;link=/checklists/weapons.html%23item_9_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Magma+Blade&quot;&gt;Magma Blade&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_9_6&amp;id=weapons_9_6&amp;link=/checklists/weapons.html%23item_9_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Magma+Blade&quot;&gt;Magma Blade&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5451,9 +5133,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="13" id="weapons_9_15" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_9_15&amp;id=weapons_9_15&amp;link=/checklists/weapons.html%23item_9_15&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Nox+Flowing+Sword&quot;&gt;Nox Flowing Sword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_9_15&amp;id=weapons_9_15&amp;link=/checklists/weapons.html%23item_9_15&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Nox+Flowing+Sword&quot;&gt;Nox Flowing Sword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5486,9 +5166,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="13" id="weapons_9_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_9_8&amp;id=weapons_9_8&amp;link=/checklists/weapons.html%23item_9_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Wing+of+Astel&quot;&gt;Wing of Astel&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_9_8&amp;id=weapons_9_8&amp;link=/checklists/weapons.html%23item_9_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Wing+of+Astel&quot;&gt;Wing of Astel&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5521,9 +5199,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="13" id="weapons_9_10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_9_10&amp;id=weapons_9_10&amp;link=/checklists/weapons.html%23item_9_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Eclipse+Shotel&quot;&gt;Eclipse Shotel&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_9_10&amp;id=weapons_9_10&amp;link=/checklists/weapons.html%23item_9_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Eclipse+Shotel&quot;&gt;Eclipse Shotel&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5556,9 +5232,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="13" id="weapons_50_19" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_19&amp;id=weapons_50_19&amp;link=/checklists/weapons.html%23item_50_19&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Spirit+Sword&quot;&gt;Spirit Sword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_19&amp;id=weapons_50_19&amp;link=/checklists/weapons.html%23item_50_19&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Spirit+Sword&quot;&gt;Spirit Sword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5591,9 +5265,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="13" id="weapons_50_20" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_20&amp;id=weapons_50_20&amp;link=/checklists/weapons.html%23item_50_20&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Falx&quot;&gt;Falx&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_20&amp;id=weapons_50_20&amp;link=/checklists/weapons.html%23item_50_20&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Falx&quot;&gt;Falx&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5626,9 +5298,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="13" id="weapons_50_21" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_21&amp;id=weapons_50_21&amp;link=/checklists/weapons.html%23item_50_21&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dancing+Blade+of+Ranah&quot;&gt;Dancing Blade of Ranah&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_21&amp;id=weapons_50_21&amp;link=/checklists/weapons.html%23item_50_21&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dancing+Blade+of+Ranah&quot;&gt;Dancing Blade of Ranah&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5661,9 +5331,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="13" id="weapons_50_22" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_22&amp;id=weapons_50_22&amp;link=/checklists/weapons.html%23item_50_22&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Horned+Warrior's+Sword&quot;&gt;Horned Warrior's Sword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_22&amp;id=weapons_50_22&amp;link=/checklists/weapons.html%23item_50_22&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Horned+Warrior's+Sword&quot;&gt;Horned Warrior's Sword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5697,9 +5365,7 @@
         <div class="card shadow-sm mb-3" id="weapons_section_14">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_14Col" data-bs-toggle="collapse" href="#weapons_14Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_14Col" data-bs-toggle="collapse" href="#weapons_14Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Curved+Greatswords">Curved Greatswords</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="weapons_totals_14"></span>
             </h4>
@@ -5711,9 +5377,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -5742,9 +5406,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="14" id="weapons_8_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_8_2&amp;id=weapons_8_2&amp;link=/checklists/weapons.html%23item_8_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dismounter&quot;&gt;Dismounter&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_8_2&amp;id=weapons_8_2&amp;link=/checklists/weapons.html%23item_8_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dismounter&quot;&gt;Dismounter&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5777,9 +5439,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="14" id="weapons_8_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_8_6&amp;id=weapons_8_6&amp;link=/checklists/weapons.html%23item_8_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Omen+Cleaver&quot;&gt;Omen Cleaver&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_8_6&amp;id=weapons_8_6&amp;link=/checklists/weapons.html%23item_8_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Omen+Cleaver&quot;&gt;Omen Cleaver&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5812,9 +5472,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="14" id="weapons_8_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_8_7&amp;id=weapons_8_7&amp;link=/checklists/weapons.html%23item_8_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Monk's+Flameblade&quot;&gt;Monk's Flameblade&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_8_7&amp;id=weapons_8_7&amp;link=/checklists/weapons.html%23item_8_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Monk's+Flameblade&quot;&gt;Monk's Flameblade&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5847,9 +5505,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="14" id="weapons_8_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_8_8&amp;id=weapons_8_8&amp;link=/checklists/weapons.html%23item_8_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Beastman's+Cleaver&quot;&gt;Beastman's Cleaver&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_8_8&amp;id=weapons_8_8&amp;link=/checklists/weapons.html%23item_8_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Beastman's+Cleaver&quot;&gt;Beastman's Cleaver&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5882,9 +5538,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="14" id="weapons_8_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_8_3&amp;id=weapons_8_3&amp;link=/checklists/weapons.html%23item_8_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Bloodhound's+Fang&quot;&gt;Bloodhound's Fang&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_8_3&amp;id=weapons_8_3&amp;link=/checklists/weapons.html%23item_8_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Bloodhound's+Fang&quot;&gt;Bloodhound's Fang&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5917,9 +5571,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="14" id="weapons_8_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_8_1&amp;id=weapons_8_1&amp;link=/checklists/weapons.html%23item_8_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Onyx+Lord's+Greatsword&quot;&gt;Onyx Lord's Greatsword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_8_1&amp;id=weapons_8_1&amp;link=/checklists/weapons.html%23item_8_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Onyx+Lord's+Greatsword&quot;&gt;Onyx Lord's Greatsword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5952,9 +5604,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="14" id="weapons_8_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_8_5&amp;id=weapons_8_5&amp;link=/checklists/weapons.html%23item_8_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Zamor+Curved+Sword&quot;&gt;Zamor Curved Sword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_8_5&amp;id=weapons_8_5&amp;link=/checklists/weapons.html%23item_8_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Zamor+Curved+Sword&quot;&gt;Zamor Curved Sword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -5987,9 +5637,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="14" id="weapons_8_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_8_4&amp;id=weapons_8_4&amp;link=/checklists/weapons.html%23item_8_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Magma+Wyrm's+Scalesword&quot;&gt;Magma Wyrm's Scalesword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_8_4&amp;id=weapons_8_4&amp;link=/checklists/weapons.html%23item_8_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Magma+Wyrm's+Scalesword&quot;&gt;Magma Wyrm's Scalesword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6022,9 +5670,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="14" id="weapons_8_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_8_9&amp;id=weapons_8_9&amp;link=/checklists/weapons.html%23item_8_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Morgott's+Cursed+Sword&quot;&gt;Morgott's Cursed Sword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_8_9&amp;id=weapons_8_9&amp;link=/checklists/weapons.html%23item_8_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Morgott's+Cursed+Sword&quot;&gt;Morgott's Cursed Sword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6057,9 +5703,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="14" id="weapons_50_24" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_24&amp;id=weapons_50_24&amp;link=/checklists/weapons.html%23item_50_24&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Freyja's+Greatsword&quot;&gt;Freyja's Greatsword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_24&amp;id=weapons_50_24&amp;link=/checklists/weapons.html%23item_50_24&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Freyja's+Greatsword&quot;&gt;Freyja's Greatsword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6092,9 +5736,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="14" id="weapons_50_25" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_25&amp;id=weapons_50_25&amp;link=/checklists/weapons.html%23item_50_25&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Horned+Warrior's+Greatsword&quot;&gt;Horned Warrior's Greatsword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_25&amp;id=weapons_50_25&amp;link=/checklists/weapons.html%23item_50_25&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Horned+Warrior's+Greatsword&quot;&gt;Horned Warrior's Greatsword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6128,9 +5770,7 @@
         <div class="card shadow-sm mb-3" id="weapons_section_15">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_15Col" data-bs-toggle="collapse" href="#weapons_15Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_15Col" data-bs-toggle="collapse" href="#weapons_15Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Katanas">Katanas</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="weapons_totals_15"></span>
             </h4>
@@ -6142,9 +5782,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -6173,9 +5811,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="15" id="weapons_17_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_17_1&amp;id=weapons_17_1&amp;link=/checklists/weapons.html%23item_17_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Uchigatana&quot;&gt;Uchigatana&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_17_1&amp;id=weapons_17_1&amp;link=/checklists/weapons.html%23item_17_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Uchigatana&quot;&gt;Uchigatana&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6208,9 +5844,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="15" id="weapons_17_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_17_2&amp;id=weapons_17_2&amp;link=/checklists/weapons.html%23item_17_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Nagakiba&quot;&gt;Nagakiba&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_17_2&amp;id=weapons_17_2&amp;link=/checklists/weapons.html%23item_17_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Nagakiba&quot;&gt;Nagakiba&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6243,9 +5877,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="15" id="weapons_17_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_17_3&amp;id=weapons_17_3&amp;link=/checklists/weapons.html%23item_17_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Serpentbone+Blade&quot;&gt;Serpentbone Blade&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_17_3&amp;id=weapons_17_3&amp;link=/checklists/weapons.html%23item_17_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Serpentbone+Blade&quot;&gt;Serpentbone Blade&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6278,9 +5910,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="15" id="weapons_17_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_17_4&amp;id=weapons_17_4&amp;link=/checklists/weapons.html%23item_17_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Meteoric+Ore+Blade&quot;&gt;Meteoric Ore Blade&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_17_4&amp;id=weapons_17_4&amp;link=/checklists/weapons.html%23item_17_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Meteoric+Ore+Blade&quot;&gt;Meteoric Ore Blade&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6313,9 +5943,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="15" id="weapons_17_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_17_5&amp;id=weapons_17_5&amp;link=/checklists/weapons.html%23item_17_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Moonveil&quot;&gt;Moonveil&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_17_5&amp;id=weapons_17_5&amp;link=/checklists/weapons.html%23item_17_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Moonveil&quot;&gt;Moonveil&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6348,9 +5976,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="15" id="weapons_17_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_17_6&amp;id=weapons_17_6&amp;link=/checklists/weapons.html%23item_17_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Rivers+of+Blood&quot;&gt;Rivers of Blood&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_17_6&amp;id=weapons_17_6&amp;link=/checklists/weapons.html%23item_17_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Rivers+of+Blood&quot;&gt;Rivers of Blood&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6383,9 +6009,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="15" id="weapons_17_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_17_7&amp;id=weapons_17_7&amp;link=/checklists/weapons.html%23item_17_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dragonscale+Blade&quot;&gt;Dragonscale Blade&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_17_7&amp;id=weapons_17_7&amp;link=/checklists/weapons.html%23item_17_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dragonscale+Blade&quot;&gt;Dragonscale Blade&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6418,9 +6042,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="15" id="weapons_17_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_17_8&amp;id=weapons_17_8&amp;link=/checklists/weapons.html%23item_17_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Hand+of+Malenia&quot;&gt;Hand of Malenia&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_17_8&amp;id=weapons_17_8&amp;link=/checklists/weapons.html%23item_17_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Hand+of+Malenia&quot;&gt;Hand of Malenia&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6453,9 +6075,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="15" id="weapons_50_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_4&amp;id=weapons_50_4&amp;link=/checklists/weapons.html%23item_50_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Star-Lined+Sword&quot;&gt;Star-Lined Sword&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_4&amp;id=weapons_50_4&amp;link=/checklists/weapons.html%23item_50_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Star-Lined+Sword&quot;&gt;Star-Lined Sword&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6488,9 +6108,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="15" id="weapons_50_26" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_26&amp;id=weapons_50_26&amp;link=/checklists/weapons.html%23item_50_26&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Sword+of+Night&quot;&gt;Sword of Night&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_26&amp;id=weapons_50_26&amp;link=/checklists/weapons.html%23item_50_26&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Sword+of+Night&quot;&gt;Sword of Night&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6524,9 +6142,7 @@
         <div class="card shadow-sm mb-3" id="weapons_section_16">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_16Col" data-bs-toggle="collapse" href="#weapons_16Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_16Col" data-bs-toggle="collapse" href="#weapons_16Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Twinblades">Twinblades</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="weapons_totals_16"></span>
             </h4>
@@ -6538,9 +6154,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -6569,9 +6183,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="16" id="weapons_18_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_18_1&amp;id=weapons_18_1&amp;link=/checklists/weapons.html%23item_18_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Twinblade&quot;&gt;Twinblade&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_18_1&amp;id=weapons_18_1&amp;link=/checklists/weapons.html%23item_18_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Twinblade&quot;&gt;Twinblade&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6604,9 +6216,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="16" id="weapons_18_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_18_2&amp;id=weapons_18_2&amp;link=/checklists/weapons.html%23item_18_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Twinned+Knight+Swords&quot;&gt;Twinned Knight Swords&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_18_2&amp;id=weapons_18_2&amp;link=/checklists/weapons.html%23item_18_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Twinned+Knight+Swords&quot;&gt;Twinned Knight Swords&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6639,9 +6249,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="16" id="weapons_18_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_18_3&amp;id=weapons_18_3&amp;link=/checklists/weapons.html%23item_18_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Godskin+Peeler&quot;&gt;Godskin Peeler&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_18_3&amp;id=weapons_18_3&amp;link=/checklists/weapons.html%23item_18_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Godskin+Peeler&quot;&gt;Godskin Peeler&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6674,9 +6282,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="16" id="weapons_18_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_18_4&amp;id=weapons_18_4&amp;link=/checklists/weapons.html%23item_18_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gargoyle's+Twinblade&quot;&gt;Gargoyle's Twinblade&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_18_4&amp;id=weapons_18_4&amp;link=/checklists/weapons.html%23item_18_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gargoyle's+Twinblade&quot;&gt;Gargoyle's Twinblade&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6709,9 +6315,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="16" id="weapons_18_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_18_5&amp;id=weapons_18_5&amp;link=/checklists/weapons.html%23item_18_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gargoyle's+Black+Blades&quot;&gt;Gargoyle's Black Blades&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_18_5&amp;id=weapons_18_5&amp;link=/checklists/weapons.html%23item_18_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gargoyle's+Black+Blades&quot;&gt;Gargoyle's Black Blades&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6744,9 +6348,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="16" id="weapons_18_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_18_6&amp;id=weapons_18_6&amp;link=/checklists/weapons.html%23item_18_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Eleonora's+Poleblade&quot;&gt;Eleonora's Poleblade&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_18_6&amp;id=weapons_18_6&amp;link=/checklists/weapons.html%23item_18_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Eleonora's+Poleblade&quot;&gt;Eleonora's Poleblade&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6779,9 +6381,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="16" id="weapons_50_27" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_27&amp;id=weapons_50_27&amp;link=/checklists/weapons.html%23item_50_27&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Euporia&quot;&gt;Euporia&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_27&amp;id=weapons_50_27&amp;link=/checklists/weapons.html%23item_50_27&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Euporia&quot;&gt;Euporia&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6814,9 +6414,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="16" id="weapons_50_28" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_28&amp;id=weapons_50_28&amp;link=/checklists/weapons.html%23item_50_28&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Black+Steel+Twinblade&quot;&gt;Black Steel Twinblade&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_28&amp;id=weapons_50_28&amp;link=/checklists/weapons.html%23item_50_28&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Black+Steel+Twinblade&quot;&gt;Black Steel Twinblade&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6850,9 +6448,7 @@
         <div class="card shadow-sm mb-3" id="weapons_section_17">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_17Col" data-bs-toggle="collapse" href="#weapons_17Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_17Col" data-bs-toggle="collapse" href="#weapons_17Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Axes">Axes</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="weapons_totals_17"></span>
             </h4>
@@ -6864,9 +6460,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -6895,9 +6489,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="17" id="weapons_1_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_1_3&amp;id=weapons_1_3&amp;link=/checklists/weapons.html%23item_1_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Hand+Axe&quot;&gt;Hand Axe&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_1_3&amp;id=weapons_1_3&amp;link=/checklists/weapons.html%23item_1_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Hand+Axe&quot;&gt;Hand Axe&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6930,9 +6522,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="17" id="weapons_1_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_1_2&amp;id=weapons_1_2&amp;link=/checklists/weapons.html%23item_1_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Forked+Hatchet&quot;&gt;Forked Hatchet&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_1_2&amp;id=weapons_1_2&amp;link=/checklists/weapons.html%23item_1_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Forked+Hatchet&quot;&gt;Forked Hatchet&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -6965,9 +6555,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="17" id="weapons_1_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_1_1&amp;id=weapons_1_1&amp;link=/checklists/weapons.html%23item_1_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Battle+Axe&quot;&gt;Battle Axe&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_1_1&amp;id=weapons_1_1&amp;link=/checklists/weapons.html%23item_1_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Battle+Axe&quot;&gt;Battle Axe&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7000,9 +6588,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="17" id="weapons_1_13" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_1_13&amp;id=weapons_1_13&amp;link=/checklists/weapons.html%23item_1_13&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Warped+Axe&quot;&gt;Warped Axe&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_1_13&amp;id=weapons_1_13&amp;link=/checklists/weapons.html%23item_1_13&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Warped+Axe&quot;&gt;Warped Axe&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7035,9 +6621,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="17" id="weapons_1_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_1_4&amp;id=weapons_1_4&amp;link=/checklists/weapons.html%23item_1_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Jawbone+Axe&quot;&gt;Jawbone Axe&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_1_4&amp;id=weapons_1_4&amp;link=/checklists/weapons.html%23item_1_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Jawbone+Axe&quot;&gt;Jawbone Axe&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7070,9 +6654,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="17" id="weapons_1_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_1_5&amp;id=weapons_1_5&amp;link=/checklists/weapons.html%23item_1_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Iron+Cleaver&quot;&gt;Iron Cleaver&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_1_5&amp;id=weapons_1_5&amp;link=/checklists/weapons.html%23item_1_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Iron+Cleaver&quot;&gt;Iron Cleaver&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7105,9 +6687,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="17" id="weapons_1_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_1_9&amp;id=weapons_1_9&amp;link=/checklists/weapons.html%23item_1_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Highland+Axe&quot;&gt;Highland Axe&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_1_9&amp;id=weapons_1_9&amp;link=/checklists/weapons.html%23item_1_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Highland+Axe&quot;&gt;Highland Axe&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7140,9 +6720,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="17" id="weapons_1_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_1_7&amp;id=weapons_1_7&amp;link=/checklists/weapons.html%23item_1_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Celebrant's+Cleaver&quot;&gt;Celebrant's Cleaver&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_1_7&amp;id=weapons_1_7&amp;link=/checklists/weapons.html%23item_1_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Celebrant's+Cleaver&quot;&gt;Celebrant's Cleaver&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7175,9 +6753,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="17" id="weapons_1_10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_1_10&amp;id=weapons_1_10&amp;link=/checklists/weapons.html%23item_1_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Sacrificial+Axe&quot;&gt;Sacrificial Axe&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_1_10&amp;id=weapons_1_10&amp;link=/checklists/weapons.html%23item_1_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Sacrificial+Axe&quot;&gt;Sacrificial Axe&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7210,9 +6786,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="17" id="weapons_1_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_1_8&amp;id=weapons_1_8&amp;link=/checklists/weapons.html%23item_1_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Icerind+Hatchet&quot;&gt;Icerind Hatchet&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_1_8&amp;id=weapons_1_8&amp;link=/checklists/weapons.html%23item_1_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Icerind+Hatchet&quot;&gt;Icerind Hatchet&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7245,9 +6819,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="17" id="weapons_1_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_1_6&amp;id=weapons_1_6&amp;link=/checklists/weapons.html%23item_1_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ripple+Blade&quot;&gt;Ripple Blade&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_1_6&amp;id=weapons_1_6&amp;link=/checklists/weapons.html%23item_1_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ripple+Blade&quot;&gt;Ripple Blade&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7280,9 +6852,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="17" id="weapons_1_12" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_1_12&amp;id=weapons_1_12&amp;link=/checklists/weapons.html%23item_1_12&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Stormhawk+Axe&quot;&gt;Stormhawk Axe&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_1_12&amp;id=weapons_1_12&amp;link=/checklists/weapons.html%23item_1_12&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Stormhawk+Axe&quot;&gt;Stormhawk Axe&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7315,9 +6885,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="17" id="weapons_1_11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_1_11&amp;id=weapons_1_11&amp;link=/checklists/weapons.html%23item_1_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Rosus'+Axe&quot;&gt;Rosus' Axe&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_1_11&amp;id=weapons_1_11&amp;link=/checklists/weapons.html%23item_1_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Rosus'+Axe&quot;&gt;Rosus' Axe&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7350,9 +6918,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="17" id="weapons_50_35" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_35&amp;id=weapons_50_35&amp;link=/checklists/weapons.html%23item_50_35&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Smithscript+Axe&quot;&gt;Smithscript Axe&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_35&amp;id=weapons_50_35&amp;link=/checklists/weapons.html%23item_50_35&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Smithscript+Axe&quot;&gt;Smithscript Axe&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7385,9 +6951,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="17" id="weapons_50_36" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_36&amp;id=weapons_50_36&amp;link=/checklists/weapons.html%23item_50_36&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Death+Knight's+Twin+Axes&quot;&gt;Death Knight's Twin Axes&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_36&amp;id=weapons_50_36&amp;link=/checklists/weapons.html%23item_50_36&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Death+Knight's+Twin+Axes&quot;&gt;Death Knight's Twin Axes&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7420,9 +6984,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="17" id="weapons_50_37" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_37&amp;id=weapons_50_37&amp;link=/checklists/weapons.html%23item_50_37&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Messmer+Soldier's+Axe&quot;&gt;Messmer Soldier's Axe&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_37&amp;id=weapons_50_37&amp;link=/checklists/weapons.html%23item_50_37&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Messmer+Soldier's+Axe&quot;&gt;Messmer Soldier's Axe&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7455,9 +7017,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="17" id="weapons_50_38" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_38&amp;id=weapons_50_38&amp;link=/checklists/weapons.html%23item_50_38&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Forked-Tongue+Hatchet&quot;&gt;Forked-Tongue Hatchet&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_38&amp;id=weapons_50_38&amp;link=/checklists/weapons.html%23item_50_38&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Forked-Tongue+Hatchet&quot;&gt;Forked-Tongue Hatchet&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7491,9 +7051,7 @@
         <div class="card shadow-sm mb-3" id="weapons_section_18">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_18Col" data-bs-toggle="collapse" href="#weapons_18Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_18Col" data-bs-toggle="collapse" href="#weapons_18Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Greataxes">Greataxes</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="weapons_totals_18"></span>
             </h4>
@@ -7505,9 +7063,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -7536,9 +7092,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="18" id="weapons_19_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_19_1&amp;id=weapons_19_1&amp;link=/checklists/weapons.html%23item_19_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Greataxe&quot;&gt;Greataxe&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_19_1&amp;id=weapons_19_1&amp;link=/checklists/weapons.html%23item_19_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Greataxe&quot;&gt;Greataxe&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7571,9 +7125,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="18" id="weapons_19_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_19_2&amp;id=weapons_19_2&amp;link=/checklists/weapons.html%23item_19_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Crescent+Moon+Axe&quot;&gt;Crescent Moon Axe&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_19_2&amp;id=weapons_19_2&amp;link=/checklists/weapons.html%23item_19_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Crescent+Moon+Axe&quot;&gt;Crescent Moon Axe&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7606,9 +7158,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="18" id="weapons_19_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_19_3&amp;id=weapons_19_3&amp;link=/checklists/weapons.html%23item_19_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Longhaft+Axe&quot;&gt;Longhaft Axe&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_19_3&amp;id=weapons_19_3&amp;link=/checklists/weapons.html%23item_19_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Longhaft+Axe&quot;&gt;Longhaft Axe&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7641,9 +7191,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="18" id="weapons_19_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_19_4&amp;id=weapons_19_4&amp;link=/checklists/weapons.html%23item_19_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Executioner's+Greataxe&quot;&gt;Executioner's Greataxe&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_19_4&amp;id=weapons_19_4&amp;link=/checklists/weapons.html%23item_19_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Executioner's+Greataxe&quot;&gt;Executioner's Greataxe&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7676,9 +7224,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="18" id="weapons_19_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_19_5&amp;id=weapons_19_5&amp;link=/checklists/weapons.html%23item_19_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Great+Omenkiller+Cleaver&quot;&gt;Great Omenkiller Cleaver&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_19_5&amp;id=weapons_19_5&amp;link=/checklists/weapons.html%23item_19_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Great+Omenkiller+Cleaver&quot;&gt;Great Omenkiller Cleaver&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7711,9 +7257,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="18" id="weapons_19_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_19_6&amp;id=weapons_19_6&amp;link=/checklists/weapons.html%23item_19_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Rusted+Anchor&quot;&gt;Rusted Anchor&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_19_6&amp;id=weapons_19_6&amp;link=/checklists/weapons.html%23item_19_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Rusted+Anchor&quot;&gt;Rusted Anchor&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7746,9 +7290,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="18" id="weapons_19_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_19_7&amp;id=weapons_19_7&amp;link=/checklists/weapons.html%23item_19_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Butchering+Knife&quot;&gt;Butchering Knife&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_19_7&amp;id=weapons_19_7&amp;link=/checklists/weapons.html%23item_19_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Butchering+Knife&quot;&gt;Butchering Knife&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7781,9 +7323,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="18" id="weapons_19_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_19_8&amp;id=weapons_19_8&amp;link=/checklists/weapons.html%23item_19_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gargoyle's+Great+Axe&quot;&gt;Gargoyle's Great Axe&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_19_8&amp;id=weapons_19_8&amp;link=/checklists/weapons.html%23item_19_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gargoyle's+Great+Axe&quot;&gt;Gargoyle's Great Axe&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7816,9 +7356,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="18" id="weapons_19_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_19_9&amp;id=weapons_19_9&amp;link=/checklists/weapons.html%23item_19_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gargoyle's+Black+Axe&quot;&gt;Gargoyle's Black Axe&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_19_9&amp;id=weapons_19_9&amp;link=/checklists/weapons.html%23item_19_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gargoyle's+Black+Axe&quot;&gt;Gargoyle's Black Axe&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7851,9 +7389,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="18" id="weapons_19_10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_19_10&amp;id=weapons_19_10&amp;link=/checklists/weapons.html%23item_19_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Winged+Greathorn&quot;&gt;Winged Greathorn&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_19_10&amp;id=weapons_19_10&amp;link=/checklists/weapons.html%23item_19_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Winged+Greathorn&quot;&gt;Winged Greathorn&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7886,9 +7422,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="18" id="weapons_19_11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_19_11&amp;id=weapons_19_11&amp;link=/checklists/weapons.html%23item_19_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Axe+of+Godrick&quot;&gt;Axe of Godrick&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_19_11&amp;id=weapons_19_11&amp;link=/checklists/weapons.html%23item_19_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Axe+of+Godrick&quot;&gt;Axe of Godrick&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7921,9 +7455,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="18" id="weapons_50_23" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_23&amp;id=weapons_50_23&amp;link=/checklists/weapons.html%23item_50_23&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Putrescence+Cleaver&quot;&gt;Putrescence Cleaver&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_23&amp;id=weapons_50_23&amp;link=/checklists/weapons.html%23item_50_23&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Putrescence+Cleaver&quot;&gt;Putrescence Cleaver&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7956,9 +7488,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="18" id="weapons_50_39" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_39&amp;id=weapons_50_39&amp;link=/checklists/weapons.html%23item_50_39&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Death+Knight's+Longhaft+Axe&quot;&gt;Death Knight's Longhaft Axe&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_39&amp;id=weapons_50_39&amp;link=/checklists/weapons.html%23item_50_39&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Death+Knight's+Longhaft+Axe&quot;&gt;Death Knight's Longhaft Axe&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -7991,9 +7521,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="18" id="weapons_50_40" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_40&amp;id=weapons_50_40&amp;link=/checklists/weapons.html%23item_50_40&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Bonny+Butchering+Knife&quot;&gt;Bonny Butchering Knife&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_40&amp;id=weapons_50_40&amp;link=/checklists/weapons.html%23item_50_40&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Bonny+Butchering+Knife&quot;&gt;Bonny Butchering Knife&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8027,9 +7555,7 @@
         <div class="card shadow-sm mb-3" id="weapons_section_19">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_19Col" data-bs-toggle="collapse" href="#weapons_19Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_19Col" data-bs-toggle="collapse" href="#weapons_19Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Hammers">Hammers</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="weapons_totals_19"></span>
             </h4>
@@ -8041,9 +7567,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -8072,9 +7596,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="19" id="weapons_20_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_20_1&amp;id=weapons_20_1&amp;link=/checklists/weapons.html%23item_20_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Club&quot;&gt;Club&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_20_1&amp;id=weapons_20_1&amp;link=/checklists/weapons.html%23item_20_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Club&quot;&gt;Club&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8107,9 +7629,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="19" id="weapons_20_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_20_2&amp;id=weapons_20_2&amp;link=/checklists/weapons.html%23item_20_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Curved+Club&quot;&gt;Curved Club&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_20_2&amp;id=weapons_20_2&amp;link=/checklists/weapons.html%23item_20_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Curved+Club&quot;&gt;Curved Club&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8142,9 +7662,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="19" id="weapons_20_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_20_3&amp;id=weapons_20_3&amp;link=/checklists/weapons.html%23item_20_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Spiked+Club&quot;&gt;Spiked Club&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_20_3&amp;id=weapons_20_3&amp;link=/checklists/weapons.html%23item_20_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Spiked+Club&quot;&gt;Spiked Club&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8177,9 +7695,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="19" id="weapons_20_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_20_4&amp;id=weapons_20_4&amp;link=/checklists/weapons.html%23item_20_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Stone+Club&quot;&gt;Stone Club&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_20_4&amp;id=weapons_20_4&amp;link=/checklists/weapons.html%23item_20_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Stone+Club&quot;&gt;Stone Club&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8212,9 +7728,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="19" id="weapons_20_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_20_5&amp;id=weapons_20_5&amp;link=/checklists/weapons.html%23item_20_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Mace&quot;&gt;Mace&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_20_5&amp;id=weapons_20_5&amp;link=/checklists/weapons.html%23item_20_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Mace&quot;&gt;Mace&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8247,9 +7761,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="19" id="weapons_20_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_20_6&amp;id=weapons_20_6&amp;link=/checklists/weapons.html%23item_20_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Morning+Star&quot;&gt;Morning Star&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_20_6&amp;id=weapons_20_6&amp;link=/checklists/weapons.html%23item_20_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Morning+Star&quot;&gt;Morning Star&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8282,9 +7794,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="19" id="weapons_20_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_20_7&amp;id=weapons_20_7&amp;link=/checklists/weapons.html%23item_20_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Warpick&quot;&gt;Warpick&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_20_7&amp;id=weapons_20_7&amp;link=/checklists/weapons.html%23item_20_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Warpick&quot;&gt;Warpick&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8317,9 +7827,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="19" id="weapons_20_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_20_8&amp;id=weapons_20_8&amp;link=/checklists/weapons.html%23item_20_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Hammer&quot;&gt;Hammer&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_20_8&amp;id=weapons_20_8&amp;link=/checklists/weapons.html%23item_20_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Hammer&quot;&gt;Hammer&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8352,9 +7860,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="19" id="weapons_20_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_20_9&amp;id=weapons_20_9&amp;link=/checklists/weapons.html%23item_20_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Monk's+Flamemace&quot;&gt;Monk's Flamemace&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_20_9&amp;id=weapons_20_9&amp;link=/checklists/weapons.html%23item_20_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Monk's+Flamemace&quot;&gt;Monk's Flamemace&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8387,9 +7893,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="19" id="weapons_20_10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_20_10&amp;id=weapons_20_10&amp;link=/checklists/weapons.html%23item_20_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Varre's+Bouquet&quot;&gt;Varré's Bouquet&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_20_10&amp;id=weapons_20_10&amp;link=/checklists/weapons.html%23item_20_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Varre's+Bouquet&quot;&gt;Varré's Bouquet&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8422,9 +7926,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="19" id="weapons_20_11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_20_11&amp;id=weapons_20_11&amp;link=/checklists/weapons.html%23item_20_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Envoy's+Horn&quot;&gt;Envoy's Horn&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_20_11&amp;id=weapons_20_11&amp;link=/checklists/weapons.html%23item_20_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Envoy's+Horn&quot;&gt;Envoy's Horn&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8457,9 +7959,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="19" id="weapons_20_12" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_20_12&amp;id=weapons_20_12&amp;link=/checklists/weapons.html%23item_20_12&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Nox+Flowing+Hammer&quot;&gt;Nox Flowing Hammer&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_20_12&amp;id=weapons_20_12&amp;link=/checklists/weapons.html%23item_20_12&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Nox+Flowing+Hammer&quot;&gt;Nox Flowing Hammer&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8492,9 +7992,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="19" id="weapons_20_13" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_20_13&amp;id=weapons_20_13&amp;link=/checklists/weapons.html%23item_20_13&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ringed+Finger&quot;&gt;Ringed Finger&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_20_13&amp;id=weapons_20_13&amp;link=/checklists/weapons.html%23item_20_13&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ringed+Finger&quot;&gt;Ringed Finger&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8527,9 +8025,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="19" id="weapons_20_14" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_20_14&amp;id=weapons_20_14&amp;link=/checklists/weapons.html%23item_20_14&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Scepter+of+the+All-Knowing&quot;&gt;Scepter of the All-Knowing&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_20_14&amp;id=weapons_20_14&amp;link=/checklists/weapons.html%23item_20_14&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Scepter+of+the+All-Knowing&quot;&gt;Scepter of the All-Knowing&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8562,9 +8058,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="19" id="weapons_20_15" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_20_15&amp;id=weapons_20_15&amp;link=/checklists/weapons.html%23item_20_15&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Marika's+Hammer&quot;&gt;Marika's Hammer&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_20_15&amp;id=weapons_20_15&amp;link=/checklists/weapons.html%23item_20_15&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Marika's+Hammer&quot;&gt;Marika's Hammer&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8597,9 +8091,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="19" id="weapons_50_29" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_29&amp;id=weapons_50_29&amp;link=/checklists/weapons.html%23item_50_29&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Flowerstone+Gavel&quot;&gt;Flowerstone Gavel&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_29&amp;id=weapons_50_29&amp;link=/checklists/weapons.html%23item_50_29&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Flowerstone+Gavel&quot;&gt;Flowerstone Gavel&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8633,9 +8125,7 @@
         <div class="card shadow-sm mb-3" id="weapons_section_20">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_20Col" data-bs-toggle="collapse" href="#weapons_20Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_20Col" data-bs-toggle="collapse" href="#weapons_20Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Flails">Flails</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="weapons_totals_20"></span>
             </h4>
@@ -8647,9 +8137,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -8678,9 +8166,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="20" id="weapons_21_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_21_1&amp;id=weapons_21_1&amp;link=/checklists/weapons.html%23item_21_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Flail&quot;&gt;Flail&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_21_1&amp;id=weapons_21_1&amp;link=/checklists/weapons.html%23item_21_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Flail&quot;&gt;Flail&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8713,9 +8199,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="20" id="weapons_21_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_21_2&amp;id=weapons_21_2&amp;link=/checklists/weapons.html%23item_21_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Nightrider+Flail&quot;&gt;Nightrider Flail&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_21_2&amp;id=weapons_21_2&amp;link=/checklists/weapons.html%23item_21_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Nightrider+Flail&quot;&gt;Nightrider Flail&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8748,9 +8232,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="20" id="weapons_21_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_21_3&amp;id=weapons_21_3&amp;link=/checklists/weapons.html%23item_21_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Chainlink+Flail&quot;&gt;Chainlink Flail&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_21_3&amp;id=weapons_21_3&amp;link=/checklists/weapons.html%23item_21_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Chainlink+Flail&quot;&gt;Chainlink Flail&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8783,9 +8265,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="20" id="weapons_21_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_21_4&amp;id=weapons_21_4&amp;link=/checklists/weapons.html%23item_21_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Family+Heads&quot;&gt;Family Heads&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_21_4&amp;id=weapons_21_4&amp;link=/checklists/weapons.html%23item_21_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Family+Heads&quot;&gt;Family Heads&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8818,9 +8298,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="20" id="weapons_21_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_21_5&amp;id=weapons_21_5&amp;link=/checklists/weapons.html%23item_21_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Bastard's+Stars&quot;&gt;Bastard's Stars&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_21_5&amp;id=weapons_21_5&amp;link=/checklists/weapons.html%23item_21_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Bastard's+Stars&quot;&gt;Bastard's Stars&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8853,9 +8331,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="20" id="weapons_50_34" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_34&amp;id=weapons_50_34&amp;link=/checklists/weapons.html%23item_50_34&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Serpent+Flail&quot;&gt;Serpent Flail&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_34&amp;id=weapons_50_34&amp;link=/checklists/weapons.html%23item_50_34&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Serpent+Flail&quot;&gt;Serpent Flail&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8889,9 +8365,7 @@
         <div class="card shadow-sm mb-3" id="weapons_section_21">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_21Col" data-bs-toggle="collapse" href="#weapons_21Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_21Col" data-bs-toggle="collapse" href="#weapons_21Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Great+Hammers">Great Hammers</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="weapons_totals_21"></span>
             </h4>
@@ -8903,9 +8377,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -8934,9 +8406,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="21" id="weapons_22_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_22_1&amp;id=weapons_22_1&amp;link=/checklists/weapons.html%23item_22_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Large+Club&quot;&gt;Large Club&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_22_1&amp;id=weapons_22_1&amp;link=/checklists/weapons.html%23item_22_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Large+Club&quot;&gt;Large Club&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -8969,9 +8439,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="21" id="weapons_22_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_22_2&amp;id=weapons_22_2&amp;link=/checklists/weapons.html%23item_22_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Curved+Great+Club&quot;&gt;Curved Great Club&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_22_2&amp;id=weapons_22_2&amp;link=/checklists/weapons.html%23item_22_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Curved+Great+Club&quot;&gt;Curved Great Club&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -9004,9 +8472,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="21" id="weapons_22_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_22_3&amp;id=weapons_22_3&amp;link=/checklists/weapons.html%23item_22_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Great+Mace&quot;&gt;Great Mace&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_22_3&amp;id=weapons_22_3&amp;link=/checklists/weapons.html%23item_22_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Great+Mace&quot;&gt;Great Mace&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -9039,9 +8505,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="21" id="weapons_22_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_22_4&amp;id=weapons_22_4&amp;link=/checklists/weapons.html%23item_22_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Pickaxe&quot;&gt;Pickaxe&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_22_4&amp;id=weapons_22_4&amp;link=/checklists/weapons.html%23item_22_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Pickaxe&quot;&gt;Pickaxe&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -9074,9 +8538,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="21" id="weapons_22_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_22_5&amp;id=weapons_22_5&amp;link=/checklists/weapons.html%23item_22_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Brick+Hammer&quot;&gt;Brick Hammer&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_22_5&amp;id=weapons_22_5&amp;link=/checklists/weapons.html%23item_22_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Brick+Hammer&quot;&gt;Brick Hammer&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -9109,9 +8571,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="21" id="weapons_22_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_22_6&amp;id=weapons_22_6&amp;link=/checklists/weapons.html%23item_22_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Battle+Hammer&quot;&gt;Battle Hammer&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_22_6&amp;id=weapons_22_6&amp;link=/checklists/weapons.html%23item_22_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Battle+Hammer&quot;&gt;Battle Hammer&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -9144,9 +8604,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="21" id="weapons_22_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_22_7&amp;id=weapons_22_7&amp;link=/checklists/weapons.html%23item_22_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Rotten+Battle+Hammer&quot;&gt;Rotten Battle Hammer&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_22_7&amp;id=weapons_22_7&amp;link=/checklists/weapons.html%23item_22_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Rotten+Battle+Hammer&quot;&gt;Rotten Battle Hammer&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -9179,9 +8637,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="21" id="weapons_22_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_22_8&amp;id=weapons_22_8&amp;link=/checklists/weapons.html%23item_22_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Celebrant's+Skull&quot;&gt;Celebrant's Skull&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_22_8&amp;id=weapons_22_8&amp;link=/checklists/weapons.html%23item_22_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Celebrant's+Skull&quot;&gt;Celebrant's Skull&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -9214,9 +8670,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="21" id="weapons_22_10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_22_10&amp;id=weapons_22_10&amp;link=/checklists/weapons.html%23item_22_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Great+Stars&quot;&gt;Great Stars&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_22_10&amp;id=weapons_22_10&amp;link=/checklists/weapons.html%23item_22_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Great+Stars&quot;&gt;Great Stars&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -9249,9 +8703,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="21" id="weapons_22_11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_22_11&amp;id=weapons_22_11&amp;link=/checklists/weapons.html%23item_22_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Greathorn+Hammer&quot;&gt;Greathorn Hammer&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_22_11&amp;id=weapons_22_11&amp;link=/checklists/weapons.html%23item_22_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Greathorn+Hammer&quot;&gt;Greathorn Hammer&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -9284,9 +8736,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="21" id="weapons_22_12" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_22_12&amp;id=weapons_22_12&amp;link=/checklists/weapons.html%23item_22_12&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Envoy's+Long+Horn&quot;&gt;Envoy's Long Horn&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_22_12&amp;id=weapons_22_12&amp;link=/checklists/weapons.html%23item_22_12&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Envoy's+Long+Horn&quot;&gt;Envoy's Long Horn&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -9319,9 +8769,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="21" id="weapons_22_13" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_22_13&amp;id=weapons_22_13&amp;link=/checklists/weapons.html%23item_22_13&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Cranial+Vessel+Candlestand&quot;&gt;Cranial Vessel Candlestand&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_22_13&amp;id=weapons_22_13&amp;link=/checklists/weapons.html%23item_22_13&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Cranial+Vessel+Candlestand&quot;&gt;Cranial Vessel Candlestand&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -9354,9 +8802,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="21" id="weapons_22_14" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_22_14&amp;id=weapons_22_14&amp;link=/checklists/weapons.html%23item_22_14&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Beastclaw+Greathammer&quot;&gt;Beastclaw Greathammer&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_22_14&amp;id=weapons_22_14&amp;link=/checklists/weapons.html%23item_22_14&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Beastclaw+Greathammer&quot;&gt;Beastclaw Greathammer&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -9389,9 +8835,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="21" id="weapons_22_15" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_22_15&amp;id=weapons_22_15&amp;link=/checklists/weapons.html%23item_22_15&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Devourer's+Scepter&quot;&gt;Devourer's Scepter&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_22_15&amp;id=weapons_22_15&amp;link=/checklists/weapons.html%23item_22_15&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Devourer's+Scepter&quot;&gt;Devourer's Scepter&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -9424,9 +8868,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="21" id="weapons_50_30" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_30&amp;id=weapons_50_30&amp;link=/checklists/weapons.html%23item_50_30&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Smithscript+Greathammer&quot;&gt;Smithscript Greathammer&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_30&amp;id=weapons_50_30&amp;link=/checklists/weapons.html%23item_50_30&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Smithscript+Greathammer&quot;&gt;Smithscript Greathammer&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -9459,9 +8901,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="21" id="weapons_50_32" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_32&amp;id=weapons_50_32&amp;link=/checklists/weapons.html%23item_50_32&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Black+Steel+Greathammer&quot;&gt;Black Steel Greathammer&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_32&amp;id=weapons_50_32&amp;link=/checklists/weapons.html%23item_50_32&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Black+Steel+Greathammer&quot;&gt;Black Steel Greathammer&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -9495,9 +8935,7 @@
         <div class="card shadow-sm mb-3" id="weapons_section_22">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_22Col" data-bs-toggle="collapse" href="#weapons_22Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_22Col" data-bs-toggle="collapse" href="#weapons_22Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Colossal+Weapons">Colossal Weapons</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="weapons_totals_22"></span>
             </h4>
@@ -9509,9 +8947,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -9540,9 +8976,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="22" id="weapons_6_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_6_5&amp;id=weapons_6_5&amp;link=/checklists/weapons.html%23item_6_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Duelist+Greataxe&quot;&gt;Duelist Greataxe&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_6_5&amp;id=weapons_6_5&amp;link=/checklists/weapons.html%23item_6_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Duelist+Greataxe&quot;&gt;Duelist Greataxe&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -9575,9 +9009,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="22" id="weapons_6_15" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_6_15&amp;id=weapons_6_15&amp;link=/checklists/weapons.html%23item_6_15&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Rotten+Greataxe&quot;&gt;Rotten Greataxe&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_6_15&amp;id=weapons_6_15&amp;link=/checklists/weapons.html%23item_6_15&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Rotten+Greataxe&quot;&gt;Rotten Greataxe&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -9610,9 +9042,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="22" id="weapons_6_12" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_6_12&amp;id=weapons_6_12&amp;link=/checklists/weapons.html%23item_6_12&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Golem's+Halberd&quot;&gt;Golem's Halberd&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_6_12&amp;id=weapons_6_12&amp;link=/checklists/weapons.html%23item_6_12&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Golem's+Halberd&quot;&gt;Golem's Halberd&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -9645,9 +9075,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="22" id="weapons_6_11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_6_11&amp;id=weapons_6_11&amp;link=/checklists/weapons.html%23item_6_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Giant-Crusher&quot;&gt;Giant-Crusher&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_6_11&amp;id=weapons_6_11&amp;link=/checklists/weapons.html%23item_6_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Giant-Crusher&quot;&gt;Giant-Crusher&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -9680,9 +9108,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="22" id="weapons_6_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_6_1&amp;id=weapons_6_1&amp;link=/checklists/weapons.html%23item_6_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Prelate's+Inferno+Crozier&quot;&gt;Prelate's Inferno Crozier&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_6_1&amp;id=weapons_6_1&amp;link=/checklists/weapons.html%23item_6_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Prelate's+Inferno+Crozier&quot;&gt;Prelate's Inferno Crozier&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -9715,9 +9141,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="22" id="weapons_6_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_6_3&amp;id=weapons_6_3&amp;link=/checklists/weapons.html%23item_6_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Great+Club&quot;&gt;Great Club&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_6_3&amp;id=weapons_6_3&amp;link=/checklists/weapons.html%23item_6_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Great+Club&quot;&gt;Great Club&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -9750,9 +9174,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="22" id="weapons_6_13" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_6_13&amp;id=weapons_6_13&amp;link=/checklists/weapons.html%23item_6_13&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Troll's+Hammer&quot;&gt;Troll's Hammer&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_6_13&amp;id=weapons_6_13&amp;link=/checklists/weapons.html%23item_6_13&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Troll's+Hammer&quot;&gt;Troll's Hammer&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -9785,9 +9207,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="22" id="weapons_6_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_6_7&amp;id=weapons_6_7&amp;link=/checklists/weapons.html%23item_6_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dragon+Greatclaw&quot;&gt;Dragon Greatclaw&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_6_7&amp;id=weapons_6_7&amp;link=/checklists/weapons.html%23item_6_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dragon+Greatclaw&quot;&gt;Dragon Greatclaw&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -9820,9 +9240,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="22" id="weapons_6_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_6_2&amp;id=weapons_6_2&amp;link=/checklists/weapons.html%23item_6_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Watchdog's+Staff&quot;&gt;Watchdog's Staff&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_6_2&amp;id=weapons_6_2&amp;link=/checklists/weapons.html%23item_6_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Watchdog's+Staff&quot;&gt;Watchdog's Staff&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -9855,9 +9273,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="22" id="weapons_6_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_6_8&amp;id=weapons_6_8&amp;link=/checklists/weapons.html%23item_6_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Staff+of+the+Avatar&quot;&gt;Staff of the Avatar&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_6_8&amp;id=weapons_6_8&amp;link=/checklists/weapons.html%23item_6_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Staff+of+the+Avatar&quot;&gt;Staff of the Avatar&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -9890,9 +9306,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="22" id="weapons_6_14" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_6_14&amp;id=weapons_6_14&amp;link=/checklists/weapons.html%23item_6_14&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Rotten+Staff&quot;&gt;Rotten Staff&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_6_14&amp;id=weapons_6_14&amp;link=/checklists/weapons.html%23item_6_14&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Rotten+Staff&quot;&gt;Rotten Staff&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -9925,9 +9339,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="22" id="weapons_6_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_6_4&amp;id=weapons_6_4&amp;link=/checklists/weapons.html%23item_6_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Envoy's+Greathorn&quot;&gt;Envoy's Greathorn&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_6_4&amp;id=weapons_6_4&amp;link=/checklists/weapons.html%23item_6_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Envoy's+Greathorn&quot;&gt;Envoy's Greathorn&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -9960,9 +9372,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="22" id="weapons_6_10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_6_10&amp;id=weapons_6_10&amp;link=/checklists/weapons.html%23item_6_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ghiza's+Wheel&quot;&gt;Ghiza's Wheel&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_6_10&amp;id=weapons_6_10&amp;link=/checklists/weapons.html%23item_6_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ghiza's+Wheel&quot;&gt;Ghiza's Wheel&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -9995,9 +9405,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="22" id="weapons_6_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_6_9&amp;id=weapons_6_9&amp;link=/checklists/weapons.html%23item_6_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Fallingstar+Beast+Jaw&quot;&gt;Fallingstar Beast Jaw&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_6_9&amp;id=weapons_6_9&amp;link=/checklists/weapons.html%23item_6_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Fallingstar+Beast+Jaw&quot;&gt;Fallingstar Beast Jaw&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -10030,9 +9438,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="22" id="weapons_6_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_6_6&amp;id=weapons_6_6&amp;link=/checklists/weapons.html%23item_6_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Axe+of+Godfrey&quot;&gt;Axe of Godfrey&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_6_6&amp;id=weapons_6_6&amp;link=/checklists/weapons.html%23item_6_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Axe+of+Godfrey&quot;&gt;Axe of Godfrey&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -10065,9 +9471,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="22" id="weapons_50_31" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_31&amp;id=weapons_50_31&amp;link=/checklists/weapons.html%23item_50_31&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Anvil+Hammer&quot;&gt;Anvil Hammer&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_31&amp;id=weapons_50_31&amp;link=/checklists/weapons.html%23item_50_31&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Anvil+Hammer&quot;&gt;Anvil Hammer&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -10100,9 +9504,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="22" id="weapons_50_33" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_33&amp;id=weapons_50_33&amp;link=/checklists/weapons.html%23item_50_33&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Bloodfiend's+Arm&quot;&gt;Bloodfiend's Arm&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_33&amp;id=weapons_50_33&amp;link=/checklists/weapons.html%23item_50_33&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Bloodfiend's+Arm&quot;&gt;Bloodfiend's Arm&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -10135,9 +9537,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="22" id="weapons_50_59" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_59&amp;id=weapons_50_59&amp;link=/checklists/weapons.html%23item_50_59&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Devonia's+Hammer&quot;&gt;Devonia's Hammer&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_59&amp;id=weapons_50_59&amp;link=/checklists/weapons.html%23item_50_59&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Devonia's+Hammer&quot;&gt;Devonia's Hammer&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -10170,9 +9570,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="22" id="weapons_50_60" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_60&amp;id=weapons_50_60&amp;link=/checklists/weapons.html%23item_50_60&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Shadow+Sunflower+Blossom&quot;&gt;Shadow Sunflower Blossom&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_60&amp;id=weapons_50_60&amp;link=/checklists/weapons.html%23item_50_60&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Shadow+Sunflower+Blossom&quot;&gt;Shadow Sunflower Blossom&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -10205,9 +9603,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="22" id="weapons_50_61" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_61&amp;id=weapons_50_61&amp;link=/checklists/weapons.html%23item_50_61&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gazing+Finger&quot;&gt;Gazing Finger&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_61&amp;id=weapons_50_61&amp;link=/checklists/weapons.html%23item_50_61&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gazing+Finger&quot;&gt;Gazing Finger&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -10241,9 +9637,7 @@
         <div class="card shadow-sm mb-3" id="weapons_section_23">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_23Col" data-bs-toggle="collapse" href="#weapons_23Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_23Col" data-bs-toggle="collapse" href="#weapons_23Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Spears">Spears</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="weapons_totals_23"></span>
             </h4>
@@ -10255,9 +9649,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -10286,9 +9678,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="23" id="weapons_23_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_23_1&amp;id=weapons_23_1&amp;link=/checklists/weapons.html%23item_23_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Short+Spear&quot;&gt;Short Spear&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_23_1&amp;id=weapons_23_1&amp;link=/checklists/weapons.html%23item_23_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Short+Spear&quot;&gt;Short Spear&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -10321,9 +9711,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="23" id="weapons_23_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_23_2&amp;id=weapons_23_2&amp;link=/checklists/weapons.html%23item_23_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Iron+Spear&quot;&gt;Iron Spear&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_23_2&amp;id=weapons_23_2&amp;link=/checklists/weapons.html%23item_23_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Iron+Spear&quot;&gt;Iron Spear&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -10356,9 +9744,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="23" id="weapons_23_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_23_3&amp;id=weapons_23_3&amp;link=/checklists/weapons.html%23item_23_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Spear&quot;&gt;Spear&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_23_3&amp;id=weapons_23_3&amp;link=/checklists/weapons.html%23item_23_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Spear&quot;&gt;Spear&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -10391,9 +9777,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="23" id="weapons_23_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_23_4&amp;id=weapons_23_4&amp;link=/checklists/weapons.html%23item_23_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Partisan&quot;&gt;Partisan&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_23_4&amp;id=weapons_23_4&amp;link=/checklists/weapons.html%23item_23_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Partisan&quot;&gt;Partisan&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -10426,9 +9810,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="23" id="weapons_23_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_23_5&amp;id=weapons_23_5&amp;link=/checklists/weapons.html%23item_23_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Pike&quot;&gt;Pike&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_23_5&amp;id=weapons_23_5&amp;link=/checklists/weapons.html%23item_23_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Pike&quot;&gt;Pike&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -10461,9 +9843,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="23" id="weapons_23_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_23_6&amp;id=weapons_23_6&amp;link=/checklists/weapons.html%23item_23_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Spiked+Spear&quot;&gt;Spiked Spear&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_23_6&amp;id=weapons_23_6&amp;link=/checklists/weapons.html%23item_23_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Spiked+Spear&quot;&gt;Spiked Spear&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -10496,9 +9876,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="23" id="weapons_23_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_23_7&amp;id=weapons_23_7&amp;link=/checklists/weapons.html%23item_23_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Cross-Naginata&quot;&gt;Cross-Naginata&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_23_7&amp;id=weapons_23_7&amp;link=/checklists/weapons.html%23item_23_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Cross-Naginata&quot;&gt;Cross-Naginata&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -10531,9 +9909,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="23" id="weapons_23_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_23_8&amp;id=weapons_23_8&amp;link=/checklists/weapons.html%23item_23_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Clayman's+Harpoon&quot;&gt;Clayman's Harpoon&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_23_8&amp;id=weapons_23_8&amp;link=/checklists/weapons.html%23item_23_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Clayman's+Harpoon&quot;&gt;Clayman's Harpoon&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -10566,9 +9942,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="23" id="weapons_23_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_23_9&amp;id=weapons_23_9&amp;link=/checklists/weapons.html%23item_23_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Celebrant's+Rib-Rake&quot;&gt;Celebrant's Rib-Rake&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_23_9&amp;id=weapons_23_9&amp;link=/checklists/weapons.html%23item_23_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Celebrant's+Rib-Rake&quot;&gt;Celebrant's Rib-Rake&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -10601,9 +9975,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="23" id="weapons_23_10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_23_10&amp;id=weapons_23_10&amp;link=/checklists/weapons.html%23item_23_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Torchpole&quot;&gt;Torchpole&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_23_10&amp;id=weapons_23_10&amp;link=/checklists/weapons.html%23item_23_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Torchpole&quot;&gt;Torchpole&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -10636,9 +10008,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="23" id="weapons_23_11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_23_11&amp;id=weapons_23_11&amp;link=/checklists/weapons.html%23item_23_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Inquisitor's+Girandole&quot;&gt;Inquisitor's Girandole&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_23_11&amp;id=weapons_23_11&amp;link=/checklists/weapons.html%23item_23_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Inquisitor's+Girandole&quot;&gt;Inquisitor's Girandole&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -10671,9 +10041,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="23" id="weapons_23_12" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_23_12&amp;id=weapons_23_12&amp;link=/checklists/weapons.html%23item_23_12&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Crystal+Spear&quot;&gt;Crystal Spear&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_23_12&amp;id=weapons_23_12&amp;link=/checklists/weapons.html%23item_23_12&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Crystal+Spear&quot;&gt;Crystal Spear&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -10706,9 +10074,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="23" id="weapons_23_13" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_23_13&amp;id=weapons_23_13&amp;link=/checklists/weapons.html%23item_23_13&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Rotten+Crystal+Spear&quot;&gt;Rotten Crystal Spear&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_23_13&amp;id=weapons_23_13&amp;link=/checklists/weapons.html%23item_23_13&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Rotten+Crystal+Spear&quot;&gt;Rotten Crystal Spear&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -10741,9 +10107,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="23" id="weapons_23_14" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_23_14&amp;id=weapons_23_14&amp;link=/checklists/weapons.html%23item_23_14&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Cleanrot+Spear&quot;&gt;Cleanrot Spear&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_23_14&amp;id=weapons_23_14&amp;link=/checklists/weapons.html%23item_23_14&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Cleanrot+Spear&quot;&gt;Cleanrot Spear&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -10776,9 +10140,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="23" id="weapons_23_15" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_23_15&amp;id=weapons_23_15&amp;link=/checklists/weapons.html%23item_23_15&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Death+Ritual+Spear&quot;&gt;Death Ritual Spear&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_23_15&amp;id=weapons_23_15&amp;link=/checklists/weapons.html%23item_23_15&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Death+Ritual+Spear&quot;&gt;Death Ritual Spear&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -10811,9 +10173,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="23" id="weapons_23_16" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_23_16&amp;id=weapons_23_16&amp;link=/checklists/weapons.html%23item_23_16&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Bolt+of+Gransax&quot;&gt;Bolt of Gransax&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_23_16&amp;id=weapons_23_16&amp;link=/checklists/weapons.html%23item_23_16&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Bolt+of+Gransax&quot;&gt;Bolt of Gransax&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -10846,9 +10206,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="23" id="weapons_50_41" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_41&amp;id=weapons_50_41&amp;link=/checklists/weapons.html%23item_50_41&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Smithscript+Spear&quot;&gt;Smithscript Spear&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_41&amp;id=weapons_50_41&amp;link=/checklists/weapons.html%23item_50_41&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Smithscript+Spear&quot;&gt;Smithscript Spear&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -10881,9 +10239,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="23" id="weapons_50_42" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_42&amp;id=weapons_50_42&amp;link=/checklists/weapons.html%23item_50_42&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Swift+Spear&quot;&gt;Swift Spear&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_42&amp;id=weapons_50_42&amp;link=/checklists/weapons.html%23item_50_42&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Swift+Spear&quot;&gt;Swift Spear&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -10916,9 +10272,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="23" id="weapons_50_43" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_43&amp;id=weapons_50_43&amp;link=/checklists/weapons.html%23item_50_43&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Bloodfiend's+Fork&quot;&gt;Bloodfiend's Fork&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_43&amp;id=weapons_50_43&amp;link=/checklists/weapons.html%23item_50_43&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Bloodfiend's+Fork&quot;&gt;Bloodfiend's Fork&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -10952,9 +10306,7 @@
         <div class="card shadow-sm mb-3" id="weapons_section_24">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_24Col" data-bs-toggle="collapse" href="#weapons_24Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_24Col" data-bs-toggle="collapse" href="#weapons_24Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Great+Spears">Great Spears</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="weapons_totals_24"></span>
             </h4>
@@ -10966,9 +10318,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -10997,9 +10347,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="24" id="weapons_24_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_24_1&amp;id=weapons_24_1&amp;link=/checklists/weapons.html%23item_24_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Lance&quot;&gt;Lance&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_24_1&amp;id=weapons_24_1&amp;link=/checklists/weapons.html%23item_24_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Lance&quot;&gt;Lance&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -11032,9 +10380,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="24" id="weapons_24_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_24_2&amp;id=weapons_24_2&amp;link=/checklists/weapons.html%23item_24_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Treespear&quot;&gt;Treespear&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_24_2&amp;id=weapons_24_2&amp;link=/checklists/weapons.html%23item_24_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Treespear&quot;&gt;Treespear&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -11067,9 +10413,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="24" id="weapons_24_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_24_3&amp;id=weapons_24_3&amp;link=/checklists/weapons.html%23item_24_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Serpent-Hunter&quot;&gt;Serpent Hunter&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_24_3&amp;id=weapons_24_3&amp;link=/checklists/weapons.html%23item_24_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Serpent-Hunter&quot;&gt;Serpent Hunter&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -11102,9 +10446,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="24" id="weapons_24_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_24_4&amp;id=weapons_24_4&amp;link=/checklists/weapons.html%23item_24_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Siluria's+Tree&quot;&gt;Siluria's Tree&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_24_4&amp;id=weapons_24_4&amp;link=/checklists/weapons.html%23item_24_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Siluria's+Tree&quot;&gt;Siluria's Tree&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -11137,9 +10479,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="24" id="weapons_24_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_24_5&amp;id=weapons_24_5&amp;link=/checklists/weapons.html%23item_24_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Vyke's+War+Spear&quot;&gt;Vyke's War Spear&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_24_5&amp;id=weapons_24_5&amp;link=/checklists/weapons.html%23item_24_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Vyke's+War+Spear&quot;&gt;Vyke's War Spear&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -11172,9 +10512,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="24" id="weapons_24_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_24_6&amp;id=weapons_24_6&amp;link=/checklists/weapons.html%23item_24_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Mohgwyn's+Sacred+Spear&quot;&gt;Mohgwyn's Sacred Spear&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_24_6&amp;id=weapons_24_6&amp;link=/checklists/weapons.html%23item_24_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Mohgwyn's+Sacred+Spear&quot;&gt;Mohgwyn's Sacred Spear&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -11207,9 +10545,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="24" id="weapons_50_44" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_44&amp;id=weapons_50_44&amp;link=/checklists/weapons.html%23item_50_44&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Bloodfiend's+Sacred+Spear&quot;&gt;Bloodfiend's Sacred Spear&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_44&amp;id=weapons_50_44&amp;link=/checklists/weapons.html%23item_50_44&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Bloodfiend's+Sacred+Spear&quot;&gt;Bloodfiend's Sacred Spear&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -11242,9 +10578,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="24" id="weapons_50_45" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_45&amp;id=weapons_50_45&amp;link=/checklists/weapons.html%23item_50_45&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Spear+of+the+Impaler&quot;&gt;Spear of the Impaler&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_45&amp;id=weapons_50_45&amp;link=/checklists/weapons.html%23item_50_45&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Spear+of+the+Impaler&quot;&gt;Spear of the Impaler&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -11277,9 +10611,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="24" id="weapons_50_46" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_46&amp;id=weapons_50_46&amp;link=/checklists/weapons.html%23item_50_46&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Messmer+Soldier's+Spear&quot;&gt;Messmer Soldier's Spear&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_46&amp;id=weapons_50_46&amp;link=/checklists/weapons.html%23item_50_46&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Messmer+Soldier's+Spear&quot;&gt;Messmer Soldier's Spear&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -11312,9 +10644,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="24" id="weapons_50_47" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_47&amp;id=weapons_50_47&amp;link=/checklists/weapons.html%23item_50_47&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Barbed+Staff-Spear&quot;&gt;Barbed Staff-Spear&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_47&amp;id=weapons_50_47&amp;link=/checklists/weapons.html%23item_50_47&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Barbed+Staff-Spear&quot;&gt;Barbed Staff-Spear&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -11348,9 +10678,7 @@
         <div class="card shadow-sm mb-3" id="weapons_section_25">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_25Col" data-bs-toggle="collapse" href="#weapons_25Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_25Col" data-bs-toggle="collapse" href="#weapons_25Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Halberds">Halberds</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="weapons_totals_25"></span>
             </h4>
@@ -11362,9 +10690,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -11393,9 +10719,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="25" id="weapons_25_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_25_1&amp;id=weapons_25_1&amp;link=/checklists/weapons.html%23item_25_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Halberd&quot;&gt;Halberd&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_25_1&amp;id=weapons_25_1&amp;link=/checklists/weapons.html%23item_25_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Halberd&quot;&gt;Halberd&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -11428,9 +10752,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="25" id="weapons_25_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_25_2&amp;id=weapons_25_2&amp;link=/checklists/weapons.html%23item_25_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Banished+Knight's+Halberd&quot;&gt;Banished Knight's Halberd&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_25_2&amp;id=weapons_25_2&amp;link=/checklists/weapons.html%23item_25_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Banished+Knight's+Halberd&quot;&gt;Banished Knight's Halberd&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -11463,9 +10785,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="25" id="weapons_25_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_25_3&amp;id=weapons_25_3&amp;link=/checklists/weapons.html%23item_25_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Lucerne&quot;&gt;Lucerne&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_25_3&amp;id=weapons_25_3&amp;link=/checklists/weapons.html%23item_25_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Lucerne&quot;&gt;Lucerne&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -11498,9 +10818,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="25" id="weapons_25_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_25_4&amp;id=weapons_25_4&amp;link=/checklists/weapons.html%23item_25_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Glaive&quot;&gt;Glaive&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_25_4&amp;id=weapons_25_4&amp;link=/checklists/weapons.html%23item_25_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Glaive&quot;&gt;Glaive&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -11533,9 +10851,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="25" id="weapons_25_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_25_5&amp;id=weapons_25_5&amp;link=/checklists/weapons.html%23item_25_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Vulgar+Militia+Shotel&quot;&gt;Vulgar Militia Shotel&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_25_5&amp;id=weapons_25_5&amp;link=/checklists/weapons.html%23item_25_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Vulgar+Militia+Shotel&quot;&gt;Vulgar Militia Shotel&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -11568,9 +10884,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="25" id="weapons_25_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_25_6&amp;id=weapons_25_6&amp;link=/checklists/weapons.html%23item_25_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Vulgar+Militia+Saw&quot;&gt;Vulgar Militia Saw&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_25_6&amp;id=weapons_25_6&amp;link=/checklists/weapons.html%23item_25_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Vulgar+Militia+Saw&quot;&gt;Vulgar Militia Saw&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -11603,9 +10917,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="25" id="weapons_25_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_25_7&amp;id=weapons_25_7&amp;link=/checklists/weapons.html%23item_25_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Guardian's+Swordspear&quot;&gt;Guardian's Swordspear&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_25_7&amp;id=weapons_25_7&amp;link=/checklists/weapons.html%23item_25_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Guardian's+Swordspear&quot;&gt;Guardian's Swordspear&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -11638,9 +10950,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="25" id="weapons_25_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_25_8&amp;id=weapons_25_8&amp;link=/checklists/weapons.html%23item_25_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gargoyle's+Halberd&quot;&gt;Gargoyle's Halberd&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_25_8&amp;id=weapons_25_8&amp;link=/checklists/weapons.html%23item_25_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gargoyle's+Halberd&quot;&gt;Gargoyle's Halberd&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -11673,9 +10983,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="25" id="weapons_25_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_25_9&amp;id=weapons_25_9&amp;link=/checklists/weapons.html%23item_25_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gargoyle's+Black+Halberd&quot;&gt;Gargoyle's Black Halberd&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_25_9&amp;id=weapons_25_9&amp;link=/checklists/weapons.html%23item_25_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gargoyle's+Black+Halberd&quot;&gt;Gargoyle's Black Halberd&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -11708,9 +11016,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="25" id="weapons_25_10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_25_10&amp;id=weapons_25_10&amp;link=/checklists/weapons.html%23item_25_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Nightrider+Glaive&quot;&gt;Nightrider Glaive&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_25_10&amp;id=weapons_25_10&amp;link=/checklists/weapons.html%23item_25_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Nightrider+Glaive&quot;&gt;Nightrider Glaive&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -11743,9 +11049,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="25" id="weapons_25_11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_25_11&amp;id=weapons_25_11&amp;link=/checklists/weapons.html%23item_25_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Pest's+Glaive&quot;&gt;Pest's Glaive&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_25_11&amp;id=weapons_25_11&amp;link=/checklists/weapons.html%23item_25_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Pest's+Glaive&quot;&gt;Pest's Glaive&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -11778,9 +11082,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="25" id="weapons_25_12" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_25_12&amp;id=weapons_25_12&amp;link=/checklists/weapons.html%23item_25_12&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ripple+Crescent+Halberd&quot;&gt;Ripple Crescent Halberd&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_25_12&amp;id=weapons_25_12&amp;link=/checklists/weapons.html%23item_25_12&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ripple+Crescent+Halberd&quot;&gt;Ripple Crescent Halberd&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -11813,9 +11115,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="25" id="weapons_25_13" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_25_13&amp;id=weapons_25_13&amp;link=/checklists/weapons.html%23item_25_13&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Golden+Halberd&quot;&gt;Golden Halberd&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_25_13&amp;id=weapons_25_13&amp;link=/checklists/weapons.html%23item_25_13&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Golden+Halberd&quot;&gt;Golden Halberd&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -11848,9 +11148,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="25" id="weapons_25_14" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_25_14&amp;id=weapons_25_14&amp;link=/checklists/weapons.html%23item_25_14&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dragon+Halberd&quot;&gt;Dragon Halberd&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_25_14&amp;id=weapons_25_14&amp;link=/checklists/weapons.html%23item_25_14&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dragon+Halberd&quot;&gt;Dragon Halberd&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -11883,9 +11181,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="25" id="weapons_25_15" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_25_15&amp;id=weapons_25_15&amp;link=/checklists/weapons.html%23item_25_15&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Loretta's+War+Sickle&quot;&gt;Loretta's War Sickle&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_25_15&amp;id=weapons_25_15&amp;link=/checklists/weapons.html%23item_25_15&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Loretta's+War+Sickle&quot;&gt;Loretta's War Sickle&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -11918,9 +11214,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="25" id="weapons_25_16" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_25_16&amp;id=weapons_25_16&amp;link=/checklists/weapons.html%23item_25_16&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Commander's+Standard&quot;&gt;Commander's Standard&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_25_16&amp;id=weapons_25_16&amp;link=/checklists/weapons.html%23item_25_16&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Commander's+Standard&quot;&gt;Commander's Standard&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -11953,9 +11247,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="25" id="weapons_50_48" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_48&amp;id=weapons_50_48&amp;link=/checklists/weapons.html%23item_50_48&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Spirit+Glaive&quot;&gt;Spirit Glaive&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_48&amp;id=weapons_50_48&amp;link=/checklists/weapons.html%23item_50_48&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Spirit+Glaive&quot;&gt;Spirit Glaive&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -11988,9 +11280,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="25" id="weapons_50_49" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_49&amp;id=weapons_50_49&amp;link=/checklists/weapons.html%23item_50_49&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Poleblade+of+the+Bud&quot;&gt;Poleblade of the Bud&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_49&amp;id=weapons_50_49&amp;link=/checklists/weapons.html%23item_50_49&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Poleblade+of+the+Bud&quot;&gt;Poleblade of the Bud&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -12024,9 +11314,7 @@
         <div class="card shadow-sm mb-3" id="weapons_section_26">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_26Col" data-bs-toggle="collapse" href="#weapons_26Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_26Col" data-bs-toggle="collapse" href="#weapons_26Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Reapers">Reapers</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="weapons_totals_26"></span>
             </h4>
@@ -12038,9 +11326,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -12069,9 +11355,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="26" id="weapons_26_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_26_1&amp;id=weapons_26_1&amp;link=/checklists/weapons.html%23item_26_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Scythe&quot;&gt;Scythe&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_26_1&amp;id=weapons_26_1&amp;link=/checklists/weapons.html%23item_26_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Scythe&quot;&gt;Scythe&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -12104,9 +11388,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="26" id="weapons_26_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_26_2&amp;id=weapons_26_2&amp;link=/checklists/weapons.html%23item_26_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Grave+Scythe&quot;&gt;Grave Scythe&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_26_2&amp;id=weapons_26_2&amp;link=/checklists/weapons.html%23item_26_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Grave+Scythe&quot;&gt;Grave Scythe&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -12139,9 +11421,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="26" id="weapons_26_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_26_3&amp;id=weapons_26_3&amp;link=/checklists/weapons.html%23item_26_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Halo+Scythe&quot;&gt;Halo Scythe&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_26_3&amp;id=weapons_26_3&amp;link=/checklists/weapons.html%23item_26_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Halo+Scythe&quot;&gt;Halo Scythe&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -12174,9 +11454,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="26" id="weapons_26_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_26_4&amp;id=weapons_26_4&amp;link=/checklists/weapons.html%23item_26_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Winged+Scythe&quot;&gt;Winged Scythe&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_26_4&amp;id=weapons_26_4&amp;link=/checklists/weapons.html%23item_26_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Winged+Scythe&quot;&gt;Winged Scythe&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -12209,9 +11487,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="26" id="weapons_50_50" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_50&amp;id=weapons_50_50&amp;link=/checklists/weapons.html%23item_50_50&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Obsidian+Lamina&quot;&gt;Obsidian Lamina&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_50&amp;id=weapons_50_50&amp;link=/checklists/weapons.html%23item_50_50&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Obsidian+Lamina&quot;&gt;Obsidian Lamina&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -12245,9 +11521,7 @@
         <div class="card shadow-sm mb-3" id="weapons_section_27">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_27Col" data-bs-toggle="collapse" href="#weapons_27Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_27Col" data-bs-toggle="collapse" href="#weapons_27Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Whips">Whips</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="weapons_totals_27"></span>
             </h4>
@@ -12259,9 +11533,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -12290,9 +11562,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="27" id="weapons_27_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_27_1&amp;id=weapons_27_1&amp;link=/checklists/weapons.html%23item_27_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Whip&quot;&gt;Whip&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_27_1&amp;id=weapons_27_1&amp;link=/checklists/weapons.html%23item_27_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Whip&quot;&gt;Whip&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -12325,9 +11595,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="27" id="weapons_27_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_27_2&amp;id=weapons_27_2&amp;link=/checklists/weapons.html%23item_27_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Thorned+Whip&quot;&gt;Thorned Whip&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_27_2&amp;id=weapons_27_2&amp;link=/checklists/weapons.html%23item_27_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Thorned+Whip&quot;&gt;Thorned Whip&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -12360,9 +11628,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="27" id="weapons_27_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_27_3&amp;id=weapons_27_3&amp;link=/checklists/weapons.html%23item_27_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Urumi&quot;&gt;Urumi&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_27_3&amp;id=weapons_27_3&amp;link=/checklists/weapons.html%23item_27_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Urumi&quot;&gt;Urumi&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -12395,9 +11661,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="27" id="weapons_27_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_27_4&amp;id=weapons_27_4&amp;link=/checklists/weapons.html%23item_27_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Hoslow's+Petal+Whip&quot;&gt;Hoslow's Petal Whip&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_27_4&amp;id=weapons_27_4&amp;link=/checklists/weapons.html%23item_27_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Hoslow's+Petal+Whip&quot;&gt;Hoslow's Petal Whip&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -12430,9 +11694,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="27" id="weapons_27_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_27_5&amp;id=weapons_27_5&amp;link=/checklists/weapons.html%23item_27_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Magma+Whip+Candlestick&quot;&gt;Magma Whip Candlestick&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_27_5&amp;id=weapons_27_5&amp;link=/checklists/weapons.html%23item_27_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Magma+Whip+Candlestick&quot;&gt;Magma Whip Candlestick&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -12465,9 +11727,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="27" id="weapons_27_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_27_6&amp;id=weapons_27_6&amp;link=/checklists/weapons.html%23item_27_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Giant's+Red+Braid&quot;&gt;Giant Red Braid&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_27_6&amp;id=weapons_27_6&amp;link=/checklists/weapons.html%23item_27_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Giant's+Red+Braid&quot;&gt;Giant Red Braid&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -12500,9 +11760,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="27" id="weapons_50_51" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_51&amp;id=weapons_50_51&amp;link=/checklists/weapons.html%23item_50_51&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Tooth+Whip&quot;&gt;Tooth Whip&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_51&amp;id=weapons_50_51&amp;link=/checklists/weapons.html%23item_50_51&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Tooth+Whip&quot;&gt;Tooth Whip&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -12536,9 +11794,7 @@
         <div class="card shadow-sm mb-3" id="weapons_section_28">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_28Col" data-bs-toggle="collapse" href="#weapons_28Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_28Col" data-bs-toggle="collapse" href="#weapons_28Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Fists">Fists</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="weapons_totals_28"></span>
             </h4>
@@ -12550,9 +11806,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -12581,9 +11835,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="28" id="weapons_28_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_28_1&amp;id=weapons_28_1&amp;link=/checklists/weapons.html%23item_28_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Caestus&quot;&gt;Caestus&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_28_1&amp;id=weapons_28_1&amp;link=/checklists/weapons.html%23item_28_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Caestus&quot;&gt;Caestus&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -12616,9 +11868,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="28" id="weapons_28_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_28_2&amp;id=weapons_28_2&amp;link=/checklists/weapons.html%23item_28_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Spiked+Caestus&quot;&gt;Spiked Caestus&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_28_2&amp;id=weapons_28_2&amp;link=/checklists/weapons.html%23item_28_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Spiked+Caestus&quot;&gt;Spiked Caestus&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -12651,9 +11901,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="28" id="weapons_28_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_28_3&amp;id=weapons_28_3&amp;link=/checklists/weapons.html%23item_28_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Katar&quot;&gt;Katar&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_28_3&amp;id=weapons_28_3&amp;link=/checklists/weapons.html%23item_28_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Katar&quot;&gt;Katar&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -12686,9 +11934,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="28" id="weapons_28_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_28_4&amp;id=weapons_28_4&amp;link=/checklists/weapons.html%23item_28_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Iron+Ball&quot;&gt;Iron Ball&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_28_4&amp;id=weapons_28_4&amp;link=/checklists/weapons.html%23item_28_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Iron+Ball&quot;&gt;Iron Ball&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -12721,9 +11967,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="28" id="weapons_28_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_28_5&amp;id=weapons_28_5&amp;link=/checklists/weapons.html%23item_28_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Star+Fist&quot;&gt;Star Fist&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_28_5&amp;id=weapons_28_5&amp;link=/checklists/weapons.html%23item_28_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Star+Fist&quot;&gt;Star Fist&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -12756,9 +12000,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="28" id="weapons_28_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_28_6&amp;id=weapons_28_6&amp;link=/checklists/weapons.html%23item_28_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Clinging+Bone&quot;&gt;Clinging Bone&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_28_6&amp;id=weapons_28_6&amp;link=/checklists/weapons.html%23item_28_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Clinging+Bone&quot;&gt;Clinging Bone&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -12791,9 +12033,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="28" id="weapons_28_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_28_7&amp;id=weapons_28_7&amp;link=/checklists/weapons.html%23item_28_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Veteran's+Prosthesis&quot;&gt;Veteran's Prosthesis&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_28_7&amp;id=weapons_28_7&amp;link=/checklists/weapons.html%23item_28_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Veteran's+Prosthesis&quot;&gt;Veteran's Prosthesis&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -12826,9 +12066,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="28" id="weapons_28_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_28_8&amp;id=weapons_28_8&amp;link=/checklists/weapons.html%23item_28_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Cipher+Pata&quot;&gt;Cipher Pata&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_28_8&amp;id=weapons_28_8&amp;link=/checklists/weapons.html%23item_28_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Cipher+Pata&quot;&gt;Cipher Pata&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -12861,9 +12099,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="28" id="weapons_28_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_28_9&amp;id=weapons_28_9&amp;link=/checklists/weapons.html%23item_28_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Grafted+Dragon&quot;&gt;Grafted Dragon&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_28_9&amp;id=weapons_28_9&amp;link=/checklists/weapons.html%23item_28_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Grafted+Dragon&quot;&gt;Grafted Dragon&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -12896,9 +12132,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="28" id="weapons_50_52" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_52&amp;id=weapons_50_52&amp;link=/checklists/weapons.html%23item_50_52&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Thiollier's+Hidden+Needle&quot;&gt;Thiollier's Hidden Needle&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_52&amp;id=weapons_50_52&amp;link=/checklists/weapons.html%23item_50_52&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Thiollier's+Hidden+Needle&quot;&gt;Thiollier's Hidden Needle&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -12931,9 +12165,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="28" id="weapons_50_53" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_53&amp;id=weapons_50_53&amp;link=/checklists/weapons.html%23item_50_53&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Pata&quot;&gt;Pata&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_53&amp;id=weapons_50_53&amp;link=/checklists/weapons.html%23item_50_53&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Pata&quot;&gt;Pata&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -12966,9 +12198,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="28" id="weapons_50_54" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_54&amp;id=weapons_50_54&amp;link=/checklists/weapons.html%23item_50_54&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Poisoned+Hand&quot;&gt;Poisoned Hand&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_54&amp;id=weapons_50_54&amp;link=/checklists/weapons.html%23item_50_54&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Poisoned+Hand&quot;&gt;Poisoned Hand&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -13001,9 +12231,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="28" id="weapons_50_55" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_55&amp;id=weapons_50_55&amp;link=/checklists/weapons.html%23item_50_55&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Madding+Hand&quot;&gt;Madding Hand&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_55&amp;id=weapons_50_55&amp;link=/checklists/weapons.html%23item_50_55&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Madding+Hand&quot;&gt;Madding Hand&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -13036,9 +12264,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="28" id="weapons_50_56" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_56&amp;id=weapons_50_56&amp;link=/checklists/weapons.html%23item_50_56&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Golem+Fist&quot;&gt;Golem Fist&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_56&amp;id=weapons_50_56&amp;link=/checklists/weapons.html%23item_50_56&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Golem+Fist&quot;&gt;Golem Fist&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -13072,9 +12298,7 @@
         <div class="card shadow-sm mb-3" id="weapons_section_29">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_29Col" data-bs-toggle="collapse" href="#weapons_29Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_29Col" data-bs-toggle="collapse" href="#weapons_29Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Claws">Claws</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="weapons_totals_29"></span>
             </h4>
@@ -13086,9 +12310,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -13117,9 +12339,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="29" id="weapons_4_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_4_1&amp;id=weapons_4_1&amp;link=/checklists/weapons.html%23item_4_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Hookclaws&quot;&gt;Hookclaws&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_4_1&amp;id=weapons_4_1&amp;link=/checklists/weapons.html%23item_4_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Hookclaws&quot;&gt;Hookclaws&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -13152,9 +12372,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="29" id="weapons_4_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_4_2&amp;id=weapons_4_2&amp;link=/checklists/weapons.html%23item_4_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Venomous+Fang&quot;&gt;Venomous Fang&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_4_2&amp;id=weapons_4_2&amp;link=/checklists/weapons.html%23item_4_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Venomous+Fang&quot;&gt;Venomous Fang&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -13187,9 +12405,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="29" id="weapons_4_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_4_3&amp;id=weapons_4_3&amp;link=/checklists/weapons.html%23item_4_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Bloodhound+Claws&quot;&gt;Bloodhound Claws&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_4_3&amp;id=weapons_4_3&amp;link=/checklists/weapons.html%23item_4_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Bloodhound+Claws&quot;&gt;Bloodhound Claws&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -13222,9 +12438,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="29" id="weapons_4_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_4_4&amp;id=weapons_4_4&amp;link=/checklists/weapons.html%23item_4_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Raptor+Talons&quot;&gt;Raptor Talons&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_4_4&amp;id=weapons_4_4&amp;link=/checklists/weapons.html%23item_4_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Raptor+Talons&quot;&gt;Raptor Talons&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -13257,9 +12471,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="29" id="weapons_50_58" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_58&amp;id=weapons_50_58&amp;link=/checklists/weapons.html%23item_50_58&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Claws+of+Night&quot;&gt;Claws of Night&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_58&amp;id=weapons_50_58&amp;link=/checklists/weapons.html%23item_50_58&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Claws+of+Night&quot;&gt;Claws of Night&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -13293,9 +12505,7 @@
         <div class="card shadow-sm mb-3" id="weapons_section_30">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_30Col" data-bs-toggle="collapse" href="#weapons_30Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_30Col" data-bs-toggle="collapse" href="#weapons_30Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Light+Bows">Light Bows</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="weapons_totals_30"></span>
             </h4>
@@ -13307,9 +12517,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -13338,9 +12546,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="30" id="weapons_11_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_11_1&amp;id=weapons_11_1&amp;link=/checklists/weapons.html%23item_11_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Shortbow&quot;&gt;Short Bow&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_11_1&amp;id=weapons_11_1&amp;link=/checklists/weapons.html%23item_11_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Shortbow&quot;&gt;Short Bow&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -13373,9 +12579,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="30" id="weapons_11_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_11_2&amp;id=weapons_11_2&amp;link=/checklists/weapons.html%23item_11_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Composite+Bow&quot;&gt;Composite Bow&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_11_2&amp;id=weapons_11_2&amp;link=/checklists/weapons.html%23item_11_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Composite+Bow&quot;&gt;Composite Bow&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -13408,9 +12612,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="30" id="weapons_11_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_11_3&amp;id=weapons_11_3&amp;link=/checklists/weapons.html%23item_11_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Red+Branch+Shortbow&quot;&gt;Red Branch Shortbow&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_11_3&amp;id=weapons_11_3&amp;link=/checklists/weapons.html%23item_11_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Red+Branch+Shortbow&quot;&gt;Red Branch Shortbow&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -13443,9 +12645,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="30" id="weapons_11_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_11_4&amp;id=weapons_11_4&amp;link=/checklists/weapons.html%23item_11_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Misbegotten+Shortbow&quot;&gt;Misbegotten Shortbow&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_11_4&amp;id=weapons_11_4&amp;link=/checklists/weapons.html%23item_11_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Misbegotten+Shortbow&quot;&gt;Misbegotten Shortbow&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -13478,9 +12678,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="30" id="weapons_11_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_11_5&amp;id=weapons_11_5&amp;link=/checklists/weapons.html%23item_11_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Harp+Bow&quot;&gt;Harp Bow&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_11_5&amp;id=weapons_11_5&amp;link=/checklists/weapons.html%23item_11_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Harp+Bow&quot;&gt;Harp Bow&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -13513,9 +12711,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="30" id="weapons_50_97" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_97&amp;id=weapons_50_97&amp;link=/checklists/weapons.html%23item_50_97&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Bone+Bow&quot;&gt;Bone Bow&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_97&amp;id=weapons_50_97&amp;link=/checklists/weapons.html%23item_50_97&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Bone+Bow&quot;&gt;Bone Bow&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -13549,9 +12745,7 @@
         <div class="card shadow-sm mb-3" id="weapons_section_31">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_31Col" data-bs-toggle="collapse" href="#weapons_31Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_31Col" data-bs-toggle="collapse" href="#weapons_31Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Bows">Bows</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="weapons_totals_31"></span>
             </h4>
@@ -13563,9 +12757,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -13594,9 +12786,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="31" id="weapons_10_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_10_1&amp;id=weapons_10_1&amp;link=/checklists/weapons.html%23item_10_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Longbow&quot;&gt;Longbow&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_10_1&amp;id=weapons_10_1&amp;link=/checklists/weapons.html%23item_10_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Longbow&quot;&gt;Longbow&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -13629,9 +12819,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="31" id="weapons_10_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_10_2&amp;id=weapons_10_2&amp;link=/checklists/weapons.html%23item_10_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Albinauric+Bow&quot;&gt;Albinauric Bow&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_10_2&amp;id=weapons_10_2&amp;link=/checklists/weapons.html%23item_10_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Albinauric+Bow&quot;&gt;Albinauric Bow&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -13664,9 +12852,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="31" id="weapons_10_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_10_7&amp;id=weapons_10_7&amp;link=/checklists/weapons.html%23item_10_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Black+Bow&quot;&gt;Black Bow&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_10_7&amp;id=weapons_10_7&amp;link=/checklists/weapons.html%23item_10_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Black+Bow&quot;&gt;Black Bow&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -13699,9 +12885,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="31" id="weapons_10_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_10_6&amp;id=weapons_10_6&amp;link=/checklists/weapons.html%23item_10_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Pulley+Bow&quot;&gt;Pulley Bow&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_10_6&amp;id=weapons_10_6&amp;link=/checklists/weapons.html%23item_10_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Pulley+Bow&quot;&gt;Pulley Bow&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -13734,9 +12918,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="31" id="weapons_10_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_10_3&amp;id=weapons_10_3&amp;link=/checklists/weapons.html%23item_10_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Horn+Bow&quot;&gt;Horn Bow&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_10_3&amp;id=weapons_10_3&amp;link=/checklists/weapons.html%23item_10_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Horn+Bow&quot;&gt;Horn Bow&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -13769,9 +12951,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="31" id="weapons_10_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_10_5&amp;id=weapons_10_5&amp;link=/checklists/weapons.html%23item_10_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Serpent+Bow&quot;&gt;Serpent Bow&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_10_5&amp;id=weapons_10_5&amp;link=/checklists/weapons.html%23item_10_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Serpent+Bow&quot;&gt;Serpent Bow&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -13804,9 +12984,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="31" id="weapons_10_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_10_4&amp;id=weapons_10_4&amp;link=/checklists/weapons.html%23item_10_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Erdtree+Bow&quot;&gt;Erdtree Bow&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_10_4&amp;id=weapons_10_4&amp;link=/checklists/weapons.html%23item_10_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Erdtree+Bow&quot;&gt;Erdtree Bow&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -13839,9 +13017,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="31" id="weapons_50_98" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_98&amp;id=weapons_50_98&amp;link=/checklists/weapons.html%23item_50_98&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ansbach's+Longbow&quot;&gt;Ansbach's Longbow&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_98&amp;id=weapons_50_98&amp;link=/checklists/weapons.html%23item_50_98&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ansbach's+Longbow&quot;&gt;Ansbach's Longbow&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -13875,9 +13051,7 @@
         <div class="card shadow-sm mb-3" id="weapons_section_32">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_32Col" data-bs-toggle="collapse" href="#weapons_32Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_32Col" data-bs-toggle="collapse" href="#weapons_32Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Greatbows">Greatbows</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="weapons_totals_32"></span>
             </h4>
@@ -13889,9 +13063,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -13920,9 +13092,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="32" id="weapons_12_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_12_1&amp;id=weapons_12_1&amp;link=/checklists/weapons.html%23item_12_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Greatbow&quot;&gt;Greatbow&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_12_1&amp;id=weapons_12_1&amp;link=/checklists/weapons.html%23item_12_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Greatbow&quot;&gt;Greatbow&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -13955,9 +13125,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="32" id="weapons_12_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_12_2&amp;id=weapons_12_2&amp;link=/checklists/weapons.html%23item_12_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Golem+Greatbow&quot;&gt;Golem Greatbow&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_12_2&amp;id=weapons_12_2&amp;link=/checklists/weapons.html%23item_12_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Golem+Greatbow&quot;&gt;Golem Greatbow&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -13990,9 +13158,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="32" id="weapons_12_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_12_3&amp;id=weapons_12_3&amp;link=/checklists/weapons.html%23item_12_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Erdtree+Greatbow&quot;&gt;Erdtree Greatbow&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_12_3&amp;id=weapons_12_3&amp;link=/checklists/weapons.html%23item_12_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Erdtree+Greatbow&quot;&gt;Erdtree Greatbow&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -14025,9 +13191,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="32" id="weapons_12_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_12_4&amp;id=weapons_12_4&amp;link=/checklists/weapons.html%23item_12_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Lion+Greatbow&quot;&gt;Lion Greatbow&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_12_4&amp;id=weapons_12_4&amp;link=/checklists/weapons.html%23item_12_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Lion+Greatbow&quot;&gt;Lion Greatbow&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -14060,9 +13224,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="32" id="weapons_50_99" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_99&amp;id=weapons_50_99&amp;link=/checklists/weapons.html%23item_50_99&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Igon's+Greatbow&quot;&gt;Igon's Greatbow&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_99&amp;id=weapons_50_99&amp;link=/checklists/weapons.html%23item_50_99&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Igon's+Greatbow&quot;&gt;Igon's Greatbow&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -14096,9 +13258,7 @@
         <div class="card shadow-sm mb-3" id="weapons_section_33">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_33Col" data-bs-toggle="collapse" href="#weapons_33Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_33Col" data-bs-toggle="collapse" href="#weapons_33Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Crossbows">Crossbows</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="weapons_totals_33"></span>
             </h4>
@@ -14110,9 +13270,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -14141,9 +13299,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="33" id="weapons_7_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_7_1&amp;id=weapons_7_1&amp;link=/checklists/weapons.html%23item_7_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Soldier's+Crossbow&quot;&gt;Soldier's Crossbow&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_7_1&amp;id=weapons_7_1&amp;link=/checklists/weapons.html%23item_7_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Soldier's+Crossbow&quot;&gt;Soldier's Crossbow&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -14176,9 +13332,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="33" id="weapons_7_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_7_2&amp;id=weapons_7_2&amp;link=/checklists/weapons.html%23item_7_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Light+Crossbow&quot;&gt;Light Crossbow&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_7_2&amp;id=weapons_7_2&amp;link=/checklists/weapons.html%23item_7_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Light+Crossbow&quot;&gt;Light Crossbow&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -14211,9 +13365,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="33" id="weapons_7_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_7_3&amp;id=weapons_7_3&amp;link=/checklists/weapons.html%23item_7_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Heavy+Crossbow&quot;&gt;Heavy Crossbow&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_7_3&amp;id=weapons_7_3&amp;link=/checklists/weapons.html%23item_7_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Heavy+Crossbow&quot;&gt;Heavy Crossbow&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -14246,9 +13398,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="33" id="weapons_7_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_7_6&amp;id=weapons_7_6&amp;link=/checklists/weapons.html%23item_7_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Arbalest&quot;&gt;Arbalest&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_7_6&amp;id=weapons_7_6&amp;link=/checklists/weapons.html%23item_7_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Arbalest&quot;&gt;Arbalest&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -14281,9 +13431,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="33" id="weapons_7_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_7_7&amp;id=weapons_7_7&amp;link=/checklists/weapons.html%23item_7_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Crepus's+Black-Key+Crossbow&quot;&gt;Crepus's Black-Key Crossbow&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_7_7&amp;id=weapons_7_7&amp;link=/checklists/weapons.html%23item_7_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Crepus's+Black-Key+Crossbow&quot;&gt;Crepus's Black-Key Crossbow&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -14316,9 +13464,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="33" id="weapons_7_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_7_4&amp;id=weapons_7_4&amp;link=/checklists/weapons.html%23item_7_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Pulley+Crossbow&quot;&gt;Pulley Crossbow&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_7_4&amp;id=weapons_7_4&amp;link=/checklists/weapons.html%23item_7_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Pulley+Crossbow&quot;&gt;Pulley Crossbow&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -14351,9 +13497,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="33" id="weapons_7_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_7_5&amp;id=weapons_7_5&amp;link=/checklists/weapons.html%23item_7_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Full+Moon+Crossbow&quot;&gt;Full Moon Crossbow&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_7_5&amp;id=weapons_7_5&amp;link=/checklists/weapons.html%23item_7_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Full+Moon+Crossbow&quot;&gt;Full Moon Crossbow&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -14386,9 +13530,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="33" id="weapons_50_100" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_100&amp;id=weapons_50_100&amp;link=/checklists/weapons.html%23item_50_100&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Repeating+Crossbow&quot;&gt;Repeating Crossbow&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_100&amp;id=weapons_50_100&amp;link=/checklists/weapons.html%23item_50_100&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Repeating+Crossbow&quot;&gt;Repeating Crossbow&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -14421,9 +13563,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="33" id="weapons_50_101" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_101&amp;id=weapons_50_101&amp;link=/checklists/weapons.html%23item_50_101&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Spread+Crossbow&quot;&gt;Spread Crossbow&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_101&amp;id=weapons_50_101&amp;link=/checklists/weapons.html%23item_50_101&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Spread+Crossbow&quot;&gt;Spread Crossbow&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -14457,9 +13597,7 @@
         <div class="card shadow-sm mb-3" id="weapons_section_34">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_34Col" data-bs-toggle="collapse" href="#weapons_34Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_34Col" data-bs-toggle="collapse" href="#weapons_34Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Ballistas">Ballistas</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="weapons_totals_34"></span>
             </h4>
@@ -14471,9 +13609,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -14502,9 +13638,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="34" id="weapons_2_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_2_1&amp;id=weapons_2_1&amp;link=/checklists/weapons.html%23item_2_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Hand+Ballista&quot;&gt;Hand Ballista&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_2_1&amp;id=weapons_2_1&amp;link=/checklists/weapons.html%23item_2_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Hand+Ballista&quot;&gt;Hand Ballista&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -14537,9 +13671,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="34" id="weapons_2_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_2_2&amp;id=weapons_2_2&amp;link=/checklists/weapons.html%23item_2_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Jar+Cannon&quot;&gt;Jar Cannon&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_2_2&amp;id=weapons_2_2&amp;link=/checklists/weapons.html%23item_2_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Jar+Cannon&quot;&gt;Jar Cannon&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -14572,9 +13704,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="34" id="weapons_50_102" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_102&amp;id=weapons_50_102&amp;link=/checklists/weapons.html%23item_50_102&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Rabbath's+Cannon&quot;&gt;Rabbath's Cannon&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_102&amp;id=weapons_50_102&amp;link=/checklists/weapons.html%23item_50_102&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Rabbath's+Cannon&quot;&gt;Rabbath's Cannon&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -14608,9 +13738,7 @@
         <div class="card shadow-sm mb-3" id="weapons_section_35">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_35Col" data-bs-toggle="collapse" href="#weapons_35Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_35Col" data-bs-toggle="collapse" href="#weapons_35Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Glintstone+Staffs">Glintstone Staffs</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="weapons_totals_35"></span>
             </h4>
@@ -14622,9 +13750,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -14653,9 +13779,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="35" id="weapons_29_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_29_1&amp;id=weapons_29_1&amp;link=/checklists/weapons.html%23item_29_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Astrologer's+Staff&quot;&gt;Astrologer's Staff&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_29_1&amp;id=weapons_29_1&amp;link=/checklists/weapons.html%23item_29_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Astrologer's+Staff&quot;&gt;Astrologer's Staff&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -14688,9 +13812,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="35" id="weapons_29_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_29_2&amp;id=weapons_29_2&amp;link=/checklists/weapons.html%23item_29_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Glintstone+Staff&quot;&gt;Glintstone Staff&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_29_2&amp;id=weapons_29_2&amp;link=/checklists/weapons.html%23item_29_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Glintstone+Staff&quot;&gt;Glintstone Staff&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -14723,9 +13845,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="35" id="weapons_29_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_29_3&amp;id=weapons_29_3&amp;link=/checklists/weapons.html%23item_29_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Academy+Glintstone+Staff&quot;&gt;Academy Glintstone Staff&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_29_3&amp;id=weapons_29_3&amp;link=/checklists/weapons.html%23item_29_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Academy+Glintstone+Staff&quot;&gt;Academy Glintstone Staff&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -14758,9 +13878,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="35" id="weapons_29_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_29_4&amp;id=weapons_29_4&amp;link=/checklists/weapons.html%23item_29_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Digger's+Staff&quot;&gt;Digger's Staff&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_29_4&amp;id=weapons_29_4&amp;link=/checklists/weapons.html%23item_29_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Digger's+Staff&quot;&gt;Digger's Staff&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -14793,9 +13911,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="35" id="weapons_29_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_29_5&amp;id=weapons_29_5&amp;link=/checklists/weapons.html%23item_29_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Demi-Human+Queen's+Staff&quot;&gt;Demi-Human Queen's Staff&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_29_5&amp;id=weapons_29_5&amp;link=/checklists/weapons.html%23item_29_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Demi-Human+Queen's+Staff&quot;&gt;Demi-Human Queen's Staff&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -14828,9 +13944,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="35" id="weapons_29_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_29_6&amp;id=weapons_29_6&amp;link=/checklists/weapons.html%23item_29_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Azur's+Glintstone+Staff&quot;&gt;Azur's Glintstone Staff&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_29_6&amp;id=weapons_29_6&amp;link=/checklists/weapons.html%23item_29_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Azur's+Glintstone+Staff&quot;&gt;Azur's Glintstone Staff&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -14863,9 +13977,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="35" id="weapons_29_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_29_7&amp;id=weapons_29_7&amp;link=/checklists/weapons.html%23item_29_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Lusat's+Glintstone+Staff&quot;&gt;Lusat's Glintstone Staff&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_29_7&amp;id=weapons_29_7&amp;link=/checklists/weapons.html%23item_29_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Lusat's+Glintstone+Staff&quot;&gt;Lusat's Glintstone Staff&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -14898,9 +14010,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="35" id="weapons_29_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_29_9&amp;id=weapons_29_9&amp;link=/checklists/weapons.html%23item_29_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Carian+Glintstone+Staff&quot;&gt;Carian Glintstone Staff&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_29_9&amp;id=weapons_29_9&amp;link=/checklists/weapons.html%23item_29_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Carian+Glintstone+Staff&quot;&gt;Carian Glintstone Staff&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -14933,9 +14043,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="35" id="weapons_29_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_29_8&amp;id=weapons_29_8&amp;link=/checklists/weapons.html%23item_29_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Carian+Glintblade+Staff&quot;&gt;Carian Glintblade Staff&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_29_8&amp;id=weapons_29_8&amp;link=/checklists/weapons.html%23item_29_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Carian+Glintblade+Staff&quot;&gt;Carian Glintblade Staff&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -14968,9 +14076,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="35" id="weapons_29_10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_29_10&amp;id=weapons_29_10&amp;link=/checklists/weapons.html%23item_29_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Carian+Regal+Scepter&quot;&gt;Carian Regal Scepter&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_29_10&amp;id=weapons_29_10&amp;link=/checklists/weapons.html%23item_29_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Carian+Regal+Scepter&quot;&gt;Carian Regal Scepter&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -15003,9 +14109,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="35" id="weapons_29_11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_29_11&amp;id=weapons_29_11&amp;link=/checklists/weapons.html%23item_29_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Albinauric+Staff&quot;&gt;Albinauric Staff&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_29_11&amp;id=weapons_29_11&amp;link=/checklists/weapons.html%23item_29_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Albinauric+Staff&quot;&gt;Albinauric Staff&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -15038,9 +14142,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="35" id="weapons_29_12" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_29_12&amp;id=weapons_29_12&amp;link=/checklists/weapons.html%23item_29_12&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Staff+of+Loss&quot;&gt;Staff of Loss&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_29_12&amp;id=weapons_29_12&amp;link=/checklists/weapons.html%23item_29_12&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Staff+of+Loss&quot;&gt;Staff of Loss&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -15073,9 +14175,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="35" id="weapons_29_13" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_29_13&amp;id=weapons_29_13&amp;link=/checklists/weapons.html%23item_29_13&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gelmir+Glintstone+Staff&quot;&gt;Gelmir Glintstone Staff&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_29_13&amp;id=weapons_29_13&amp;link=/checklists/weapons.html%23item_29_13&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gelmir+Glintstone+Staff&quot;&gt;Gelmir Glintstone Staff&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -15108,9 +14208,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="35" id="weapons_29_14" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_29_14&amp;id=weapons_29_14&amp;link=/checklists/weapons.html%23item_29_14&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Crystal+Staff&quot;&gt;Crystal Staff&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_29_14&amp;id=weapons_29_14&amp;link=/checklists/weapons.html%23item_29_14&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Crystal+Staff&quot;&gt;Crystal Staff&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -15143,9 +14241,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="35" id="weapons_29_15" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_29_15&amp;id=weapons_29_15&amp;link=/checklists/weapons.html%23item_29_15&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Rotten+Crystal+Staff&quot;&gt;Rotten Crystal Staff&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_29_15&amp;id=weapons_29_15&amp;link=/checklists/weapons.html%23item_29_15&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Rotten+Crystal+Staff&quot;&gt;Rotten Crystal Staff&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -15178,9 +14274,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="35" id="weapons_29_16" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_29_16&amp;id=weapons_29_16&amp;link=/checklists/weapons.html%23item_29_16&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Meteorite+Staff&quot;&gt;Meteorite Staff&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_29_16&amp;id=weapons_29_16&amp;link=/checklists/weapons.html%23item_29_16&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Meteorite+Staff&quot;&gt;Meteorite Staff&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -15213,9 +14307,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="35" id="weapons_29_17" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_29_17&amp;id=weapons_29_17&amp;link=/checklists/weapons.html%23item_29_17&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Staff+of+the+Guilty&quot;&gt;Staff of the Guilty&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_29_17&amp;id=weapons_29_17&amp;link=/checklists/weapons.html%23item_29_17&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Staff+of+the+Guilty&quot;&gt;Staff of the Guilty&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -15248,9 +14340,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="35" id="weapons_29_18" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_29_18&amp;id=weapons_29_18&amp;link=/checklists/weapons.html%23item_29_18&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Prince+of+Death's+Staff&quot;&gt;Prince of Death's Staff&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_29_18&amp;id=weapons_29_18&amp;link=/checklists/weapons.html%23item_29_18&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Prince+of+Death's+Staff&quot;&gt;Prince of Death's Staff&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -15283,9 +14373,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="35" id="weapons_50_92" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_92&amp;id=weapons_50_92&amp;link=/checklists/weapons.html%23item_50_92&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Staff+of+the+Great+Beyond&quot;&gt;Staff of the Great Beyond&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_92&amp;id=weapons_50_92&amp;link=/checklists/weapons.html%23item_50_92&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Staff+of+the+Great+Beyond&quot;&gt;Staff of the Great Beyond&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -15318,9 +14406,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="35" id="weapons_50_93" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_93&amp;id=weapons_50_93&amp;link=/checklists/weapons.html%23item_50_93&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Maternal+Staff&quot;&gt;Maternal Staff&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_93&amp;id=weapons_50_93&amp;link=/checklists/weapons.html%23item_50_93&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Maternal+Staff&quot;&gt;Maternal Staff&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -15354,9 +14440,7 @@
         <div class="card shadow-sm mb-3" id="weapons_section_36">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_36Col" data-bs-toggle="collapse" href="#weapons_36Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_36Col" data-bs-toggle="collapse" href="#weapons_36Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Sacred+Seals">Sacred Seals</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="weapons_totals_36"></span>
             </h4>
@@ -15368,9 +14452,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -15399,9 +14481,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="36" id="weapons_30_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_30_1&amp;id=weapons_30_1&amp;link=/checklists/weapons.html%23item_30_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Finger+Seal&quot;&gt;Finger Seal&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_30_1&amp;id=weapons_30_1&amp;link=/checklists/weapons.html%23item_30_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Finger+Seal&quot;&gt;Finger Seal&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -15434,9 +14514,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="36" id="weapons_30_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_30_2&amp;id=weapons_30_2&amp;link=/checklists/weapons.html%23item_30_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Erdtree+Seal&quot;&gt;Erdtree Seal&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_30_2&amp;id=weapons_30_2&amp;link=/checklists/weapons.html%23item_30_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Erdtree+Seal&quot;&gt;Erdtree Seal&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -15469,9 +14547,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="36" id="weapons_30_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_30_3&amp;id=weapons_30_3&amp;link=/checklists/weapons.html%23item_30_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Golden+Order+Seal&quot;&gt;Golden Order Seal&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_30_3&amp;id=weapons_30_3&amp;link=/checklists/weapons.html%23item_30_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Golden+Order+Seal&quot;&gt;Golden Order Seal&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -15504,9 +14580,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="36" id="weapons_30_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_30_4&amp;id=weapons_30_4&amp;link=/checklists/weapons.html%23item_30_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gravel+Stone+Seal&quot;&gt;Gravel Stone Seal&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_30_4&amp;id=weapons_30_4&amp;link=/checklists/weapons.html%23item_30_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gravel+Stone+Seal&quot;&gt;Gravel Stone Seal&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -15539,9 +14613,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="36" id="weapons_30_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_30_5&amp;id=weapons_30_5&amp;link=/checklists/weapons.html%23item_30_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Giant's+Seal&quot;&gt;Giant's Seal&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_30_5&amp;id=weapons_30_5&amp;link=/checklists/weapons.html%23item_30_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Giant's+Seal&quot;&gt;Giant's Seal&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -15574,9 +14646,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="36" id="weapons_30_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_30_6&amp;id=weapons_30_6&amp;link=/checklists/weapons.html%23item_30_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Godslayer's+Seal&quot;&gt;Godslayer's Seal&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_30_6&amp;id=weapons_30_6&amp;link=/checklists/weapons.html%23item_30_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Godslayer's+Seal&quot;&gt;Godslayer's Seal&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -15609,9 +14679,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="36" id="weapons_30_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_30_7&amp;id=weapons_30_7&amp;link=/checklists/weapons.html%23item_30_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Clawmark+Seal&quot;&gt;Clawmark Seal&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_30_7&amp;id=weapons_30_7&amp;link=/checklists/weapons.html%23item_30_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Clawmark+Seal&quot;&gt;Clawmark Seal&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -15644,9 +14712,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="36" id="weapons_30_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_30_8&amp;id=weapons_30_8&amp;link=/checklists/weapons.html%23item_30_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Frenzied+Flame+Seal&quot;&gt;Frenzied Flame Seal&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_30_8&amp;id=weapons_30_8&amp;link=/checklists/weapons.html%23item_30_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Frenzied+Flame+Seal&quot;&gt;Frenzied Flame Seal&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -15679,9 +14745,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="36" id="weapons_30_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_30_9&amp;id=weapons_30_9&amp;link=/checklists/weapons.html%23item_30_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dragon+Communion+Seal&quot;&gt;Dragon Communion Seal&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_30_9&amp;id=weapons_30_9&amp;link=/checklists/weapons.html%23item_30_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dragon+Communion+Seal&quot;&gt;Dragon Communion Seal&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -15714,9 +14778,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="36" id="weapons_50_94" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_94&amp;id=weapons_50_94&amp;link=/checklists/weapons.html%23item_50_94&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dryleaf+Seal&quot;&gt;Dryleaf Seal&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_94&amp;id=weapons_50_94&amp;link=/checklists/weapons.html%23item_50_94&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dryleaf+Seal&quot;&gt;Dryleaf Seal&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -15749,9 +14811,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="36" id="weapons_50_95" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_95&amp;id=weapons_50_95&amp;link=/checklists/weapons.html%23item_50_95&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Fire+Knight's+Seal&quot;&gt;Fire Knight's Seal&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_95&amp;id=weapons_50_95&amp;link=/checklists/weapons.html%23item_50_95&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Fire+Knight's+Seal&quot;&gt;Fire Knight's Seal&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -15784,9 +14844,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="36" id="weapons_50_96" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_96&amp;id=weapons_50_96&amp;link=/checklists/weapons.html%23item_50_96&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Spiraltree+Seal&quot;&gt;Spiraltree Seal&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_96&amp;id=weapons_50_96&amp;link=/checklists/weapons.html%23item_50_96&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Spiraltree+Seal&quot;&gt;Spiraltree Seal&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -15820,9 +14878,7 @@
         <div class="card shadow-sm mb-3" id="weapons_section_37">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_37Col" data-bs-toggle="collapse" href="#weapons_37Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_37Col" data-bs-toggle="collapse" href="#weapons_37Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Torches">Torches</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="weapons_totals_37"></span>
             </h4>
@@ -15834,9 +14890,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -15865,9 +14919,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="37" id="weapons_31_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_31_1&amp;id=weapons_31_1&amp;link=/checklists/weapons.html%23item_31_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Torch&quot;&gt;Torch&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_31_1&amp;id=weapons_31_1&amp;link=/checklists/weapons.html%23item_31_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Torch&quot;&gt;Torch&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -15900,9 +14952,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="37" id="weapons_31_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_31_2&amp;id=weapons_31_2&amp;link=/checklists/weapons.html%23item_31_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Beast-Repellent+Torch&quot;&gt;Beast-Repllent Torch&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_31_2&amp;id=weapons_31_2&amp;link=/checklists/weapons.html%23item_31_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Beast-Repellent+Torch&quot;&gt;Beast-Repllent Torch&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -15935,9 +14985,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="37" id="weapons_31_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_31_3&amp;id=weapons_31_3&amp;link=/checklists/weapons.html%23item_31_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Steel-Wire+Torch&quot;&gt;Steel-Wire Torch&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_31_3&amp;id=weapons_31_3&amp;link=/checklists/weapons.html%23item_31_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Steel-Wire+Torch&quot;&gt;Steel-Wire Torch&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -15970,9 +15018,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="37" id="weapons_31_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_31_4&amp;id=weapons_31_4&amp;link=/checklists/weapons.html%23item_31_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Sentry's+Torch&quot;&gt;Sentry's Torch&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_31_4&amp;id=weapons_31_4&amp;link=/checklists/weapons.html%23item_31_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Sentry's+Torch&quot;&gt;Sentry's Torch&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -16005,9 +15051,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="37" id="weapons_31_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_31_5&amp;id=weapons_31_5&amp;link=/checklists/weapons.html%23item_31_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ghostflame+Torch&quot;&gt;Ghostflame Torch&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_31_5&amp;id=weapons_31_5&amp;link=/checklists/weapons.html%23item_31_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ghostflame+Torch&quot;&gt;Ghostflame Torch&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -16040,9 +15084,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="37" id="weapons_31_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_31_6&amp;id=weapons_31_6&amp;link=/checklists/weapons.html%23item_31_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/St+Trina's+Torch&quot;&gt;St Trina's Torch&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_31_6&amp;id=weapons_31_6&amp;link=/checklists/weapons.html%23item_31_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/St+Trina's+Torch&quot;&gt;St Trina's Torch&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -16075,9 +15117,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="37" id="weapons_50_62" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_62&amp;id=weapons_50_62&amp;link=/checklists/weapons.html%23item_50_62&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Nanaya's+Torch&quot;&gt;Nanaya's Torch&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_62&amp;id=weapons_50_62&amp;link=/checklists/weapons.html%23item_50_62&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Nanaya's+Torch&quot;&gt;Nanaya's Torch&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -16110,9 +15150,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="37" id="weapons_50_84" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_84&amp;id=weapons_50_84&amp;link=/checklists/weapons.html%23item_50_84&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Lamenting+Visage&quot;&gt;Lamenting Visage&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_84&amp;id=weapons_50_84&amp;link=/checklists/weapons.html%23item_50_84&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Lamenting+Visage&quot;&gt;Lamenting Visage&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -16146,9 +15184,7 @@
         <div class="card shadow-sm mb-3" id="weapons_section_38">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_38Col" data-bs-toggle="collapse" href="#weapons_38Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_38Col" data-bs-toggle="collapse" href="#weapons_38Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Small+Shields">Small Shields</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="weapons_totals_38"></span>
             </h4>
@@ -16160,9 +15196,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -16191,9 +15225,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="38" id="weapons_32_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_32_4&amp;id=weapons_32_4&amp;link=/checklists/weapons.html%23item_32_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Rickety+Shield&quot;&gt;Rickety Shield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_32_4&amp;id=weapons_32_4&amp;link=/checklists/weapons.html%23item_32_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Rickety+Shield&quot;&gt;Rickety Shield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -16226,9 +15258,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="38" id="weapons_32_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_32_9&amp;id=weapons_32_9&amp;link=/checklists/weapons.html%23item_32_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Riveted+Wooden+Shield&quot;&gt;Riveted Wooden Shield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_32_9&amp;id=weapons_32_9&amp;link=/checklists/weapons.html%23item_32_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Riveted+Wooden+Shield&quot;&gt;Riveted Wooden Shield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -16261,9 +15291,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="38" id="weapons_32_10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_32_10&amp;id=weapons_32_10&amp;link=/checklists/weapons.html%23item_32_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Blue-White+Wooden+Shield&quot;&gt;Blue-white Wooden Shield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_32_10&amp;id=weapons_32_10&amp;link=/checklists/weapons.html%23item_32_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Blue-White+Wooden+Shield&quot;&gt;Blue-white Wooden Shield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -16296,9 +15324,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="38" id="weapons_32_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_32_8&amp;id=weapons_32_8&amp;link=/checklists/weapons.html%23item_32_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Scripture+Wooden+Shield&quot;&gt;Scripture Wooden Shield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_32_8&amp;id=weapons_32_8&amp;link=/checklists/weapons.html%23item_32_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Scripture+Wooden+Shield&quot;&gt;Scripture Wooden Shield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -16331,9 +15357,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="38" id="weapons_32_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_32_7&amp;id=weapons_32_7&amp;link=/checklists/weapons.html%23item_32_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Red+Thorn+Roundshield&quot;&gt;Red Thorn Roundshield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_32_7&amp;id=weapons_32_7&amp;link=/checklists/weapons.html%23item_32_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Red+Thorn+Roundshield&quot;&gt;Red Thorn Roundshield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -16366,9 +15390,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="38" id="weapons_32_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_32_5&amp;id=weapons_32_5&amp;link=/checklists/weapons.html%23item_32_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Pillory+Shield&quot;&gt;Pillory Shield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_32_5&amp;id=weapons_32_5&amp;link=/checklists/weapons.html%23item_32_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Pillory+Shield&quot;&gt;Pillory Shield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -16401,9 +15423,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="38" id="weapons_32_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_32_1&amp;id=weapons_32_1&amp;link=/checklists/weapons.html%23item_32_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Buckler&quot;&gt;Buckler&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_32_1&amp;id=weapons_32_1&amp;link=/checklists/weapons.html%23item_32_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Buckler&quot;&gt;Buckler&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -16436,9 +15456,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="38" id="weapons_32_12" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_32_12&amp;id=weapons_32_12&amp;link=/checklists/weapons.html%23item_32_12&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Iron+Roundshield&quot;&gt;Iron Roundshield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_32_12&amp;id=weapons_32_12&amp;link=/checklists/weapons.html%23item_32_12&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Iron+Roundshield&quot;&gt;Iron Roundshield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -16471,9 +15489,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="38" id="weapons_32_13" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_32_13&amp;id=weapons_32_13&amp;link=/checklists/weapons.html%23item_32_13&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gilded+Iron+Shield&quot;&gt;Gilded Iron Shield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_32_13&amp;id=weapons_32_13&amp;link=/checklists/weapons.html%23item_32_13&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gilded+Iron+Shield&quot;&gt;Gilded Iron Shield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -16506,9 +15522,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="38" id="weapons_32_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_32_3&amp;id=weapons_32_3&amp;link=/checklists/weapons.html%23item_32_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Man-Serpent's+Shield&quot;&gt;Man-serpent's Shield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_32_3&amp;id=weapons_32_3&amp;link=/checklists/weapons.html%23item_32_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Man-Serpent's+Shield&quot;&gt;Man-serpent's Shield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -16541,9 +15555,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="38" id="weapons_32_14" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_32_14&amp;id=weapons_32_14&amp;link=/checklists/weapons.html%23item_32_14&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ice+Crest+Shield&quot;&gt;Ice Crest Shield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_32_14&amp;id=weapons_32_14&amp;link=/checklists/weapons.html%23item_32_14&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ice+Crest+Shield&quot;&gt;Ice Crest Shield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -16576,9 +15588,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="38" id="weapons_32_11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_32_11&amp;id=weapons_32_11&amp;link=/checklists/weapons.html%23item_32_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Rift+Shield&quot;&gt;Rift Shield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_32_11&amp;id=weapons_32_11&amp;link=/checklists/weapons.html%23item_32_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Rift+Shield&quot;&gt;Rift Shield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -16611,9 +15621,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="38" id="weapons_32_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_32_2&amp;id=weapons_32_2&amp;link=/checklists/weapons.html%23item_32_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Perfumer's+Shield&quot;&gt;Perfumer's Shield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_32_2&amp;id=weapons_32_2&amp;link=/checklists/weapons.html%23item_32_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Perfumer's+Shield&quot;&gt;Perfumer's Shield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -16646,9 +15654,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="38" id="weapons_32_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_32_6&amp;id=weapons_32_6&amp;link=/checklists/weapons.html%23item_32_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Shield+of+the+Guilty&quot;&gt;Shield Of The Guilty&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_32_6&amp;id=weapons_32_6&amp;link=/checklists/weapons.html%23item_32_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Shield+of+the+Guilty&quot;&gt;Shield Of The Guilty&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -16681,9 +15687,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="38" id="weapons_32_16" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_32_16&amp;id=weapons_32_16&amp;link=/checklists/weapons.html%23item_32_16&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Spiralhorn+Shield&quot;&gt;Spiralhorn Shield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_32_16&amp;id=weapons_32_16&amp;link=/checklists/weapons.html%23item_32_16&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Spiralhorn+Shield&quot;&gt;Spiralhorn Shield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -16716,9 +15720,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="38" id="weapons_32_15" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_32_15&amp;id=weapons_32_15&amp;link=/checklists/weapons.html%23item_32_15&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Smoldering+Shield&quot;&gt;Smoldering Shield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_32_15&amp;id=weapons_32_15&amp;link=/checklists/weapons.html%23item_32_15&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Smoldering+Shield&quot;&gt;Smoldering Shield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -16751,9 +15753,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="38" id="weapons_32_17" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_32_17&amp;id=weapons_32_17&amp;link=/checklists/weapons.html%23item_32_17&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Coil+Shield&quot;&gt;Coil Shield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_32_17&amp;id=weapons_32_17&amp;link=/checklists/weapons.html%23item_32_17&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Coil+Shield&quot;&gt;Coil Shield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -16786,9 +15786,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="38" id="weapons_50_57" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_57&amp;id=weapons_50_57&amp;link=/checklists/weapons.html%23item_50_57&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Shield+of+Night&quot;&gt;Shield of Night&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_57&amp;id=weapons_50_57&amp;link=/checklists/weapons.html%23item_50_57&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Shield+of+Night&quot;&gt;Shield of Night&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -16821,9 +15819,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="38" id="weapons_50_85" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_85&amp;id=weapons_50_85&amp;link=/checklists/weapons.html%23item_50_85&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Smithscript+Shield&quot;&gt;Smithscript Shield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_85&amp;id=weapons_50_85&amp;link=/checklists/weapons.html%23item_50_85&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Smithscript+Shield&quot;&gt;Smithscript Shield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -16857,9 +15853,7 @@
         <div class="card shadow-sm mb-3" id="weapons_section_39">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_39Col" data-bs-toggle="collapse" href="#weapons_39Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_39Col" data-bs-toggle="collapse" href="#weapons_39Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Medium+Shields">Medium Shields</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="weapons_totals_39"></span>
             </h4>
@@ -16871,9 +15865,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -16902,9 +15894,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="39" id="weapons_33_20" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_33_20&amp;id=weapons_33_20&amp;link=/checklists/weapons.html%23item_33_20&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Hawk+Crest+Wooden+Shield&quot;&gt;Hawk Crest Wooden Shield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_33_20&amp;id=weapons_33_20&amp;link=/checklists/weapons.html%23item_33_20&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Hawk+Crest+Wooden+Shield&quot;&gt;Hawk Crest Wooden Shield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -16936,9 +15926,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="39" id="weapons_33_17" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_33_17&amp;id=weapons_33_17&amp;link=/checklists/weapons.html%23item_33_17&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Horse+Crest+Wooden+Shield&quot;&gt;Horse Crest Wooden Shield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_33_17&amp;id=weapons_33_17&amp;link=/checklists/weapons.html%23item_33_17&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Horse+Crest+Wooden+Shield&quot;&gt;Horse Crest Wooden Shield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -16970,9 +15958,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="39" id="weapons_33_18" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_33_18&amp;id=weapons_33_18&amp;link=/checklists/weapons.html%23item_33_18&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Candletree+Wooden+Shield&quot;&gt;Candletree Wooden Shield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_33_18&amp;id=weapons_33_18&amp;link=/checklists/weapons.html%23item_33_18&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Candletree+Wooden+Shield&quot;&gt;Candletree Wooden Shield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -17004,9 +15990,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="39" id="weapons_33_19" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_33_19&amp;id=weapons_33_19&amp;link=/checklists/weapons.html%23item_33_19&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Flame+Crest+Wooden+Shield&quot;&gt;Flame Crest Wooden Shield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_33_19&amp;id=weapons_33_19&amp;link=/checklists/weapons.html%23item_33_19&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Flame+Crest+Wooden+Shield&quot;&gt;Flame Crest Wooden Shield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -17038,9 +16022,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="39" id="weapons_33_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_33_3&amp;id=weapons_33_3&amp;link=/checklists/weapons.html%23item_33_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Marred+Wooden+Shield&quot;&gt;Marred Wooden Shield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_33_3&amp;id=weapons_33_3&amp;link=/checklists/weapons.html%23item_33_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Marred+Wooden+Shield&quot;&gt;Marred Wooden Shield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -17072,9 +16054,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="39" id="weapons_33_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_33_6&amp;id=weapons_33_6&amp;link=/checklists/weapons.html%23item_33_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Sun+Realm+Shield&quot;&gt;Sun Realm Shield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_33_6&amp;id=weapons_33_6&amp;link=/checklists/weapons.html%23item_33_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Sun+Realm+Shield&quot;&gt;Sun Realm Shield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -17106,9 +16086,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="39" id="weapons_33_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_33_8&amp;id=weapons_33_8&amp;link=/checklists/weapons.html%23item_33_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Round+Shield&quot;&gt;Round Shield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_33_8&amp;id=weapons_33_8&amp;link=/checklists/weapons.html%23item_33_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Round+Shield&quot;&gt;Round Shield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -17140,9 +16118,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="39" id="weapons_33_16" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_33_16&amp;id=weapons_33_16&amp;link=/checklists/weapons.html%23item_33_16&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Large+Leather+Shield&quot;&gt;Large Leather Shield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_33_16&amp;id=weapons_33_16&amp;link=/checklists/weapons.html%23item_33_16&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Large+Leather+Shield&quot;&gt;Large Leather Shield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -17174,9 +16150,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="39" id="weapons_33_27" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_33_27&amp;id=weapons_33_27&amp;link=/checklists/weapons.html%23item_33_27&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Black+Leather+Shield&quot;&gt;Black Leather Shield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_33_27&amp;id=weapons_33_27&amp;link=/checklists/weapons.html%23item_33_27&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Black+Leather+Shield&quot;&gt;Black Leather Shield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -17208,9 +16182,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="39" id="weapons_33_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_33_2&amp;id=weapons_33_2&amp;link=/checklists/weapons.html%23item_33_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Marred+Leather+Shield&quot;&gt;Marred Leather Shield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_33_2&amp;id=weapons_33_2&amp;link=/checklists/weapons.html%23item_33_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Marred+Leather+Shield&quot;&gt;Marred Leather Shield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -17242,9 +16214,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="39" id="weapons_33_26" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_33_26&amp;id=weapons_33_26&amp;link=/checklists/weapons.html%23item_33_26&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Heater+Shield&quot;&gt;Heater Shield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_33_26&amp;id=weapons_33_26&amp;link=/checklists/weapons.html%23item_33_26&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Heater+Shield&quot;&gt;Heater Shield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -17276,9 +16246,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="39" id="weapons_33_23" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_33_23&amp;id=weapons_33_23&amp;link=/checklists/weapons.html%23item_33_23&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Blue+Crest+Heater+Shield&quot;&gt;Blue Crest Heater Shield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_33_23&amp;id=weapons_33_23&amp;link=/checklists/weapons.html%23item_33_23&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Blue+Crest+Heater+Shield&quot;&gt;Blue Crest Heater Shield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -17310,9 +16278,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="39" id="weapons_33_22" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_33_22&amp;id=weapons_33_22&amp;link=/checklists/weapons.html%23item_33_22&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Red+Crest+Heater+Shield&quot;&gt;Red Crest Heater Shield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_33_22&amp;id=weapons_33_22&amp;link=/checklists/weapons.html%23item_33_22&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Red+Crest+Heater+Shield&quot;&gt;Red Crest Heater Shield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -17344,9 +16310,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="39" id="weapons_33_21" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_33_21&amp;id=weapons_33_21&amp;link=/checklists/weapons.html%23item_33_21&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Beast+Crest+Heater+Shield&quot;&gt;Beast Crest Heater Shield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_33_21&amp;id=weapons_33_21&amp;link=/checklists/weapons.html%23item_33_21&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Beast+Crest+Heater+Shield&quot;&gt;Beast Crest Heater Shield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -17378,9 +16342,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="39" id="weapons_33_25" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_33_25&amp;id=weapons_33_25&amp;link=/checklists/weapons.html%23item_33_25&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Inverted+Hawk+Heater+Shield&quot;&gt;Inverted Hawk Heater Shield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_33_25&amp;id=weapons_33_25&amp;link=/checklists/weapons.html%23item_33_25&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Inverted+Hawk+Heater+Shield&quot;&gt;Inverted Hawk Heater Shield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -17412,9 +16374,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="39" id="weapons_33_24" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_33_24&amp;id=weapons_33_24&amp;link=/checklists/weapons.html%23item_33_24&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Eclipse+Crest+Heater+Shield&quot;&gt;Eclipse Crest Heater Shield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_33_24&amp;id=weapons_33_24&amp;link=/checklists/weapons.html%23item_33_24&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Eclipse+Crest+Heater+Shield&quot;&gt;Eclipse Crest Heater Shield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -17446,9 +16406,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="39" id="weapons_33_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_33_1&amp;id=weapons_33_1&amp;link=/checklists/weapons.html%23item_33_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Kite+Shield&quot;&gt;Kite Shield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_33_1&amp;id=weapons_33_1&amp;link=/checklists/weapons.html%23item_33_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Kite+Shield&quot;&gt;Kite Shield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -17480,9 +16438,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="39" id="weapons_33_11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_33_11&amp;id=weapons_33_11&amp;link=/checklists/weapons.html%23item_33_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Blue-Gold+Kite+Shield&quot;&gt;Blue-gold Kite Shield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_33_11&amp;id=weapons_33_11&amp;link=/checklists/weapons.html%23item_33_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Blue-Gold+Kite+Shield&quot;&gt;Blue-gold Kite Shield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -17514,9 +16470,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="39" id="weapons_33_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_33_9&amp;id=weapons_33_9&amp;link=/checklists/weapons.html%23item_33_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Scorpion+Kite+Shield&quot;&gt;Scorpion Kite Shield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_33_9&amp;id=weapons_33_9&amp;link=/checklists/weapons.html%23item_33_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Scorpion+Kite+Shield&quot;&gt;Scorpion Kite Shield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -17548,9 +16502,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="39" id="weapons_33_10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_33_10&amp;id=weapons_33_10&amp;link=/checklists/weapons.html%23item_33_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Twinbird+Kite+Shield&quot;&gt;Twinbird Kite Shield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_33_10&amp;id=weapons_33_10&amp;link=/checklists/weapons.html%23item_33_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Twinbird+Kite+Shield&quot;&gt;Twinbird Kite Shield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -17582,9 +16534,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="39" id="weapons_33_12" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_33_12&amp;id=weapons_33_12&amp;link=/checklists/weapons.html%23item_33_12&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Brass+Shield&quot;&gt;Brass Shield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_33_12&amp;id=weapons_33_12&amp;link=/checklists/weapons.html%23item_33_12&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Brass+Shield&quot;&gt;Brass Shield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -17616,9 +16566,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="39" id="weapons_33_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_33_4&amp;id=weapons_33_4&amp;link=/checklists/weapons.html%23item_33_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Banished+Knight's+Shield&quot;&gt;Banished Knight's Shield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_33_4&amp;id=weapons_33_4&amp;link=/checklists/weapons.html%23item_33_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Banished+Knight's+Shield&quot;&gt;Banished Knight's Shield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -17650,9 +16598,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="39" id="weapons_33_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_33_5&amp;id=weapons_33_5&amp;link=/checklists/weapons.html%23item_33_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Albinauric+Shield&quot;&gt;Albinauric Shield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_33_5&amp;id=weapons_33_5&amp;link=/checklists/weapons.html%23item_33_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Albinauric+Shield&quot;&gt;Albinauric Shield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -17684,9 +16630,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="39" id="weapons_33_14" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_33_14&amp;id=weapons_33_14&amp;link=/checklists/weapons.html%23item_33_14&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Beastman's+Jar-Shield&quot;&gt;Beastman's Jar-shield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_33_14&amp;id=weapons_33_14&amp;link=/checklists/weapons.html%23item_33_14&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Beastman's+Jar-Shield&quot;&gt;Beastman's Jar-shield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -17718,9 +16662,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="39" id="weapons_33_15" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_33_15&amp;id=weapons_33_15&amp;link=/checklists/weapons.html%23item_33_15&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Carian+Knight's+Shield&quot;&gt;Carian Knight's Shield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_33_15&amp;id=weapons_33_15&amp;link=/checklists/weapons.html%23item_33_15&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Carian+Knight's+Shield&quot;&gt;Carian Knight's Shield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -17752,9 +16694,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="39" id="weapons_33_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_33_7&amp;id=weapons_33_7&amp;link=/checklists/weapons.html%23item_33_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Silver+Mirrorshield&quot;&gt;Silver Mirrorshield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_33_7&amp;id=weapons_33_7&amp;link=/checklists/weapons.html%23item_33_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Silver+Mirrorshield&quot;&gt;Silver Mirrorshield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -17786,9 +16726,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="39" id="weapons_33_13" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_33_13&amp;id=weapons_33_13&amp;link=/checklists/weapons.html%23item_33_13&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Great+Turtle+Shell&quot;&gt;Great Turtle Shell&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_33_13&amp;id=weapons_33_13&amp;link=/checklists/weapons.html%23item_33_13&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Great+Turtle+Shell&quot;&gt;Great Turtle Shell&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -17820,9 +16758,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="39" id="weapons_50_86" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_86&amp;id=weapons_50_86&amp;link=/checklists/weapons.html%23item_50_86&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Messmer+Soldier+Shield&quot;&gt;Messmer Soldier Shield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_86&amp;id=weapons_50_86&amp;link=/checklists/weapons.html%23item_50_86&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Messmer+Soldier+Shield&quot;&gt;Messmer Soldier Shield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -17855,9 +16791,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="39" id="weapons_50_87" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_87&amp;id=weapons_50_87&amp;link=/checklists/weapons.html%23item_50_87&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Wolf+Crest+Shield&quot;&gt;Wolf Crest Shield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_87&amp;id=weapons_50_87&amp;link=/checklists/weapons.html%23item_50_87&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Wolf+Crest+Shield&quot;&gt;Wolf Crest Shield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -17890,9 +16824,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="39" id="weapons_50_88" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_88&amp;id=weapons_50_88&amp;link=/checklists/weapons.html%23item_50_88&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Serpent+Crest+Shield&quot;&gt;Serpent Crest Shield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_88&amp;id=weapons_50_88&amp;link=/checklists/weapons.html%23item_50_88&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Serpent+Crest+Shield&quot;&gt;Serpent Crest Shield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -17925,9 +16857,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="39" id="weapons_50_89" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_89&amp;id=weapons_50_89&amp;link=/checklists/weapons.html%23item_50_89&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Golden+Lion+Shield&quot;&gt;Golden Lion Shield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_89&amp;id=weapons_50_89&amp;link=/checklists/weapons.html%23item_50_89&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Golden+Lion+Shield&quot;&gt;Golden Lion Shield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -17961,9 +16891,7 @@
         <div class="card shadow-sm mb-3" id="weapons_section_40">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_40Col" data-bs-toggle="collapse" href="#weapons_40Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_40Col" data-bs-toggle="collapse" href="#weapons_40Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Greatshields">Greatshields</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="weapons_totals_40"></span>
             </h4>
@@ -17975,9 +16903,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -18006,9 +16932,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="40" id="weapons_34_24" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_34_24&amp;id=weapons_34_24&amp;link=/checklists/weapons.html%23item_34_24&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Wooden+Greatshield&quot;&gt;Wooden Greatshield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_34_24&amp;id=weapons_34_24&amp;link=/checklists/weapons.html%23item_34_24&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Wooden+Greatshield&quot;&gt;Wooden Greatshield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -18040,9 +16964,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="40" id="weapons_34_25" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_34_25&amp;id=weapons_34_25&amp;link=/checklists/weapons.html%23item_34_25&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Lordsworn's+Shield&quot;&gt;Lordsworn's Shield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_34_25&amp;id=weapons_34_25&amp;link=/checklists/weapons.html%23item_34_25&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Lordsworn's+Shield&quot;&gt;Lordsworn's Shield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -18074,9 +16996,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="40" id="weapons_34_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_34_5&amp;id=weapons_34_5&amp;link=/checklists/weapons.html%23item_34_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Briar+Greatshield&quot;&gt;Briar Greatshield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_34_5&amp;id=weapons_34_5&amp;link=/checklists/weapons.html%23item_34_5&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Briar+Greatshield&quot;&gt;Briar Greatshield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -18108,9 +17028,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="40" id="weapons_34_13" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_34_13&amp;id=weapons_34_13&amp;link=/checklists/weapons.html%23item_34_13&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Spiked+Palisade+Shield&quot;&gt;Spiked Palisade Shield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_34_13&amp;id=weapons_34_13&amp;link=/checklists/weapons.html%23item_34_13&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Spiked+Palisade+Shield&quot;&gt;Spiked Palisade Shield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -18142,9 +17060,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="40" id="weapons_34_10" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_34_10&amp;id=weapons_34_10&amp;link=/checklists/weapons.html%23item_34_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Icon+Shield&quot;&gt;Icon Shield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_34_10&amp;id=weapons_34_10&amp;link=/checklists/weapons.html%23item_34_10&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Icon+Shield&quot;&gt;Icon Shield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -18176,9 +17092,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="40" id="weapons_34_7" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_34_7&amp;id=weapons_34_7&amp;link=/checklists/weapons.html%23item_34_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Golden+Beast+Crest+Shield&quot;&gt;Golden Beast Crest Shield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_34_7&amp;id=weapons_34_7&amp;link=/checklists/weapons.html%23item_34_7&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Golden+Beast+Crest+Shield&quot;&gt;Golden Beast Crest Shield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -18210,9 +17124,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="40" id="weapons_34_14" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_34_14&amp;id=weapons_34_14&amp;link=/checklists/weapons.html%23item_34_14&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Manor+Towershield&quot;&gt;Manor Towershield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_34_14&amp;id=weapons_34_14&amp;link=/checklists/weapons.html%23item_34_14&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Manor+Towershield&quot;&gt;Manor Towershield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -18244,9 +17156,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="40" id="weapons_34_15" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_34_15&amp;id=weapons_34_15&amp;link=/checklists/weapons.html%23item_34_15&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Crossed-Tree+Towershield&quot;&gt;Crossed-tree Towershield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_34_15&amp;id=weapons_34_15&amp;link=/checklists/weapons.html%23item_34_15&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Crossed-Tree+Towershield&quot;&gt;Crossed-tree Towershield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -18278,9 +17188,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="40" id="weapons_34_16" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_34_16&amp;id=weapons_34_16&amp;link=/checklists/weapons.html%23item_34_16&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Inverted+Hawk+Towershield&quot;&gt;Inverted Hawk Towershield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_34_16&amp;id=weapons_34_16&amp;link=/checklists/weapons.html%23item_34_16&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Inverted+Hawk+Towershield&quot;&gt;Inverted Hawk Towershield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -18312,9 +17220,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="40" id="weapons_34_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_34_1&amp;id=weapons_34_1&amp;link=/checklists/weapons.html%23item_34_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dragon+Towershield&quot;&gt;Dragon Towershield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_34_1&amp;id=weapons_34_1&amp;link=/checklists/weapons.html%23item_34_1&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dragon+Towershield&quot;&gt;Dragon Towershield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -18346,9 +17252,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="40" id="weapons_34_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_34_2&amp;id=weapons_34_2&amp;link=/checklists/weapons.html%23item_34_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Distinguished+Greatshield&quot;&gt;Distinguished Greatshield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_34_2&amp;id=weapons_34_2&amp;link=/checklists/weapons.html%23item_34_2&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Distinguished+Greatshield&quot;&gt;Distinguished Greatshield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -18380,9 +17284,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="40" id="weapons_34_22" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_34_22&amp;id=weapons_34_22&amp;link=/checklists/weapons.html%23item_34_22&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gilded+Greatshield&quot;&gt;Gilded Greatshield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_34_22&amp;id=weapons_34_22&amp;link=/checklists/weapons.html%23item_34_22&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Gilded+Greatshield&quot;&gt;Gilded Greatshield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -18414,9 +17316,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="40" id="weapons_34_20" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_34_20&amp;id=weapons_34_20&amp;link=/checklists/weapons.html%23item_34_20&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Cuckoo+Greatshield&quot;&gt;Cuckoo Greatshield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_34_20&amp;id=weapons_34_20&amp;link=/checklists/weapons.html%23item_34_20&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Cuckoo+Greatshield&quot;&gt;Cuckoo Greatshield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -18448,9 +17348,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="40" id="weapons_34_18" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_34_18&amp;id=weapons_34_18&amp;link=/checklists/weapons.html%23item_34_18&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Redmane+Greatshield&quot;&gt;Redmane Greatshield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_34_18&amp;id=weapons_34_18&amp;link=/checklists/weapons.html%23item_34_18&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Redmane+Greatshield&quot;&gt;Redmane Greatshield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -18482,9 +17380,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="40" id="weapons_34_21" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_34_21&amp;id=weapons_34_21&amp;link=/checklists/weapons.html%23item_34_21&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Golden+Greatshield&quot;&gt;Golden Greatshield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_34_21&amp;id=weapons_34_21&amp;link=/checklists/weapons.html%23item_34_21&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Golden+Greatshield&quot;&gt;Golden Greatshield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -18516,9 +17412,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="40" id="weapons_34_23" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_34_23&amp;id=weapons_34_23&amp;link=/checklists/weapons.html%23item_34_23&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Haligtree+Crest+Greatshield&quot;&gt;Haligtree Crest Greatshield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_34_23&amp;id=weapons_34_23&amp;link=/checklists/weapons.html%23item_34_23&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Haligtree+Crest+Greatshield&quot;&gt;Haligtree Crest Greatshield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -18550,9 +17444,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="40" id="weapons_34_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_34_3&amp;id=weapons_34_3&amp;link=/checklists/weapons.html%23item_34_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Crucible+Hornshield&quot;&gt;Crucible Hornshield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_34_3&amp;id=weapons_34_3&amp;link=/checklists/weapons.html%23item_34_3&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Crucible+Hornshield&quot;&gt;Crucible Hornshield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -18584,9 +17476,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="40" id="weapons_34_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_34_4&amp;id=weapons_34_4&amp;link=/checklists/weapons.html%23item_34_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dragonclaw+Shield&quot;&gt;Dragonclaw Shield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_34_4&amp;id=weapons_34_4&amp;link=/checklists/weapons.html%23item_34_4&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dragonclaw+Shield&quot;&gt;Dragonclaw Shield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -18618,9 +17508,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="40" id="weapons_34_9" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_34_9&amp;id=weapons_34_9&amp;link=/checklists/weapons.html%23item_34_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Fingerprint+Stone+Shield&quot;&gt;Fingerprint Stone Shield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_34_9&amp;id=weapons_34_9&amp;link=/checklists/weapons.html%23item_34_9&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Fingerprint+Stone+Shield&quot;&gt;Fingerprint Stone Shield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -18652,9 +17540,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="40" id="weapons_34_19" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_34_19&amp;id=weapons_34_19&amp;link=/checklists/weapons.html%23item_34_19&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Eclipse+Crest+Greatshield&quot;&gt;Eclipse Crest Greatshield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_34_19&amp;id=weapons_34_19&amp;link=/checklists/weapons.html%23item_34_19&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Eclipse+Crest+Greatshield&quot;&gt;Eclipse Crest Greatshield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -18686,9 +17572,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="40" id="weapons_34_17" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_34_17&amp;id=weapons_34_17&amp;link=/checklists/weapons.html%23item_34_17&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ant's+Skull+Plate&quot;&gt;Ant's Skull Plate&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_34_17&amp;id=weapons_34_17&amp;link=/checklists/weapons.html%23item_34_17&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Ant's+Skull+Plate&quot;&gt;Ant's Skull Plate&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -18720,9 +17604,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="40" id="weapons_34_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_34_6&amp;id=weapons_34_6&amp;link=/checklists/weapons.html%23item_34_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Erdtree+Greatshield&quot;&gt;Erdtree Greatshield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_34_6&amp;id=weapons_34_6&amp;link=/checklists/weapons.html%23item_34_6&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Erdtree+Greatshield&quot;&gt;Erdtree Greatshield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -18754,9 +17636,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="40" id="weapons_34_8" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_34_8&amp;id=weapons_34_8&amp;link=/checklists/weapons.html%23item_34_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Jellyfish+Shield&quot;&gt;Jellyfish Shield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_34_8&amp;id=weapons_34_8&amp;link=/checklists/weapons.html%23item_34_8&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Jellyfish+Shield&quot;&gt;Jellyfish Shield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -18788,9 +17668,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="40" id="weapons_34_12" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_34_12&amp;id=weapons_34_12&amp;link=/checklists/weapons.html%23item_34_12&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Visage+Shield&quot;&gt;Visage Shield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_34_12&amp;id=weapons_34_12&amp;link=/checklists/weapons.html%23item_34_12&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Visage+Shield&quot;&gt;Visage Shield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -18822,9 +17700,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="40" id="weapons_34_11" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_34_11&amp;id=weapons_34_11&amp;link=/checklists/weapons.html%23item_34_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/One-Eyed+Shield&quot;&gt;One-eyed Shield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_34_11&amp;id=weapons_34_11&amp;link=/checklists/weapons.html%23item_34_11&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/One-Eyed+Shield&quot;&gt;One-eyed Shield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -18856,9 +17732,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="40" id="weapons_50_90" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_90&amp;id=weapons_50_90&amp;link=/checklists/weapons.html%23item_50_90&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Black+Steel+Greatshield&quot;&gt;Black Steel Greatshield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_90&amp;id=weapons_50_90&amp;link=/checklists/weapons.html%23item_50_90&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Black+Steel+Greatshield&quot;&gt;Black Steel Greatshield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -18891,9 +17765,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="40" id="weapons_50_91" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_91&amp;id=weapons_50_91&amp;link=/checklists/weapons.html%23item_50_91&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Verdigris+Greatshield&quot;&gt;Verdigris Greatshield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_91&amp;id=weapons_50_91&amp;link=/checklists/weapons.html%23item_50_91&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Verdigris+Greatshield&quot;&gt;Verdigris Greatshield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -18927,9 +17799,7 @@
         <div class="card shadow-sm mb-3" id="weapons_section_41">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_41Col" data-bs-toggle="collapse" href="#weapons_41Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#weapons_41Col" data-bs-toggle="collapse" href="#weapons_41Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <a class="d-print-inline" href="https://eldenring.wiki.fextralife.com/Thrusting+Shields">Thrusting Shields</a>
               <span class="mt-0 badge rounded-pill d-print-none" id="weapons_totals_41"></span>
             </h4>
@@ -18941,9 +17811,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -18972,9 +17840,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="41" id="weapons_50_70" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_70&amp;id=weapons_50_70&amp;link=/checklists/weapons.html%23item_50_70&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dueling+Shield&quot;&gt;Dueling Shield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_70&amp;id=weapons_50_70&amp;link=/checklists/weapons.html%23item_50_70&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Dueling+Shield&quot;&gt;Dueling Shield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -19007,9 +17873,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="41" id="weapons_50_71" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="/map.html?target=weapons_50_71&amp;id=weapons_50_71&amp;link=/checklists/weapons.html%23item_50_71&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Carian+Thrusting+Shield&quot;&gt;Carian Thrusting Shield&lt;/a&gt;">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="/map.html?target=weapons_50_71&amp;id=weapons_50_71&amp;link=/checklists/weapons.html%23item_50_71&amp;title=&lt;a href=&quot;https://eldenring.wiki.fextralife.com/Carian+Thrusting+Shield&quot;&gt;Carian Thrusting Shield&lt;/a&gt;"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">

--- a/docs/checklists/whetstones.html
+++ b/docs/checklists/whetstones.html
@@ -27,14 +27,10 @@
         <a class="navbar-brand me-auto ms-2" href="/index.html">Roundtable Guides</a>
         <form class="d-none d-sm-flex order-2 order-xl-3">
           <input aria-label="search" class="form-control me-2" name="search" placeholder="Search" type="search">
-          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit">
-            <i class="bi bi-search"></i>
-          </button>
+          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit"><i class="bi bi-search"></i></button>
         </form>
         <div class="d-sm-none order-2">
-          <a class="nav-link me-0" href="/search.html">
-            <i class="bi bi-search sb-icon-search"></i>
-          </a>
+          <a class="nav-link me-0" href="/search.html"><i class="bi bi-search sb-icon-search"></i></a>
         </div>
         <div class="collapse navbar-collapse order-3 order-xl-2 ms-xl-2" id="nav-collapse">
           <ul class="nav navbar-nav navbar-nav-scroll mr-auto">
@@ -179,14 +175,10 @@
               </ul>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/map.html">
-                <i class="bi bi-map"></i> Map
-              </a>
+              <a class="nav-link hide-buttons" href="/map.html"><i class="bi bi-map"></i> Map</a>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/options.html">
-                <i class="bi bi-gear-fill"></i> Options
-              </a>
+              <a class="nav-link hide-buttons" href="/options.html"><i class="bi bi-gear-fill"></i> Options</a>
             </li>
           </ul>
         </div>
@@ -206,9 +198,7 @@
       </div>
       <nav class="text-muted toc d-print-none">
         <strong class="d-block h5">
-          <a class="toc-button" data-bs-toggle="collapse" href="#toc_whetstones" role="button">
-            <i class="bi bi-plus-lg"></i>Table Of Contents
-          </a>
+          <a class="toc-button" data-bs-toggle="collapse" href="#toc_whetstones" role="button"><i class="bi bi-plus-lg"></i>Table Of Contents</a>
         </strong>
         <ul class="toc_page collapse" id="toc_whetstones">
           <li>
@@ -224,9 +214,7 @@
         <div class="card shadow-sm mb-3" id="whetstones_section_0">
           <div class="card-body">
             <h4 class="mt-1">
-              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#whetstones_0Col" data-bs-toggle="collapse" href="#whetstones_0Col" role="button">
-                <i class="bi bi-chevron-up d-print-none"></i>
-              </button>
+              <button class="btn btn-primary btn-sm me-2 collapse-button d-print-none" data-bs-target="#whetstones_0Col" data-bs-toggle="collapse" href="#whetstones_0Col" role="button"><i class="bi bi-chevron-up d-print-none"></i></button>
               <span class="d-print-inline">Whetstones</span>
               <span class="mt-0 badge rounded-pill d-print-none" id="whetstones_totals_0"></span>
             </h4>
@@ -238,9 +226,7 @@
                       <input class="form-check-input invisible pe-0 me-0" type="checkbox">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="invisible" href="#">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="invisible" href="#"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block">
                       <div class="row">
@@ -269,9 +255,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="whetstones_0_1" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=whetstones_0_1&amp;id=whetstones_0_1&amp;link=/checklists/whetstones.html%23item_0_1&amp;title=Whetstone Knife">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=whetstones_0_1&amp;id=whetstones_0_1&amp;link=/checklists/whetstones.html%23item_0_1&amp;title=Whetstone Knife"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -304,9 +288,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="whetstones_0_2" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=whetstones_0_2&amp;id=whetstones_0_2&amp;link=/checklists/whetstones.html%23item_0_2&amp;title=Iron Whetblade">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=whetstones_0_2&amp;id=whetstones_0_2&amp;link=/checklists/whetstones.html%23item_0_2&amp;title=Iron Whetblade"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -339,9 +321,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="whetstones_0_3" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=whetstones_0_3&amp;id=whetstones_0_3&amp;link=/checklists/whetstones.html%23item_0_3&amp;title=Glintstone Whetblade">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=whetstones_0_3&amp;id=whetstones_0_3&amp;link=/checklists/whetstones.html%23item_0_3&amp;title=Glintstone Whetblade"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -374,9 +354,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="whetstones_0_4" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=whetstones_0_4&amp;id=whetstones_0_4&amp;link=/checklists/whetstones.html%23item_0_4&amp;title=Red-Hot Whetblade">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=whetstones_0_4&amp;id=whetstones_0_4&amp;link=/checklists/whetstones.html%23item_0_4&amp;title=Red-Hot Whetblade"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -409,9 +387,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="whetstones_0_5" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=whetstones_0_5&amp;id=whetstones_0_5&amp;link=/checklists/whetstones.html%23item_0_5&amp;title=Black Whetblade">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=whetstones_0_5&amp;id=whetstones_0_5&amp;link=/checklists/whetstones.html%23item_0_5&amp;title=Black Whetblade"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">
@@ -444,9 +420,7 @@
                       <input class="form-check-input pe-0 me-0" data-section-idx="0" id="whetstones_0_6" type="checkbox" value="">
                     </div>
                     <div class="col-auto d-flex align-items-center order-last">
-                      <a class="" href="/map.html?target=whetstones_0_6&amp;id=whetstones_0_6&amp;link=/checklists/whetstones.html%23item_0_6&amp;title=Sanctified Whetblade">
-                        <i class="bi bi-geo-alt"></i>
-                      </a>
+                      <a class="" href="/map.html?target=whetstones_0_6&amp;id=whetstones_0_6&amp;link=/checklists/whetstones.html%23item_0_6&amp;title=Sanctified Whetblade"><i class="bi bi-geo-alt"></i></a>
                     </div>
                     <div class="col d-flex align-items-center d-md-block d-none">
                       <div class="row">

--- a/docs/index.html
+++ b/docs/index.html
@@ -27,14 +27,10 @@
         <a class="navbar-brand me-auto ms-2 active" href="/index.html">Roundtable Guides</a>
         <form class="d-none d-sm-flex order-2 order-xl-3">
           <input aria-label="search" class="form-control me-2" name="search" placeholder="Search" type="search">
-          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit">
-            <i class="bi bi-search"></i>
-          </button>
+          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit"><i class="bi bi-search"></i></button>
         </form>
         <div class="d-sm-none order-2">
-          <a class="nav-link me-0" href="/search.html">
-            <i class="bi bi-search sb-icon-search"></i>
-          </a>
+          <a class="nav-link me-0" href="/search.html"><i class="bi bi-search sb-icon-search"></i></a>
         </div>
         <div class="collapse navbar-collapse order-3 order-xl-2 ms-xl-2" id="nav-collapse">
           <ul class="nav navbar-nav navbar-nav-scroll mr-auto">
@@ -179,14 +175,10 @@
               </ul>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/map.html">
-                <i class="bi bi-map"></i> Map
-              </a>
+              <a class="nav-link hide-buttons" href="/map.html"><i class="bi bi-map"></i> Map</a>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/options.html">
-                <i class="bi bi-gear-fill"></i> Options
-              </a>
+              <a class="nav-link hide-buttons" href="/options.html"><i class="bi bi-gear-fill"></i> Options</a>
             </li>
           </ul>
         </div>

--- a/docs/map.html
+++ b/docs/map.html
@@ -31,14 +31,10 @@
             <a class="navbar-brand me-auto ms-2" href="/index.html">Roundtable Guides</a>
             <form class="d-none d-sm-flex order-2 order-xl-3">
               <input aria-label="search" class="form-control me-2" name="search" placeholder="Search" type="search">
-              <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit">
-                <i class="bi bi-search"></i>
-              </button>
+              <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit"><i class="bi bi-search"></i></button>
             </form>
             <div class="d-sm-none order-2">
-              <a class="nav-link me-0" href="/search.html">
-                <i class="bi bi-search sb-icon-search"></i>
-              </a>
+              <a class="nav-link me-0" href="/search.html"><i class="bi bi-search sb-icon-search"></i></a>
             </div>
             <div class="collapse navbar-collapse order-3 order-xl-2 ms-xl-2" id="nav-collapse">
               <ul class="nav navbar-nav navbar-nav-scroll mr-auto">
@@ -183,14 +179,10 @@
                   </ul>
                 </li>
                 <li class="nav-item tab-li">
-                  <a class="nav-link hide-buttons active" href="/map.html">
-                    <i class="bi bi-map"></i> Map
-                  </a>
+                  <a class="nav-link hide-buttons active" href="/map.html"><i class="bi bi-map"></i> Map</a>
                 </li>
                 <li class="nav-item tab-li">
-                  <a class="nav-link hide-buttons" href="/options.html">
-                    <i class="bi bi-gear-fill"></i> Options
-                  </a>
+                  <a class="nav-link hide-buttons" href="/options.html"><i class="bi bi-gear-fill"></i> Options</a>
                 </li>
               </ul>
             </div>
@@ -201,10 +193,7 @@
         <div class="m-0 p-0 g-0" id="map"></div>
       </div>
       <div class="offcanvas offcanvas-end m-0 p-0 g-0 w-auto show d-none d-lg-block" data-bs-backdrop="false" data-bs-stroll="true" id="layer-menu" tabindex="-1">
-        <button class="btn btn-primary btn-sml offcanvas-btn position-absolute p-1" data-bs-target="#layer-menu" data-bs-toggle="offcanvas" style="height: 50px;" type="button">
-          <i class="bi bi-caret-left-fill m-0 p-0"></i>
-          <i class="bi bi-caret-right-fill m-0 p-0"></i>
-        </button>
+        <button class="btn btn-primary btn-sml offcanvas-btn position-absolute p-1" data-bs-target="#layer-menu" data-bs-toggle="offcanvas" style="height: 50px;" type="button"><i class="bi bi-caret-left-fill m-0 p-0"></i><i class="bi bi-caret-right-fill m-0 p-0"></i></button>
         <div class="offcanvas-body overflow-auto h-100">
           <div class="d-flex align-items-center justify-content-between">
             <h3 class="offcanvas-title">Layers</h3>
@@ -362,9 +351,7 @@
         <div class="card-body form-check checkbox d-flex align-items-center popup-content">
           <input class="form-check-input" id="popup-checkbox" type="checkbox" value="">
           <label class="form-check-label item_content ms-2" for="popup-checkbox" id="popup-title"></label>
-          <a class="ms-3" href="#" id="popup-link">
-            <i class="bi bi-link-45deg"></i>
-          </a>
+          <a class="ms-3" href="#" id="popup-link"><i class="bi bi-link-45deg"></i></a>
           <div class="d-none" id="dev-mode-copy">
             <a class="btn btn-primary btn-sm" id="dev-mode-copy-button" type="button">map_link</a>
           </div>

--- a/docs/options.html
+++ b/docs/options.html
@@ -27,14 +27,10 @@
         <a class="navbar-brand me-auto ms-2" href="/index.html">Roundtable Guides</a>
         <form class="d-none d-sm-flex order-2 order-xl-3">
           <input aria-label="search" class="form-control me-2" name="search" placeholder="Search" type="search">
-          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit">
-            <i class="bi bi-search"></i>
-          </button>
+          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit"><i class="bi bi-search"></i></button>
         </form>
         <div class="d-sm-none order-2">
-          <a class="nav-link me-0" href="/search.html">
-            <i class="bi bi-search sb-icon-search"></i>
-          </a>
+          <a class="nav-link me-0" href="/search.html"><i class="bi bi-search sb-icon-search"></i></a>
         </div>
         <div class="collapse navbar-collapse order-3 order-xl-2 ms-xl-2" id="nav-collapse">
           <ul class="nav navbar-nav navbar-nav-scroll mr-auto">
@@ -179,14 +175,10 @@
               </ul>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/map.html">
-                <i class="bi bi-map"></i> Map
-              </a>
+              <a class="nav-link hide-buttons" href="/map.html"><i class="bi bi-map"></i> Map</a>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons active" href="/options.html">
-                <i class="bi bi-gear-fill"></i> Options
-              </a>
+              <a class="nav-link hide-buttons active" href="/options.html"><i class="bi bi-gear-fill"></i> Options</a>
             </li>
           </ul>
         </div>

--- a/docs/search.html
+++ b/docs/search.html
@@ -27,14 +27,10 @@
         <a class="navbar-brand me-auto ms-2" href="/index.html">Roundtable Guides</a>
         <form class="d-none d-sm-flex order-2 order-xl-3">
           <input aria-label="search" class="form-control me-2" name="search" placeholder="Search" type="search">
-          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit">
-            <i class="bi bi-search"></i>
-          </button>
+          <button class="btn" formaction="/search.html" formmethod="get" formnovalidate="true" type="submit"><i class="bi bi-search"></i></button>
         </form>
         <div class="d-sm-none order-2">
-          <a class="nav-link me-0" href="/search.html">
-            <i class="bi bi-search sb-icon-search"></i>
-          </a>
+          <a class="nav-link me-0" href="/search.html"><i class="bi bi-search sb-icon-search"></i></a>
         </div>
         <div class="collapse navbar-collapse order-3 order-xl-2 ms-xl-2" id="nav-collapse">
           <ul class="nav navbar-nav navbar-nav-scroll mr-auto">
@@ -179,14 +175,10 @@
               </ul>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/map.html">
-                <i class="bi bi-map"></i> Map
-              </a>
+              <a class="nav-link hide-buttons" href="/map.html"><i class="bi bi-map"></i> Map</a>
             </li>
             <li class="nav-item tab-li">
-              <a class="nav-link hide-buttons" href="/options.html">
-                <i class="bi bi-gear-fill"></i> Options
-              </a>
+              <a class="nav-link hide-buttons" href="/options.html"><i class="bi bi-gear-fill"></i> Options</a>
             </li>
           </ul>
         </div>
@@ -199,9 +191,7 @@
       <div class="row mt-4">
         <form class="d-flex">
           <input aria-label="search" class="form-control me-2" id="page_search" name="search" placeholder="Search" type="search">
-          <button class="btn" id="search_submit">
-            <i class="bi bi-search"></i>
-          </button>
+          <button class="btn" id="search_submit"><i class="bi bi-search"></i></button>
         </form>
       </div>
       <div class="row mt-4 d-flex justify-content-center d-none" id="spinner">

--- a/generate.py
+++ b/generate.py
@@ -426,7 +426,7 @@ def make_checklist(page):
             with div(cls="input-group d-print-none"):
                 input_(type="search", id=page['id'] + "_search", cls="form-control my-3", placeholder="Start typing to filter results...")
 
-            if page['id'] in {'weapons', 'armor', 'incantations', 'ashesofwar'}:
+            if page['id'] in {'weapons', 'armor', 'incantations', 'ashesofwar', 'cookbooks'}:
                 with div(cls='row d-print-none mb-3'):
                     with div(cls='col-auto d-flex align-items-center gap-2'):
                         label('Show:', _for='dlc_filter', cls='mb-0')
@@ -480,7 +480,7 @@ def make_checklist(page):
                                             'data_id': page['id'] + '_' + id,
                                             'id': 'item_' + id,
                                         }
-                                        if page['id'] in {'weapons', 'armor', 'incantations', 'ashesofwar'}:
+                                        if page['id'] in {'weapons', 'armor', 'incantations', 'ashesofwar', 'cookbooks'}:
                                             is_dlc = item.get('dlc', section.get('dlc', page.get('dlc', False)))
                                             li_kwargs['data_dlc'] = str(bool(is_dlc)).lower()
                                         with li(**li_kwargs):
@@ -541,7 +541,7 @@ def make_checklist(page):
                                             'cls': "list-group-item searchable ps-0",
                                             'id': 'item_' + id,
                                         }
-                                        if page['id'] in {'weapons', 'armor', 'incantations', 'ashesofwar'}:
+                                        if page['id'] in {'weapons', 'armor', 'incantations', 'ashesofwar', 'cookbooks'}:
                                             is_dlc = item.get('dlc', section.get('dlc', page.get('dlc', False)))
                                             li_kwargs['data_dlc'] = str(bool(is_dlc)).lower()
                                         with li(**li_kwargs):


### PR DESCRIPTION
## Summary

- Tags all 13 Shadow of the Erdtree cookbook categories with `dlc: true`
  at **section level** in `cookbooks.yaml`
- Adds `'cookbooks'` to the DLC-aware page set in `generate.py` (3
  occurrences) so the **Show / Base Game / DLC** selector is rendered
  and `data-dlc` attributes are emitted on every item
- Regenerates `docs/checklists/cookbooks.html`

## Why section-level tagging

Every cookbook category is 100% base game or 100% DLC — no section
mixes the two. Tagging at section level means the filter never produces
an empty category, and the YAML stays clean without per-item boilerplate.

**Result:** 45 DLC items across 13 sections, 59 base game items across
8 sections.

## DLC sections tagged

Forager Brood · Igon's · Finger-Weaver's · Greater Potentate's ·
Ancient Dragon Knight's · Mad Craftsman's · St. Trina Disciple's ·
Fire Knight's · Loyal Knight's · Battlefield Priest's · Grave Keeper's ·
Antiquity Scholar's · Tibia's

## Test plan

- [ ] Open Cookbooks page — confirm **Show / Base Game / DLC** dropdown is visible
- [ ] Select **Base Game** — only the 8 base game sections remain
- [ ] Select **DLC** — only the 13 DLC sections remain, no empty categories
- [ ] Select **Both** — all 21 sections shown
